### PR TITLE
[Chore] Fix task-status skill frontmatter

### DIFF
--- a/.claude/skills/task-status/SKILL.md
+++ b/.claude/skills/task-status/SKILL.md
@@ -2,7 +2,6 @@
 name: task-status
 description: Show the current PhiScan task position — what was last merged, what is in progress, and what comes next according to PLAN.md
 disable-model-invocation: true
-allowed-tools: Bash, Read
 ---
 
 ## /task-status


### PR DESCRIPTION
## Summary
- Remove `allowed-tools` from `.claude/skills/task-status/SKILL.md` frontmatter
- `allowed-tools` is not a supported skill attribute — valid attributes are: `argument-hint`, `compatibility`, `description`, `disable-model-invocation`, `license`, `metadata`, `name`, `user-invocable`
- Resolves the VSCode diagnostics warning without changing skill behaviour

## Test plan
- [ ] Confirm diagnostics warning is gone in VSCode after merge