### PR TITLE
fix: expand .phi-scanignore to cover all test files and generated artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,29 +67,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify compensating controls for glob ignore rules
+      - name: Check PHI scan configuration invariants
         shell: bash
-        run: |
-          # .phi-scanignore excludes tests/test_*.py via glob. The compensating
-          # control is diff-based PR scanning (diff_ref: origin/main on the Scan
-          # step). This step enforces that invariant by parsing only the with: block
-          # of the 'Scan for PHI/PII' step — not the entire file — so the check
-          # cannot be satisfied by a matching string anywhere else in ci.yml
-          # (including inside this step's own run block or comments).
-          if grep -qE '^tests/test_\*\.py' .phi-scanignore; then
-            if ! awk '
-              /name: Scan for PHI\/PII/ { in_step=1; next }
-              in_step && /^[[:space:]]+-[[:space:]]+name:/ { exit }
-              in_step && /diff_ref:.*origin\/main/ { found=1; exit }
-              END { exit !found }
-            ' .github/workflows/ci.yml; then
-              echo "FAIL: .phi-scanignore excludes tests/test_*.py via glob but"
-              echo "the 'Scan for PHI/PII' step has no diff_ref referencing origin/main."
-              echo "Either restore explicit per-file entries or re-add the diff_ref key."
-              exit 1
-            fi
-            echo "OK: diff_ref compensating control present in Scan for PHI/PII step"
-          fi
+        run: bash scripts/verify_phi_scan_config.sh
 
       - name: Scan for PHI/PII
         uses: joeyessak/phi-scan-action@b17418799d4cf730cf57676b49d4828a579930ed  # v0.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,25 +70,25 @@ jobs:
       - name: Verify compensating controls for glob ignore rules
         shell: bash
         run: |
-          # .phi-scanignore uses tests/test_*.py to exclude all test files from
-          # full-repo push scans. The compensating control is that every PR scan
-          # is diff-based, so new test files are scanned before they reach main.
-          # This step enforces that invariant at the YAML-key level.
-          #
-          # The pattern ^\s+diff_ref:\s+ matches only the actual YAML 'with:' key.
-          # It does NOT match comment lines, echo statements, or grep commands that
-          # contain the string "diff_ref" — those do not start with whitespace
-          # followed immediately by the key name and a colon-space pair.
-          # This avoids the self-referential false-positive that a broader pattern
-          # like 'diff_ref.*origin/main' would produce when grepping this file.
+          # .phi-scanignore excludes tests/test_*.py via glob. The compensating
+          # control is diff-based PR scanning (diff_ref: origin/main on the Scan
+          # step). This step enforces that invariant by parsing only the with: block
+          # of the 'Scan for PHI/PII' step — not the entire file — so the check
+          # cannot be satisfied by a matching string anywhere else in ci.yml
+          # (including inside this step's own run block or comments).
           if grep -qE '^tests/test_\*\.py' .phi-scanignore; then
-            if ! grep -qE '^\s+diff_ref:\s+.*origin/main' .github/workflows/ci.yml; then
+            if ! awk '
+              /name: Scan for PHI\/PII/ { in_step=1; next }
+              in_step && /^[[:space:]]+-[[:space:]]+name:/ { exit }
+              in_step && /diff_ref:.*origin\/main/ { found=1; exit }
+              END { exit !found }
+            ' .github/workflows/ci.yml; then
               echo "FAIL: .phi-scanignore excludes tests/test_*.py via glob but"
-              echo "no 'diff_ref:' YAML key referencing origin/main was found in ci.yml."
+              echo "the 'Scan for PHI/PII' step has no diff_ref referencing origin/main."
               echo "Either restore explicit per-file entries or re-add the diff_ref key."
               exit 1
             fi
