### PR TITLE
[Phase 1A.2] Create CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to PhiScan will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Project scaffolding: pyproject.toml, CI workflows, MIT license

--- a/PLAN.md
+++ b/PLAN.md
@@ -107,7 +107,7 @@ and explain commands deferred to Phase 2).
 ### 1A — Project Scaffolding & Dependencies
 
 - [x] **1A.1** Create `LICENSE` file — MIT license with copyright year and author name
-- [ ] **1A.2** Create `CHANGELOG.md` — initial entry: `## [Unreleased]` section
+- [x] **1A.2** Create `CHANGELOG.md` — initial entry: `## [Unreleased]` section
 - [ ] **1A.3** Create `SECURITY.md` — vulnerability reporting policy (email, response commitment, disclosure timeline)
 - [ ] **1A.4** Rewrite `pyproject.toml` — full metadata, all core dependencies, `[project.scripts]` entry point, version `0.1.0`
   - Include `[project.optional-dependencies]` groups: see Dependency Strategy section below

--- a/uv.lock
+++ b/uv.lock
@@ -229,7 +229,7 @@ name = "phi-scan"
 version = "0.1.0"
 source = { virtual = "." }
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "mypy" },
     { name = "pytest" },
@@ -238,13 +238,14 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.6" },
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.10" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-cov", specifier = ">=5.0" },
+    { name = "ruff", specifier = ">=0.15.6" },
 ]
-provides-extras = ["dev"]
 
 [[package]]
 name = "pluggy"


### PR DESCRIPTION
## Task 1A.2 — Create CHANGELOG.md

Reference: PLAN.md Phase 1A, task 1A.2

### What was done
- Added CHANGELOG.md following Keep a Changelog format
- Initial `[Unreleased]` section with scaffolding entries
- Synced uv.lock to resolve lockfile drift

### Verification
- `ruff check .` — zero errors
- `mypy phi_scan/` — zero errors
- `pytest tests/` — all tests pass
- No deviations from PLAN.md specification