### PR TITLE
[Phase 1A.17] Verify ci.yml and add CI badge to README.md

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -126,7 +126,7 @@ and explain commands deferred to Phase 2).
 - [x] **1A.14** Create `.phi-scanignore` — default exclusion patterns (see Ignore Format Spec below)
 - [x] **1A.15** Update `.gitignore` — add `.env`, `*.db`, `*.sqlite3`, `.phi-scanner/`, `phi-report.json`, `dist/`, `*.egg-info`
 - [x] **1A.16** Update `README.md` — project name, install instructions, basic usage, license badge
-- [ ] **1A.17** Create `.github/workflows/ci.yml` — PhiScan's own CI pipeline (see 1H below)
+- [x] **1A.17** Create `.github/workflows/ci.yml` — PhiScan's own CI pipeline (see 1H below)
 
 ### 1B — Package Modules (`phi_scan/`)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/)
+[![CI](https://github.com/joeyessak/phi-scan/actions/workflows/ci.yml/badge.svg)](https://github.com/joeyessak/phi-scan/actions/workflows/ci.yml)
 
 HIPAA & FHIR compliant PHI/PII scanner for CI/CD pipelines. Local execution only — no PHI ever leaves your infrastructure.
 


### PR DESCRIPTION
## Summary
`.github/workflows/ci.yml` was committed in the initial project scaffold (commit `7620b15`, merged via PR #1). It fully satisfies the 1H.1 spec:
- Matrix: Python 3.12 on ubuntu-latest, macos-latest, windows-latest
- Steps: checkout → uv sync → ruff lint + format → mypy → pytest with coverage upload

To verify the file exists: `git show main:.github/workflows/ci.yml`

This PR:
- Adds CI badge to `README.md` now that the workflow is confirmed present (badge was deferred from 1A.16 to avoid a broken state)
- Marks 1A.17 complete in PLAN.md

No new workflow file is added in this diff because the file already exists in the repository since the initial scaffold.

## Test plan
- [x] `make lint` — passed
- [x] `make typecheck` — passed
- [x] `make test` — 25 passed, 100% coverage