-            echo "OK: diff_ref compensating control is present in ci.yml"
+            echo "OK: diff_ref compensating control present in Scan for PHI/PII step"
           fi
 
       - name: Scan for PHI/PII

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,26 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify compensating controls for glob ignore rules
+        shell: bash
+        run: |
+          # .phi-scanignore uses tests/test_*.py to exclude all test files from
+          # full-repo push scans. The stated compensating control is that every PR
+          # scan is diff-based (diff_ref: origin/main), so new test files are scanned
+          # before they reach main. This step enforces that invariant: if a glob
+          # exclusion covering test files is present, diff_ref must be configured.
+          # Fail fast here rather than silently missing PHI in new test files.
+          if grep -qE '^tests/test_\*\.py' .phi-scanignore; then
+            if ! grep -qE 'diff_ref.*origin/main' .github/workflows/ci.yml; then
+              echo "ERROR: .phi-scanignore excludes tests/test_*.py via glob but"
+              echo "ci.yml does not configure diff_ref: origin/main for pull_request"
+              echo "events. The compensating control is missing — either restore"
+              echo "explicit per-file entries in .phi-scanignore or re-add diff_ref."
+              exit 1
+            fi
+            echo "OK: diff_ref: origin/main compensating control is present in ci.yml"
+          fi
+
       - name: Scan for PHI/PII
         uses: joeyessak/phi-scan-action@b17418799d4cf730cf57676b49d4828a579930ed  # v0.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,20 +71,24 @@ jobs:
         shell: bash
         run: |
           # .phi-scanignore uses tests/test_*.py to exclude all test files from
-          # full-repo push scans. The stated compensating control is that every PR
-          # scan is diff-based (diff_ref: origin/main), so new test files are scanned
-          # before they reach main. This step enforces that invariant: if a glob
-          # exclusion covering test files is present, diff_ref must be configured.
-          # Fail fast here rather than silently missing PHI in new test files.
+          # full-repo push scans. The compensating control is that every PR scan
+          # is diff-based, so new test files are scanned before they reach main.
+          # This step enforces that invariant at the YAML-key level.
+          #
+          # The pattern ^\s+diff_ref:\s+ matches only the actual YAML 'with:' key.
+          # It does NOT match comment lines, echo statements, or grep commands that
+          # contain the string "diff_ref" — those do not start with whitespace
+          # followed immediately by the key name and a colon-space pair.
+          # This avoids the self-referential false-positive that a broader pattern
+          # like 'diff_ref.*origin/main' would produce when grepping this file.
           if grep -qE '^tests/test_\*\.py' .phi-scanignore; then
-            if ! grep -qE 'diff_ref.*origin/main' .github/workflows/ci.yml; then
-              echo "ERROR: .phi-scanignore excludes tests/test_*.py via glob but"
-              echo "ci.yml does not configure diff_ref: origin/main for pull_request"
-              echo "events. The compensating control is missing — either restore"
-              echo "explicit per-file entries in .phi-scanignore or re-add diff_ref."
+            if ! grep -qE '^\s+diff_ref:\s+.*origin/main' .github/workflows/ci.yml; then
+              echo "FAIL: .phi-scanignore excludes tests/test_*.py via glob but"
+              echo "no 'diff_ref:' YAML key referencing origin/main was found in ci.yml."
+              echo "Either restore explicit per-file entries or re-add the diff_ref key."
               exit 1
             fi
-            echo "OK: diff_ref: origin/main compensating control is present in ci.yml"
+            echo "OK: diff_ref compensating control is present in ci.yml"
           fi
 
       - name: Scan for PHI/PII

--- a/.phi-scanignore
+++ b/.phi-scanignore
@@ -88,22 +88,16 @@ target/
 
 # Synthetic PHI fixture corpus — contains intentional PHI-like patterns for
 # detection testing. Excluding prevents false positives when scanning this repo.
-tests/fixtures/phi/
-# Clean fixture corpus — contains version numbers, reserved SSN ranges (000-xx-xxxx,
-# xxx-00-xxxx), and quasi-identifier combinations deliberately crafted to exercise
-# the scanner's true-negative path. These patterns trigger AGE_OVER_THRESHOLD,
-# ZIP_CODE, and quasi-identifier combination detectors as false positives when the
-# scanner scans its own test fixtures.
-tests/fixtures/clean/
-# Fixture manifest — lists fixture file paths and expected finding counts; field
-# names like "unique_id" and "mrn" trigger the quasi-identifier combination detector.
-tests/fixtures/manifest.json
-# All test files — unit tests contain intentional synthetic PHI patterns (SSNs,
-# MRNs, SSN-like values, IP addresses, FHIR fixtures, HL7 messages) required to
-# exercise the detection engine. These are false positives when scanned as
-# application source. Test files are covered by diff-based PR scans; excluding
-# them on full-repo push scans prevents noise without reducing coverage.
-tests/
+tests/fixtures/
+# Unit test files — contain intentional synthetic PHI patterns (SSNs, MRNs,
+# IP addresses, FHIR fixtures, HL7 messages, loopback addresses) required to
+# exercise the detection engine. Tests are covered by diff-based PR scans;
+# excluding test_*.py on full-repo push scans prevents noise without reducing
+# coverage. tests/fixtures/ and any future tests/data/ or tests/integration/
+# subdirectories are excluded separately so non-test subdirectories (helpers,
+# utilities) remain scannable.
+tests/test_*.py
+tests/conftest.py
 
 # PhiScan project-level documentation and CI configuration.
 # These files are excluded to suppress false positives when phi-scan scans its

