### PR TITLE
chore: Claude settings and task-status skill fixes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,9 @@
       "Bash(git add:*)",
       "Bash(git commit:*)",
       "Bash(git push:*)",
-      "Bash(gh pr list:*)"
+      "Bash(gh pr list:*)",
+      "Bash(gh pr list --state open --json number,title,headRefName,statusCheckRollup)",
+      "Bash(uv run:*)"
     ]
   }
 }

--- a/.claude/skills/task-status/SKILL.md
+++ b/.claude/skills/task-status/SKILL.md
@@ -2,6 +2,7 @@
 name: task-status
 description: Show the current PhiScan task position — what was last merged, what is in progress, and what comes next according to PLAN.md
 disable-model-invocation: true
+allowed-tools: Bash(git log:*), Bash(git branch:*), Bash(git status:*), Bash(gh pr list:*)
 ---
 
 ## /task-status


### PR DESCRIPTION
## Summary
- Add `uv run:*` and the full `gh pr list` variant to allowed tools in `.claude/settings.local.json`
- Add `allowed-tools` frontmatter to `.claude/skills/task-status/SKILL.md` so the skill can run its git/gh commands without prompting

## Test plan
- [ ] `/task-status` runs without tool-permission prompts
- [ ] `uv run` commands are auto-approved in Claude sessions