### PR TITLE
[Phase 1G] Cross-platform compatibility — path normalization and encoding

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -527,12 +527,12 @@ polished, informative, and visually striking. Users should enjoy running this to
 
 ### 1G — Cross-Platform Compatibility
 
-- [ ] **1G.1** Use `pathlib.Path` exclusively — never string concatenation for paths
-- [ ] **1G.2** No WSL-specific assumptions: no hardcoded `/mnt/`, no Windows path separators
-- [ ] **1G.3** Test path handling with forward slashes on all platforms
-- [ ] **1G.4** `.phi-scanignore` patterns use forward slashes (normalized internally on Windows)
-- [ ] **1G.5** All file I/O uses `encoding="utf-8"` explicitly — no platform-default encoding
-- [ ] **1G.6** SQLite paths use `pathlib.Path.home()` — no hardcoded `~` expansion
+- [x] **1G.1** Use `pathlib.Path` exclusively — never string concatenation for paths
+- [x] **1G.2** No WSL-specific assumptions: no hardcoded `/mnt/`, no Windows path separators
+- [x] **1G.3** Test path handling with forward slashes on all platforms
+- [x] **1G.4** `.phi-scanignore` patterns use forward slashes (normalized internally on Windows)
+- [x] **1G.5** All file I/O uses `encoding="utf-8"` explicitly — no platform-default encoding
+- [x] **1G.6** SQLite paths use `pathlib.Path.home()` — no hardcoded `~` expansion
 
 ### 1H — PhiScan's Own CI Pipeline
 

--- a/phi_scan/logging_config.py
+++ b/phi_scan/logging_config.py
@@ -120,6 +120,9 @@ def _build_file_handler(log_file_path: Path) -> logging.handlers.RotatingFileHan
     expanded_path = log_file_path.expanduser()
     if expanded_path.is_symlink():
         raise PhiScanLoggingError(_SYMLINK_LOG_PATH_ERROR.format(path=expanded_path))
+    # os.path.normpath collapses .. without following symlinks — Path.resolve()
+    # is intentionally avoided here because it resolves symlinks, which would
+    # defeat the symlink-detection guard in _reject_symlinked_parents below.
     normalized_path = Path(os.path.normpath(expanded_path.absolute()))
     _reject_symlinked_parents(normalized_path)
     _create_log_directory(normalized_path.parent)

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -114,7 +114,9 @@ def is_path_excluded(file_path: Path, exclusion_spec: pathspec.PathSpec) -> bool
     Returns:
         True if the path matches at least one exclusion pattern, False otherwise.
     """
-    return exclusion_spec.match_file(str(file_path))
+    # as_posix() ensures forward slashes on Windows; pathspec gitignore patterns
+    # always use forward slashes so str() would produce non-matching backslash paths.
+    return exclusion_spec.match_file(file_path.as_posix())
 
 
 def is_binary_file(file_path: Path) -> bool:

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -72,6 +72,18 @@ def test_directory_pattern_excludes_file_at_depth_one() -> None:
     assert is_excluded is True
 
 
+def test_directory_pattern_excludes_path_constructed_from_parts() -> None:
+    # Regression guard for Windows: Path("a") / "b" produces backslash separators
+    # when converted with str() on Windows. is_path_excluded must use as_posix() so
+    # gitignore patterns (which always use forward slashes) match on all platforms.
+    spec = pathspec.PathSpec.from_lines(PathspecMatchStyle.GITIGNORE, [_NODE_MODULES_PATTERN])
+    parts_path = Path("node_modules") / "index.js"
+
+    is_excluded = is_path_excluded(parts_path, spec)
+
+    assert is_excluded is True
+
+
 def test_directory_pattern_excludes_file_at_depth_three() -> None:
     spec = pathspec.PathSpec.from_lines(PathspecMatchStyle.GITIGNORE, [_NODE_MODULES_PATTERN])
 


### PR DESCRIPTION
## Summary

- **1G.4 (bug fix):** `is_path_excluded` in `scanner.py` was calling `str(file_path)` before passing to pathspec. On Windows, `Path` str-converts with backslashes, which breaks gitignore-style patterns (always forward slashes). Changed to `file_path.as_posix()`.
- **1G.1:** `logging_config.py` uses `os.path.normpath` — documented why `Path.resolve()` is intentionally avoided (it follows symlinks, defeating the symlink-detection guard).
- **1G.3:** Added `test_directory_pattern_excludes_path_constructed_from_parts` to `test_ignore.py` as a Windows CI regression guard, documenting the `as_posix()` requirement.
- **1G.2, 1G.5, 1G.6:** Verified clean — no hardcoded OS paths, all text-mode I/O has explicit `encoding=`, all tilde expansion uses `Path.expanduser()`.

## Test plan

- [ ] 544 tests pass (`uv run pytest tests/ -v --cov=phi_scan`)
- [ ] Zero lint errors (`uv run ruff check .`)
- [ ] Zero type errors (`uv run mypy phi_scan/`)
- [ ] New regression test passes on Linux (forward slashes — same result expected on Windows CI)