--- a/.phi-scanignore
+++ b/.phi-scanignore
@@ -88,16 +88,38 @@ target/
 
 # Synthetic PHI fixture corpus — contains intentional PHI-like patterns for
 # detection testing. Excluding prevents false positives when scanning this repo.
+# tests/fixtures/phi/   — realistic SSN, MRN, DOB, name, and address values
+# tests/fixtures/clean/ — reserved SSN ranges (000-xx, xxx-00), version numbers,
+#                         and quasi-identifier combinations for true-negative tests
+# tests/fixtures/manifest.json — lists fixture paths and expected finding counts;
+#                         field names like "unique_id" and "mrn" trigger detectors
 tests/fixtures/
-# Unit test files — contain intentional synthetic PHI patterns (SSNs, MRNs,
-# IP addresses, FHIR fixtures, HL7 messages, loopback addresses) required to
-# exercise the detection engine. Tests are covered by diff-based PR scans;
-# excluding test_*.py on full-repo push scans prevents noise without reducing
-# coverage. tests/fixtures/ and any future tests/data/ or tests/integration/
-# subdirectories are excluded separately so non-test subdirectories (helpers,
-# utilities) remain scannable.
+
+# Unit test files — excluded from full-repo push scans only.
+#
+# TRUST BOUNDARY: This glob excludes all current and future tests/test_*.py files
+# from full-repo push scans. New test files are excluded by default, not scanned
+# by default. A developer who accidentally commits real PHI into a new test file
+# will NOT be caught by the push-to-main scan.
+#
+# COMPENSATING CONTROL: Every PR scan runs diff-based (diff_ref: origin/main in
+# ci.yml), so any new or modified test file is scanned before it reaches main.
+# The push-to-main full-repo scan is a belt-and-suspenders check for non-diff
+# code paths, not the primary gate for test files.
+#
+# WHY these files trigger false positives:
+#   test_ai_review.py      — synthetic SSN '123-45-6789' (fictional, not real)
+#   test_notifier.py       — RFC1918 / loopback IP literals for SSRF tests
+#   test_hl7_scanner.py    — multi-segment HL7 message with dates and MRN-like IDs
+#   test_fhir_recognizer.py — FHIR JSON with birthDate, family name fields
+#   test_regex_detector.py  — DEA, SSN, MBI, MRN, VIN, ZIP synthetic values
+#   test_suppression.py    — SSN patterns required to test inline suppression
+#   test_compliance_*.py   — PhiCategory / ComplianceFramework constant combos
+#   test_audit.py          — HIPAA category names trigger quasi-identifier detector
+#   test_scanner.py        — ARCHIVE_MAX_* constants + numeric combos
+#   remaining test_*.py    — variable names containing 'name', 'address', 'mrn'
+#                            trigger HEALTH_PLAN_NUMBER and combination detectors
 tests/test_*.py
-tests/conftest.py
 
 # PhiScan project-level documentation and CI configuration.
 # These files are excluded to suppress false positives when phi-scan scans its

--- a/.phi-scanignore
+++ b/.phi-scanignore
@@ -88,11 +88,17 @@ target/
 
 # Synthetic PHI fixture corpus — contains intentional PHI-like patterns for
 # detection testing. Excluding prevents false positives when scanning this repo.
-# tests/fixtures/phi/   — realistic SSN, MRN, DOB, name, and address values
-# tests/fixtures/clean/ — reserved SSN ranges (000-xx, xxx-00), version numbers,
-#                         and quasi-identifier combinations for true-negative tests
-# tests/fixtures/manifest.json — lists fixture paths and expected finding counts;
-#                         field names like "unique_id" and "mrn" trigger detectors
+# This glob covers all current fixture sub-paths and any new fixture directories
+# or file types added in future (e.g. tests/fixtures/hl7/, tests/fixtures/dicom/).
+# The same trust-boundary and compensating-control notes for tests/test_*.py apply
+# here: new fixture subdirectories are excluded by default; PR diff scans are the
+# primary gate.
+#   tests/fixtures/phi/          — realistic SSN, MRN, DOB, name, and address values
+#   tests/fixtures/clean/        — reserved SSN ranges (000-xx, xxx-00), version
+#                                  numbers, and quasi-identifier combinations for
+#                                  true-negative path tests
+#   tests/fixtures/manifest.json — fixture paths + expected finding counts; field
+#                                  names like "unique_id" and "mrn" trigger detectors
 tests/fixtures/
 
 # Unit test files — excluded from full-repo push scans only.
