### PR TITLE
fix: make install gracefully skips spaCy download when nlp extras absent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,13 @@ unexport DIFF_BASE
 
 .PHONY: install lint format typecheck test ci scan clean help
 
-install: ## Install dependencies and download spaCy model (hash-verified)
+install: ## Install dependencies; download spaCy model if [nlp] extras are installed
 	uv sync
-	uv pip install --require-hashes -r constraints/spacy-model.txt
+	@if uv run python -c "import spacy" 2>/dev/null; then \
+		uv pip install --require-hashes -r constraints/spacy-model.txt; \
+	else \
+		echo "spaCy not installed — skipping model download (run 'pip install phi-scan[nlp]' to enable NLP layer)"; \
+	fi
 
 lint: ## Check code style without modifying files (CI-safe)
 	uv run ruff check . --no-fix


### PR DESCRIPTION
## Summary

- `make install` was failing because `uv pip install --require-hashes -r constraints/spacy-model.txt` requires ALL transitive deps to be pinned, but spaCy itself wasn't pinned in the constraints file
- spaCy is an optional Phase 2 dependency (`phi-scan[nlp]`); it should not be required in Phase 1
- Fixed by checking if spaCy is importable first; if not, prints a helpful message and skips the model download

Found during Phase 1 verification checklist execution.

## Test plan

- [ ] `make install` succeeds with spaCy absent (skips with message)
- [ ] `make install` would download model when spaCy is present (Phase 2)
- [ ] All 544 tests pass