### PR TITLE
[Task 1B.5] Fix logging_config review violations

### DIFF
--- a/phi_scan/exceptions.py
+++ b/phi_scan/exceptions.py
@@ -14,6 +14,7 @@ __all__ = [
     "MissingOptionalDependencyError",
     "PhiDetectionError",
     "PhiScanError",
+    "PhiScanLoggingError",
     "SchemaMigrationError",
     "TraversalError",
 ]
@@ -84,6 +85,18 @@ class MissingOptionalDependencyError(PhiScanError):
     Args:
         message: Description of the missing dependency including the package name
             and the install command that will resolve it.
+    """
+
+
+class PhiScanLoggingError(PhiScanError):
+    """Raised when the logging system cannot be configured safely.
+
+    Examples include a log file path that resolves to a symlink, which could
+    allow an attacker to redirect log output to an arbitrary file.
+
+    Args:
+        message: Description of the unsafe configuration including the path
+            and the reason it was rejected.
     """
 
 

--- a/phi_scan/logging_config.py
+++ b/phi_scan/logging_config.py
@@ -5,19 +5,24 @@ from __future__ import annotations
 import logging
 import logging.handlers
 from pathlib import Path
+from typing import TextIO
+
+from phi_scan.exceptions import PhiScanLoggingError
 
 __all__ = [
+    "LOG_FORMAT",
     "configure_logging",
     "get_logger",
 ]
 
 _LOGGER_NAME: str = "phi_scan"
-_LOG_FORMAT: str = "[%(asctime)s] %(levelname)s %(name)s: %(message)s"
+LOG_FORMAT: str = "[%(asctime)s] %(levelname)s %(name)s: %(message)s"
 _DEFAULT_LOG_DIRECTORY: Path = Path.home() / ".phi-scanner"
 _DEFAULT_LOG_FILENAME: str = "phi-scan.log"
 _DEFAULT_CONSOLE_LEVEL: int = logging.WARNING
-_MAX_LOG_FILE_BYTES: int = 10 * 1024 * 1024  # 10 MB per rotation slice
-_LOG_FILE_BACKUP_COUNT: int = 5  # keep 5 rotated files
+_MAX_LOG_FILE_BYTES: int = 10 * 1024 * 1024
+_LOG_FILE_BACKUP_COUNT: int = 5
+_SILENCED_LOG_LEVEL: int = logging.CRITICAL + 1
 
 
 def get_logger(name: str | None = None) -> logging.Logger:
@@ -60,7 +65,7 @@ def configure_logging(
     root_logger.handlers.clear()
 
     console_handler = _build_console_handler(
-        level=logging.CRITICAL + 1 if is_quiet else console_level,
+        level=_SILENCED_LOG_LEVEL if is_quiet else console_level,
     )
     root_logger.addHandler(console_handler)
 
@@ -69,7 +74,7 @@ def configure_logging(
         root_logger.addHandler(file_handler)
 
 
-def _build_console_handler(level: int) -> logging.StreamHandler:  # type: ignore[type-arg]
+def _build_console_handler(level: int) -> logging.StreamHandler[TextIO]:
     """Build a StreamHandler with the standard phi_scan log format.
 
     Args:
@@ -78,9 +83,9 @@ def _build_console_handler(level: int) -> logging.StreamHandler:  # type: ignore
     Returns:
         A configured StreamHandler writing to stderr.
     """
-    handler = logging.StreamHandler()
+    handler: logging.StreamHandler[TextIO] = logging.StreamHandler()
     handler.setLevel(level)
-    handler.setFormatter(logging.Formatter(_LOG_FORMAT))
+    handler.setFormatter(logging.Formatter(LOG_FORMAT))
     return handler
 
 
@@ -93,8 +98,15 @@ def _build_file_handler(log_file_path: Path) -> logging.handlers.RotatingFileHan
 
     Returns:
         A configured RotatingFileHandler at DEBUG level.
+
+    Raises:
+        PhiScanLoggingError: If log_file_path resolves to a symlink. Following
+            symlinks during log writes could redirect output to arbitrary files.
     """
-    resolved_path = log_file_path.expanduser().resolve()
+    expanded_path = log_file_path.expanduser()
+    if expanded_path.is_symlink():
+        raise PhiScanLoggingError(f"Log file path must not be a symlink: {expanded_path}")
+    resolved_path = expanded_path.resolve()
     resolved_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
 
     handler = logging.handlers.RotatingFileHandler(
@@ -104,5 +116,5 @@ def _build_file_handler(log_file_path: Path) -> logging.handlers.RotatingFileHan
         encoding="utf-8",
     )
     handler.setLevel(logging.DEBUG)
-    handler.setFormatter(logging.Formatter(_LOG_FORMAT))
+    handler.setFormatter(logging.Formatter(LOG_FORMAT))
     return handler

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -5,9 +5,20 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from phi_scan.logging_config import configure_logging, get_logger
+import pytest
+
+from phi_scan.exceptions import PhiScanLoggingError
+from phi_scan.logging_config import LOG_FORMAT, configure_logging, get_logger
 
 _PHI_SCAN_LOGGER_NAME: str = "phi_scan"