@@ -100,25 +106,29 @@ tests/fixtures/
 # TRUST BOUNDARY: This glob excludes all current and future tests/test_*.py files
 # from full-repo push scans. New test files are excluded by default, not scanned
 # by default. A developer who accidentally commits real PHI into a new test file
-# will NOT be caught by the push-to-main scan.
+# will NOT be caught by the push-to-main full-repo scan.
 #
-# COMPENSATING CONTROL: Every PR scan runs diff-based (diff_ref: origin/main in
-# ci.yml), so any new or modified test file is scanned before it reaches main.
-# The push-to-main full-repo scan is a belt-and-suspenders check for non-diff
-# code paths, not the primary gate for test files.
+# COMPENSATING CONTROL (machine-enforced): Every PR scan runs diff-based
+# (diff_ref: origin/main in ci.yml), so any new or modified test file is scanned
+# before it reaches main. The "Verify compensating controls" CI step enforces this
+# — it fails the build if the diff_ref YAML key is removed while this glob remains,
+# converting the trust assumption into a hard contract. For environments where
+# direct pushes to main by admins are possible, enabling branch protection rules
+# that require the PHI/PII scan to pass (and disabling admin bypass) provides a
+# stronger guarantee than CI alone.
 #
 # WHY these files trigger false positives:
-#   test_ai_review.py      — synthetic SSN '123-45-6789' (fictional, not real)
-#   test_notifier.py       — RFC1918 / loopback IP literals for SSRF tests
-#   test_hl7_scanner.py    — multi-segment HL7 message with dates and MRN-like IDs
+#   test_ai_review.py       — synthetic SSN '123-45-6789' (fictional, not real)
+#   test_notifier.py        — RFC1918 / loopback IP literals for SSRF tests
+#   test_hl7_scanner.py     — multi-segment HL7 message with dates and MRN-like IDs
 #   test_fhir_recognizer.py — FHIR JSON with birthDate, family name fields
 #   test_regex_detector.py  — DEA, SSN, MBI, MRN, VIN, ZIP synthetic values
-#   test_suppression.py    — SSN patterns required to test inline suppression
-#   test_compliance_*.py   — PhiCategory / ComplianceFramework constant combos
-#   test_audit.py          — HIPAA category names trigger quasi-identifier detector
-#   test_scanner.py        — ARCHIVE_MAX_* constants + numeric combos
-#   remaining test_*.py    — variable names containing 'name', 'address', 'mrn'
-#                            trigger HEALTH_PLAN_NUMBER and combination detectors
+#   test_suppression.py     — SSN patterns required to test inline suppression
+#   test_compliance_*.py    — PhiCategory / ComplianceFramework constant combos
+#   test_audit.py           — HIPAA category names trigger quasi-identifier detector
+#   test_scanner.py         — ARCHIVE_MAX_* constants + numeric combos
+#   remaining test_*.py     — variable names containing 'name', 'address', 'mrn'
+#                             trigger HEALTH_PLAN_NUMBER and combination detectors
 tests/test_*.py
 
 # PhiScan project-level documentation and CI configuration.

--- a/.phi-scanignore
+++ b/.phi-scanignore
@@ -98,44 +98,12 @@ tests/fixtures/clean/
 # Fixture manifest — lists fixture file paths and expected finding counts; field
 # names like "unique_id" and "mrn" trigger the quasi-identifier combination detector.
 tests/fixtures/manifest.json
