### PR TITLE
[Phase 1B.1] Confirm __init__.py — version and app name

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -130,7 +130,7 @@ and explain commands deferred to Phase 2).
 
 ### 1B — Package Modules (`phi_scan/`)
 
-- [ ] **1B.1** `__init__.py` — `__version__ = "0.1.0"`, `__app_name__ = "phi-scan"`
+- [x] **1B.1** `__init__.py` — `__version__ = "0.1.0"`, `__app_name__ = "phi-scan"`
 - [ ] **1B.2** `constants.py` — all named constants and enums
   - `DEFAULT_CONFIG_FILENAME`, `DEFAULT_IGNORE_FILENAME`
   - `KNOWN_BINARY_EXTENSIONS` — skip list (.png, .jpg, .gif, .ico, .wasm, .exe, .dll, .so, .dylib, .zip, .tar, .gz, .jar, .pyc, .pyo, .o, .a, .pdf, .doc, .docx, .xls, .xlsx, .ppt, .pptx, .mp3, .mp4, .mov, .avi, .wav, .ttf, .woff, .woff2, .eot)


### PR DESCRIPTION
## Summary
`phi_scan/__init__.py` was part of the initial scaffold and already contains the exact content required by task 1B.1:
- `__version__ = "0.1.0"`
- `__app_name__ = "phi-scan"`

No file changes needed. This PR marks the task complete in PLAN.md.

## Test plan
- [x] `make lint` — passed
- [x] `make typecheck` — passed
- [x] `make test` — 25 passed, 100% coverage