+
+
+@pytest.fixture(autouse=True)
+def reset_phi_scan_logger() -> object:
+    """Ensure each test starts and ends with a clean phi_scan logger state."""
+    yield
+    logger = logging.getLogger(_PHI_SCAN_LOGGER_NAME)
+    logger.handlers.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -107,12 +118,21 @@ def test_configure_logging_quiet_mode_silences_console_handler() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _get_file_handler(
+    root_logger: logging.Logger,
+) -> logging.handlers.RotatingFileHandler:
+    """Return the RotatingFileHandler attached to root_logger."""
+    return next(
+        h for h in root_logger.handlers if isinstance(h, logging.handlers.RotatingFileHandler)
+    )
+
+
 def test_configure_logging_file_handler_is_at_debug_level(tmp_path: Path) -> None:
     log_file = tmp_path / "phi-scan.log"
 
     configure_logging(log_file_path=log_file)
     root_logger = logging.getLogger(_PHI_SCAN_LOGGER_NAME)
-    file_handler = root_logger.handlers[1]
+    file_handler = _get_file_handler(root_logger)
 
     assert file_handler.level == logging.DEBUG
 
@@ -132,7 +152,7 @@ def test_configure_logging_quiet_mode_does_not_silence_file_handler(
 
     configure_logging(log_file_path=log_file, is_quiet=True)
     root_logger = logging.getLogger(_PHI_SCAN_LOGGER_NAME)
-    file_handler = root_logger.handlers[1]
+    file_handler = _get_file_handler(root_logger)
 
     # File handler must remain at DEBUG even when console is silenced.
     assert file_handler.level == logging.DEBUG
@@ -143,9 +163,21 @@ def test_configure_logging_file_handler_is_rotating_type(tmp_path: Path) -> None
 
     configure_logging(log_file_path=log_file)
     root_logger = logging.getLogger(_PHI_SCAN_LOGGER_NAME)
-    file_handler = root_logger.handlers[1]
+    file_handler = _get_file_handler(root_logger)
 
     assert isinstance(file_handler, logging.handlers.RotatingFileHandler)
+
+
+def test_configure_logging_raises_phi_scan_logging_error_for_symlinked_log_path(
+    tmp_path: Path,
+) -> None:
+    real_file = tmp_path / "real.log"
+    real_file.touch()
+    symlink_path = tmp_path / "phi-scan.log"
+    symlink_path.symlink_to(real_file)
+
+    with pytest.raises(PhiScanLoggingError):
+        configure_logging(log_file_path=symlink_path)
 
 
 # ---------------------------------------------------------------------------
@@ -162,11 +194,5 @@ def test_configure_logging_console_handler_has_formatter() -> None:
 
 
 def test_configure_logging_log_format_contains_levelname_and_name() -> None:
-    configure_logging()
-    root_logger = logging.getLogger(_PHI_SCAN_LOGGER_NAME)
-    formatter = root_logger.handlers[0].formatter
-    assert formatter is not None
-    fmt = formatter._fmt  # type: ignore[union-attr]
-
-    assert "%(levelname)s" in fmt
-    assert "%(name)s" in fmt
+    assert "%(levelname)s" in LOG_FORMAT
+    assert "%(name)s" in LOG_FORMAT


### PR DESCRIPTION
## Summary

Addresses all issues raised in the automated review of PR #23.

- **Symlink security guard**: `_build_file_handler` now calls `expanded_path.is_symlink()` before `resolve()` and raises `PhiScanLoggingError` if the path is a symlink — prevents log redirect attacks via crafted symlinks. `PhiScanLoggingError` added to the exception hierarchy.
- **Named constant for silenced level**: Extracted `logging.CRITICAL + 1` magic calculation to `_SILENCED_LOG_LEVEL: int`.
- **Redundant inline comments removed**: `_MAX_LOG_FILE_BYTES` and `_LOG_FILE_BACKUP_COUNT` names are self-documenting; comments deleted.
- **Explicit generic type annotation**: `_build_console_handler` now returns `logging.StreamHandler[TextIO]` with `from typing import TextIO` — eliminates `type: ignore[type-arg]`.
- **Public `LOG_FORMAT` export**: Renamed `_LOG_FORMAT` → `LOG_FORMAT` and added to `__all__` so tests can assert against the constant directly without accessing `formatter._fmt`.
- **Test isolation fixture**: `autouse` `reset_phi_scan_logger` fixture clears handlers after every test, preventing dirty logger state from leaking between tests.
- **Type-safe handler lookup**: File handler tests now use `isinstance`-based filtering via `_get_file_handler()` instead of positional index.
- **Symlink rejection test**: New test verifies `PhiScanLoggingError` is raised when the log path is a symlink.