-# HL7 v2 test file — embeds a multi-segment synthetic HL7 message (_FAKE_HL7_MESSAGE)
-# that contains dates, MRN-like identifiers, and a synthetic patient name required
-# for segment-level scanner tests. The fixture values are provably fictional per
-# CLAUDE.md§FixtureCorpusException but reside in the test file rather than the
-# fixtures directory because they are tightly coupled to the HL7 scanner unit tests.
-tests/test_hl7_scanner.py
-# Audit unit test file — imports HIPAA category names and remediation constants
-# (PhiCategory, HIPAA_REMEDIATION_GUIDANCE, ACCOUNT_NUMBER) as test identifiers.
-# These produce false positives against the quasi-identifier combination detector
-# when scanned as application source.
-tests/test_audit.py
-# CLI unit test file — contains SARIF output keys, date literals used as test
-# inputs, and constants like _JSON_FINDINGS_KEY that combine with surrounding
-# context to trigger quasi-identifier and date detectors as false positives.
-tests/test_cli.py
-# Compliance unit test file — imports ComplianceFramework, PhiCategory, and
-# ComplianceControl constants whose combinations trigger the quasi-identifier
-# combination detector when scanned as application source.
-tests/test_compliance_4b.py
-# AI review unit test file — contains a synthetic SSN value (`'123-45-6789'`) used
-# to verify that ScanFinding rejects unredacted code_context at construction time.
-# The value is intentionally fictional (555-01-0000 style) but triggers the SSN
-# detector. Also imports PhiCategory and AIReviewConfig constants that combine to
-# produce quasi-identifier false positives when scanned as application source.
-tests/test_ai_review.py
-# Notifier unit test file — contains deliberate private/RFC1918/loopback IP
-# address literals required to test SSRF protection (7E.2). These addresses are
-# test inputs for _validate_webhook_url, not real endpoints.
-tests/test_notifier.py
-# Scanner unit test file — imports ARCHIVE_MAX_COMPRESSION_RATIO,
-# ARCHIVE_MAX_MEMBER_UNCOMPRESSED_BYTES, and defines ZipInfo helper constants
-# whose combinations trigger the quasi-identifier and health plan number detectors
-# when scanned as application source.
-tests/test_scanner.py
-# Output unit test file — imports display constants (WATCH_RESULT_CLEAN_TEXT,
-# WatchEvent) and format function names whose surrounding context triggers the
-# quasi-identifier combination detector when scanned as application source.
-tests/test_output.py
+# All test files — unit tests contain intentional synthetic PHI patterns (SSNs,
+# MRNs, SSN-like values, IP addresses, FHIR fixtures, HL7 messages) required to
+# exercise the detection engine. These are false positives when scanned as
+# application source. Test files are covered by diff-based PR scans; excluding
+# them on full-repo push scans prevents noise without reducing coverage.
+tests/
 
 # PhiScan project-level documentation and CI configuration.
 # These files are excluded to suppress false positives when phi-scan scans its
@@ -170,3 +138,17 @@ phi_scan/
 .phi-scanner.yml
 .phi-scanignore
 .gitignore
+
+# Project root files — legal text, build scripts, and pre-commit configuration
+# contain word patterns (e.g. "coverage", "version", hook names) that trigger
+# HEALTH_PLAN_NUMBER and combination detectors as false positives.
+LICENSE
+Makefile
+.pre-commit-hooks.yaml
+.pre-commit-config.yaml
+
+# Generated build artifacts — coverage.xml contains class names, method names,
+# and line counts from the test suite. Attribute names like "name" and "branch"
+# combined with numeric values trigger multiple detectors as false positives.
+coverage.xml
+coverage/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,6 +37,38 @@ release).
   disclosure to give us time to develop and release a fix.
 - Once a fix is released, we will publish a security advisory on GitHub.
 
+## CI/CD Configuration Requirements
+
+PhiScan's CI pipeline relies on the following configuration to maintain full PHI
+detection coverage. Deviating from these requirements weakens the security posture.
+
+### Branch protection (required)
+
+The `main` branch must have branch protection rules enabled with:
+
+- **Require pull request before merging** — prevents direct commits to `main` that
+  bypass the diff-based PHI/PII scan
+- **Require status checks to pass** — the `PHI/PII scan` check must be required
+- **Do not allow bypassing the above settings** — admin bypass must be disabled
+
+**Why this matters:** `.phi-scanignore` excludes `tests/test_*.py` via a glob
+pattern. The compensating control is the diff-based PR scan (`diff_ref: origin/main`
+in `ci.yml`), which scans new and modified test files before they reach `main`. A
+CI enforcement step verifies that `diff_ref` remains configured. However, if an
+admin can push directly to `main` bypassing branch protection, new test files
+containing real PHI would reach `main` unscanned and then be silently excluded from
+all future full-repo push scans. Branch protection with admin-bypass disabled is
+the only mechanism that closes this gap.
+
+### Diff-based PR scan (enforced by CI)
+
+`ci.yml` must configure `diff_ref: origin/main` on the `Scan for PHI/PII` step for
+pull request events. A dedicated CI step (`Verify compensating controls for glob
+ignore rules`) fails the build if this key is removed while the test glob exclusion
+remains in `.phi-scanignore`.
+
+---
+
 ## Security Design Principles
 
 PhiScan is designed to handle sensitive data environments. Key security properties:

--- a/scripts/verify_phi_scan_config.sh
+++ b/scripts/verify_phi_scan_config.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PHI_SCANIGNORE_PATH=".phi-scanignore"
+CI_WORKFLOW_PATH=".github/workflows/ci.yml"
+TEST_GLOB_PATTERN='^tests/test_\*\.py'
+SCAN_STEP_NAME="Scan for PHI/PII"
+DIFF_REF_YAML_KEY='^[[:space:]]+diff_ref:[[:space:]]+'
+
+if ! grep -qE "${TEST_GLOB_PATTERN}" "${PHI_SCANIGNORE_PATH}"; then
+    exit 0
+fi
+
+if awk -v step="${SCAN_STEP_NAME}" -v key_pattern="${DIFF_REF_YAML_KEY}" '
+    $0 ~ ("name: " step) { in_step=1; next }
+    in_step && /^[[:space:]]+-[[:space:]]+name:/ { exit }
+    in_step && $0 ~ key_pattern { found=1; exit }
+    END { exit !found }
+' "${CI_WORKFLOW_PATH}"; then
+    echo "OK: diff_ref compensating control present in ${SCAN_STEP_NAME} step"
+    exit 0
+fi
+
+echo "FAIL: ${PHI_SCANIGNORE_PATH} excludes tests/test_*.py via glob"
+echo "but ${CI_WORKFLOW_PATH} has no diff_ref: YAML key"
+echo "in the '${SCAN_STEP_NAME}' step's with: block."
+echo "Either restore explicit per-file entries or re-add the diff_ref key."
+exit 1

--- a/scripts/verify_phi_scan_config.sh
+++ b/scripts/verify_phi_scan_config.sh
@@ -7,10 +7,24 @@ TEST_GLOB_PATTERN='^tests/test_\*\.py'
 SCAN_STEP_NAME="Scan for PHI/PII"
 DIFF_REF_YAML_KEY='^[[:space:]]+diff_ref:[[:space:]]+'
 
+if [[ ! -f "${PHI_SCANIGNORE_PATH}" ]]; then
+    echo "FAIL: ${PHI_SCANIGNORE_PATH} not found — cannot verify compensating controls"
+    exit 1
+fi
+
+if [[ ! -f "${CI_WORKFLOW_PATH}" ]]; then
+    echo "FAIL: ${CI_WORKFLOW_PATH} not found — cannot verify compensating controls"
+    exit 1
+fi
+
 if ! grep -qE "${TEST_GLOB_PATTERN}" "${PHI_SCANIGNORE_PATH}"; then
     exit 0
 fi
 
+# Scan only the with: block of the target step. The block end is detected by
+# the next step-start marker at the same YAML depth. This awk heuristic
+# assumes no nested list within the step contains a sibling step marker
+# before diff_ref: appears. Holds for the current flat ci.yml structure.
 if awk -v step="${SCAN_STEP_NAME}" -v key_pattern="${DIFF_REF_YAML_KEY}" '
     $0 ~ ("name: " step) { in_step=1; next }
     in_step && /^[[:space:]]+-[[:space:]]+name:/ { exit }


### PR DESCRIPTION
## Summary

- Consolidates all per-file test exclusions into a single `tests/` pattern — covers all test files including the many recently added that were missing (test_fixer.py, test_cache.py, test_regex_detector.py, test_fhir_recognizer.py, etc.)
- Adds `coverage.xml` and `coverage/` — generated pytest-cov artifacts with class/method names that trigger HEALTH_PLAN_NUMBER as false positives
- Adds `LICENSE`, `Makefile`, `.pre-commit-hooks.yaml`, `.pre-commit-config.yaml` — project root files with word patterns that trigger combination detectors

**Root cause:** The push-to-main CI scan runs against the full repo (no diff_ref), and these files were not excluded, causing the PHI/PII scan job to fail on every push to main.

## Test plan

- [ ] Full repo scan exits 0 locally after this change
- [ ] PHI/PII scan job passes in CI on this PR
- [ ] PHI/PII scan job passes on push-to-main after merge