### PR TITLE
[Phase 1A.15] Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,20 @@ wheels/
 
 # Virtual environments
 .venv
+
+# Environment variables — never commit credentials or PHI values
+.env
+
+# SQLite databases — may contain PHI; exclude from version control
+*.db
+*.sqlite3
+
+# PhiScan internal state — stores SHA-256 hashes, never raw PHI
+.phi-scanner/
+
+# PhiScan scan output
+phi-report.json
+
+# Test coverage artifacts
+.coverage
+coverage.xml

--- a/PLAN.md
+++ b/PLAN.md
@@ -124,7 +124,7 @@ and explain commands deferred to Phase 2).
 - [x] **1A.12** Create `Makefile` — targets: `install`, `lint`, `typecheck`, `test`, `scan`, `help`
 - [x] **1A.13** Create `.phi-scanner.yml` — default scanner configuration
 - [x] **1A.14** Create `.phi-scanignore` — default exclusion patterns (see Ignore Format Spec below)
-- [ ] **1A.15** Update `.gitignore` — add `.env`, `*.db`, `*.sqlite3`, `.phi-scanner/`, `phi-report.json`, `dist/`, `*.egg-info`
+- [x] **1A.15** Update `.gitignore` — add `.env`, `*.db`, `*.sqlite3`, `.phi-scanner/`, `phi-report.json`, `dist/`, `*.egg-info`
 - [ ] **1A.16** Update `README.md` — project name, install instructions, basic usage, license badge
 - [ ] **1A.17** Create `.github/workflows/ci.yml` — PhiScan's own CI pipeline (see 1H below)
 


### PR DESCRIPTION
## Summary
- Added `.env` — credentials and PHI values must never be committed
- Added `*.db` / `*.sqlite3` — SQLite databases may contain PHI
- Added `.phi-scanner/` — PhiScan internal state directory
- Added `phi-report.json` — scan output artifact
- Added `.coverage` / `coverage.xml` — test coverage artifacts (already in repo as untracked noise)

## Notes
`dist/` and `*.egg-info` were already present in `.gitignore` from the initial scaffold — no change needed.

## Test plan
- [x] `make lint` — passed
- [x] `make typecheck` — passed
- [x] `make test` — 25 passed, 100% coverage