### PR TITLE
[7H] Post-review quality fixes: security doc, notifier model, finding factory

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,7 +74,11 @@ remains in `.phi-scanignore`.
 PhiScan is designed to handle sensitive data environments. Key security properties:
 
 - **Local execution only:** all scanning runs locally within your CI/CD pipeline
-  runner. No PHI or PII is ever transmitted to an external API or third-party service.
+  runner. No PHI or PII is ever transmitted to an external API or third-party
+  service by default. The optional AI confidence review layer
+  (`ai.enable_ai_review`, disabled by default) sends redacted code structure
+  only — never raw PHI values — to the configured AI provider when explicitly
+  enabled. Raw PHI never leaves the local runner under any configuration.
 - **No raw PHI in logs:** audit logs store SHA-256 hashes of detected values, never
   the raw values themselves.
 - **Immutable audit trail:** audit log entries are append-only (INSERT only, never

--- a/phi_scan/cli.py
+++ b/phi_scan/cli.py
@@ -104,7 +104,11 @@ from phi_scan.help_text import (
 )
 from phi_scan.logging_config import get_logger, replace_logger_handlers
 from phi_scan.models import ScanConfig, ScanFinding, ScanResult
-from phi_scan.notifier import send_email_notification, send_webhook_notification
+from phi_scan.notifier import (
+    NotificationRequest,
+    send_email_notification,
+    send_webhook_notification,
+)
 from phi_scan.output import (
     WATCH_RESULT_CLEAN_TEXT,
     WATCH_RESULT_VIOLATION_FORMAT,
@@ -848,16 +852,23 @@ def _dispatch_notifications(
 
     repo = _get_current_repository_path()
     branch = _get_current_branch()
+    notification_request = NotificationRequest(
+        scan_result=scan_result,
+        repository=repo,
+        branch=branch,
+        scanner_version=__version__,
+        report_path=report_path,
+    )
     sent_channels: list[str] = []
     if config.is_email_enabled:
         try:
-            send_email_notification(config, scan_result, repo, branch, __version__, report_path)
+            send_email_notification(config, notification_request)
             sent_channels.append("email")
         except NotificationError as email_error:
             _logger.warning(_NOTIFICATION_EMAIL_FAILURE_WARNING.format(error=email_error))
     if config.is_webhook_enabled:
         try:
-            send_webhook_notification(config, scan_result, repo, branch, __version__)
+            send_webhook_notification(config, notification_request)
             sent_channels.append(f"webhook-{config.webhook_type.value}")
         except NotificationError as webhook_error:
             _logger.warning(_NOTIFICATION_WEBHOOK_FAILURE_WARNING.format(error=webhook_error))

--- a/phi_scan/cli.py
+++ b/phi_scan/cli.py
@@ -850,11 +850,11 @@ def _dispatch_notifications(
         return []
     from phi_scan.audit import _get_current_branch, _get_current_repository_path
 
-    repo = _get_current_repository_path()
+    repository = _get_current_repository_path()
     branch = _get_current_branch()
     notification_request = NotificationRequest(
         scan_result=scan_result,
-        repository=repo,
+        repository=repository,
         branch=branch,
         scanner_version=__version__,
         report_path=report_path,

--- a/phi_scan/constants.py
+++ b/phi_scan/constants.py
@@ -623,7 +623,7 @@ WEBHOOK_DEFAULT_TIMEOUT_SECONDS: int = 10
 # Subject template for PHI alert email notifications.
 # Formatted with: risk_level, findings_count, repo, branch.
 NOTIFICATION_SUBJECT_FORMAT: str = (
-    "[PHI ALERT] {risk_level} — {findings_count} findings in {repo}/{branch}"
+    "[PHI ALERT] {risk_level} — {findings_count} findings in {repository}/{branch}"
 )
 
 # Audit action_taken values — recorded after each scan.

--- a/phi_scan/fhir_recognizer.py
+++ b/phi_scan/fhir_recognizer.py
@@ -35,7 +35,11 @@ from phi_scan.constants import (
     DetectionLayer,
     PhiCategory,
 )
-from phi_scan.hashing import StructuredFindingRequest, build_structured_finding
+from phi_scan.hashing import (
+    StructuredFindingRequest,
+    build_structured_finding,
+    compute_value_hash,
+)
 from phi_scan.models import ScanFinding
 
 __all__ = ["detect_phi_in_structured_content"]
@@ -200,7 +204,7 @@ def _build_fhir_finding(file_path: Path, line_match: _FhirLineMatch) -> ScanFind
             hipaa_category=phi_category,
             confidence=_FHIR_FIELD_BASE_CONFIDENCE,
             detection_layer=DetectionLayer.FHIR,
-            raw_value=line_match.raw_value,
+            value_hash=compute_value_hash(line_match.raw_value),
             code_context=code_context,
         )
     )

--- a/phi_scan/fhir_recognizer.py
+++ b/phi_scan/fhir_recognizer.py
@@ -32,11 +32,10 @@ from phi_scan.constants import (
     CONFIDENCE_HIGH_FLOOR,
     CONFIDENCE_STRUCTURED_MAX,
     CONFIDENCE_STRUCTURED_MIN,
-    HIPAA_REMEDIATION_GUIDANCE,
     DetectionLayer,
     PhiCategory,
 )
-from phi_scan.hashing import compute_value_hash, severity_from_confidence
+from phi_scan.hashing import build_structured_finding
 from phi_scan.models import ScanFinding
 
 __all__ = ["detect_phi_in_structured_content"]
@@ -176,7 +175,8 @@ def _build_fhir_finding(file_path: Path, line_match: _FhirLineMatch) -> ScanFind
     """Construct a ScanFinding from a FHIR field match.
 
     The raw matched value is hashed immediately; only the digest is stored
-    (HIPAA audit requirement).
+    (HIPAA audit requirement). Delegates hash + severity + remediation derivation
+    to build_structured_finding to keep this pattern consistent across layers.
 
     Args:
         file_path: Source path recorded in the finding for reporting.
@@ -186,23 +186,21 @@ def _build_fhir_finding(file_path: Path, line_match: _FhirLineMatch) -> ScanFind
         Immutable ScanFinding for this FHIR field detection.
     """
     phi_category = _FHIR_PHI_FIELD_CATEGORIES[line_match.field_name]
-    confidence = _FHIR_FIELD_BASE_CONFIDENCE
-    return ScanFinding(
+    # Store only the matched field name — never the raw line text.
+    # A single FHIR line may contain multiple PHI fields; using line_text
+    # would expose every other field's value regardless of how many
+    # str.replace() calls are applied. The field name is sufficient for a
+    # developer to locate and remediate the finding.
+    code_context = f'"{line_match.field_name}": {CODE_CONTEXT_REDACTED_VALUE}'
+    return build_structured_finding(
         file_path=file_path,
         line_number=line_match.line_number,
         entity_type=line_match.field_name,
         hipaa_category=phi_category,
-        confidence=confidence,
+        confidence=_FHIR_FIELD_BASE_CONFIDENCE,
         detection_layer=DetectionLayer.FHIR,
-        value_hash=compute_value_hash(line_match.raw_value),
-        severity=severity_from_confidence(confidence),
-        # Store only the matched field name — never the raw line text.
-        # A single FHIR line may contain multiple PHI fields; using line_text
-        # would expose every other field's value regardless of how many
-        # str.replace() calls are applied. The field name is sufficient for a
-        # developer to locate and remediate the finding.
-        code_context=f'"{line_match.field_name}": {CODE_CONTEXT_REDACTED_VALUE}',
-        remediation_hint=HIPAA_REMEDIATION_GUIDANCE.get(phi_category, ""),
+        raw_value=line_match.raw_value,
+        code_context=code_context,
     )
 
 

--- a/phi_scan/fhir_recognizer.py
+++ b/phi_scan/fhir_recognizer.py
@@ -35,7 +35,7 @@ from phi_scan.constants import (
     DetectionLayer,
     PhiCategory,
 )
-from phi_scan.hashing import build_structured_finding
+from phi_scan.hashing import StructuredFindingRequest, build_structured_finding
 from phi_scan.models import ScanFinding
 
 __all__ = ["detect_phi_in_structured_content"]
@@ -193,14 +193,16 @@ def _build_fhir_finding(file_path: Path, line_match: _FhirLineMatch) -> ScanFind
     # developer to locate and remediate the finding.
     code_context = f'"{line_match.field_name}": {CODE_CONTEXT_REDACTED_VALUE}'
     return build_structured_finding(
-        file_path=file_path,
-        line_number=line_match.line_number,
-        entity_type=line_match.field_name,
-        hipaa_category=phi_category,
-        confidence=_FHIR_FIELD_BASE_CONFIDENCE,
-        detection_layer=DetectionLayer.FHIR,
-        raw_value=line_match.raw_value,
-        code_context=code_context,
+        StructuredFindingRequest(
+            file_path=file_path,
+            line_number=line_match.line_number,
+            entity_type=line_match.field_name,
+            hipaa_category=phi_category,
+            confidence=_FHIR_FIELD_BASE_CONFIDENCE,
+            detection_layer=DetectionLayer.FHIR,
+            raw_value=line_match.raw_value,
+            code_context=code_context,
+        )
     )
 
 

--- a/phi_scan/hashing.py
+++ b/phi_scan/hashing.py
@@ -45,8 +45,10 @@ _NO_REMEDIATION_HINT: str = ""
 class StructuredFindingRequest:
     """Input bundle for build_structured_finding.
 
-    Groups the 8 layer-specific inputs required to construct a ScanFinding,
+    Groups the 7 layer-specific inputs required to construct a ScanFinding,
     satisfying the ≤3 argument rule for build_structured_finding.
+    Callers must call compute_value_hash() before constructing this object —
+    raw PHI must never be stored in a field.
     """
 
     file_path: Path
@@ -55,7 +57,7 @@ class StructuredFindingRequest:
     hipaa_category: PhiCategory
     confidence: float
     detection_layer: DetectionLayer
-    raw_value: str
+    value_hash: str
     code_context: str
 
 
@@ -115,15 +117,16 @@ def severity_from_confidence(confidence: float) -> SeverityLevel:
 def build_structured_finding(request: StructuredFindingRequest) -> ScanFinding:
     """Construct a ScanFinding for structured detectors (FHIR, HL7).
 
-    Centralises hash + severity + remediation-hint derivation so the
-    HIPAA-critical operations cannot diverge between FHIR and HL7 layers.
+    Centralises severity + remediation-hint derivation so the HIPAA-critical
+    operations cannot diverge between FHIR and HL7 layers. The caller is
+    responsible for hashing the raw PHI value before constructing the request.
 
     Args:
         request: All layer-specific inputs bundled as a StructuredFindingRequest.
 
     Returns:
-        Immutable ScanFinding with value_hash, severity, and remediation_hint
-        derived from the request.
+        Immutable ScanFinding with severity and remediation_hint derived from
+        the request.
     """
     return ScanFinding(
         file_path=request.file_path,
@@ -132,7 +135,7 @@ def build_structured_finding(request: StructuredFindingRequest) -> ScanFinding:
         hipaa_category=request.hipaa_category,
         confidence=request.confidence,
         detection_layer=request.detection_layer,
-        value_hash=compute_value_hash(request.raw_value),
+        value_hash=request.value_hash,
         severity=severity_from_confidence(request.confidence),
         code_context=request.code_context,
         remediation_hint=HIPAA_REMEDIATION_GUIDANCE.get(

--- a/phi_scan/hashing.py
+++ b/phi_scan/hashing.py
@@ -1,9 +1,10 @@
-"""Shared PHI detection utilities: value hashing and severity scoring.
+"""Shared PHI detection utilities: value hashing, severity scoring, and finding construction.
 
-Both functions are used by every detection layer (regex, NLP, FHIR, HL7) to
-build ``ScanFinding`` objects. Centralising them here ensures the
-HIPAA-critical hash function has a single implementation and that severity
-bands stay consistent across all layers.
+All three functions are used by every detection layer (regex, NLP, FHIR, HL7) to
+build ``ScanFinding`` objects. Centralising them here ensures the HIPAA-critical
+hash function has a single implementation, severity bands stay consistent across
+all layers, and the structured-finding construction pattern (hash + severity +
+remediation lookup) cannot diverge between FHIR and HL7.
 
 This module is an intentional exception to the "no premature abstraction"
 rule — the identical functions existed verbatim in four detection modules
@@ -14,6 +15,7 @@ extracted here.
 from __future__ import annotations
 
 import hashlib
+from pathlib import Path
 
 from phi_scan.constants import (
     CONFIDENCE_HIGH_FLOOR,
@@ -21,10 +23,14 @@ from phi_scan.constants import (
     CONFIDENCE_MEDIUM_FLOOR,
     CONFIDENCE_SCORE_MAXIMUM,
     CONFIDENCE_SCORE_MINIMUM,
+    HIPAA_REMEDIATION_GUIDANCE,
+    DetectionLayer,
+    PhiCategory,
     SeverityLevel,
 )
+from phi_scan.models import ScanFinding
 
-__all__ = ["compute_value_hash", "severity_from_confidence"]
+__all__ = ["build_structured_finding", "compute_value_hash", "severity_from_confidence"]
 
 
 def compute_value_hash(text: str) -> str:
@@ -78,3 +84,48 @@ def severity_from_confidence(confidence: float) -> SeverityLevel:
     if confidence >= CONFIDENCE_LOW_FLOOR:
         return SeverityLevel.LOW
     return SeverityLevel.INFO
+
+
+def build_structured_finding(
+    file_path: Path,
+    line_number: int,
+    entity_type: str,
+    hipaa_category: PhiCategory,
+    confidence: float,
+    detection_layer: DetectionLayer,
+    raw_value: str,
+    code_context: str,
+) -> ScanFinding:
+    """Construct a ScanFinding for structured detectors (FHIR, HL7).
+
+    Centralises the hash + severity + remediation-hint derivation that both
+    FHIR and HL7 layers perform identically. Callers supply only the
+    layer-specific inputs; this function ensures the HIPAA-critical operations
+    cannot diverge between layers.
+
+    Args:
+        file_path: Source path recorded in the finding for reporting.
+        line_number: 1-based line number of the match.
+        entity_type: Human-readable entity label (e.g. field name or category value).
+        hipaa_category: HIPAA category for this finding.
+        confidence: Base confidence score for this detection layer.
+        detection_layer: Which structured layer produced the finding.
+        raw_value: The raw matched PHI value — hashed immediately, never stored.
+        code_context: Pre-redacted source context string (must contain [REDACTED]).
+
+    Returns:
+        Immutable ScanFinding with value_hash, severity, and remediation_hint
+        derived from the inputs.
+    """
+    return ScanFinding(
+        file_path=file_path,
+        line_number=line_number,
+        entity_type=entity_type,
+        hipaa_category=hipaa_category,
+        confidence=confidence,
+        detection_layer=detection_layer,
+        value_hash=compute_value_hash(raw_value),
+        severity=severity_from_confidence(confidence),
+        code_context=code_context,
+        remediation_hint=HIPAA_REMEDIATION_GUIDANCE.get(hipaa_category, ""),
+    )

--- a/phi_scan/hashing.py
+++ b/phi_scan/hashing.py
@@ -15,6 +15,7 @@ extracted here.
 from __future__ import annotations
 
 import hashlib
+import string
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -39,6 +40,7 @@ __all__ = [
 ]
 
 _NO_REMEDIATION_HINT: str = ""
+_SHA256_HEX_DIGEST_LENGTH: int = 64
 
 
 @dataclass(frozen=True)
@@ -59,6 +61,19 @@ class StructuredFindingRequest:
     detection_layer: DetectionLayer
     value_hash: str
     code_context: str
+
+    def __post_init__(self) -> None:
+        """Reject value_hash that is not a valid SHA-256 hex digest.
+
+        Raises:
+            ValueError: If value_hash is not exactly 64 lowercase hex characters.
+        """
+        is_valid_length = len(self.value_hash) == _SHA256_HEX_DIGEST_LENGTH
+        is_valid_hex = all(character in string.hexdigits for character in self.value_hash)
+        if not is_valid_length or not is_valid_hex:
+            raise ValueError(
+                f"value_hash must be a 64-character hex digest; got length {len(self.value_hash)}"
+            )
 
 
 def compute_value_hash(text: str) -> str:

--- a/phi_scan/hashing.py
+++ b/phi_scan/hashing.py
@@ -15,6 +15,7 @@ extracted here.
 from __future__ import annotations
 
 import hashlib
+from dataclasses import dataclass
 from pathlib import Path
 
 from phi_scan.constants import (
@@ -30,7 +31,32 @@ from phi_scan.constants import (
 )
 from phi_scan.models import ScanFinding
 
-__all__ = ["build_structured_finding", "compute_value_hash", "severity_from_confidence"]
+__all__ = [
+    "StructuredFindingRequest",
+    "build_structured_finding",
+    "compute_value_hash",
+    "severity_from_confidence",
+]
+
+_NO_REMEDIATION_HINT: str = ""
+
+
+@dataclass(frozen=True)
+class StructuredFindingRequest:
+    """Input bundle for build_structured_finding.
+
+    Groups the 8 layer-specific inputs required to construct a ScanFinding,
+    satisfying the ≤3 argument rule for build_structured_finding.
+    """
+
+    file_path: Path
+    line_number: int
+    entity_type: str
+    hipaa_category: PhiCategory
+    confidence: float
+    detection_layer: DetectionLayer
+    raw_value: str
+    code_context: str
 
 
 def compute_value_hash(text: str) -> str:
@@ -86,46 +112,30 @@ def severity_from_confidence(confidence: float) -> SeverityLevel:
     return SeverityLevel.INFO
 
 
-def build_structured_finding(
-    file_path: Path,
-    line_number: int,
-    entity_type: str,
-    hipaa_category: PhiCategory,
-    confidence: float,
-    detection_layer: DetectionLayer,
-    raw_value: str,
-    code_context: str,
-) -> ScanFinding:
+def build_structured_finding(request: StructuredFindingRequest) -> ScanFinding:
     """Construct a ScanFinding for structured detectors (FHIR, HL7).
 
-    Centralises the hash + severity + remediation-hint derivation that both
-    FHIR and HL7 layers perform identically. Callers supply only the
-    layer-specific inputs; this function ensures the HIPAA-critical operations
-    cannot diverge between layers.
+    Centralises hash + severity + remediation-hint derivation so the
+    HIPAA-critical operations cannot diverge between FHIR and HL7 layers.
 
     Args:
-        file_path: Source path recorded in the finding for reporting.
-        line_number: 1-based line number of the match.
-        entity_type: Human-readable entity label (e.g. field name or category value).
-        hipaa_category: HIPAA category for this finding.
-        confidence: Base confidence score for this detection layer.
-        detection_layer: Which structured layer produced the finding.
-        raw_value: The raw matched PHI value — hashed immediately, never stored.
-        code_context: Pre-redacted source context string (must contain [REDACTED]).
+        request: All layer-specific inputs bundled as a StructuredFindingRequest.
 
     Returns:
         Immutable ScanFinding with value_hash, severity, and remediation_hint
-        derived from the inputs.
+        derived from the request.
     """
     return ScanFinding(
-        file_path=file_path,
-        line_number=line_number,
-        entity_type=entity_type,
-        hipaa_category=hipaa_category,
-        confidence=confidence,
-        detection_layer=detection_layer,
-        value_hash=compute_value_hash(raw_value),
-        severity=severity_from_confidence(confidence),
-        code_context=code_context,
-        remediation_hint=HIPAA_REMEDIATION_GUIDANCE.get(hipaa_category, ""),
+        file_path=request.file_path,
+        line_number=request.line_number,
+        entity_type=request.entity_type,
+        hipaa_category=request.hipaa_category,
+        confidence=request.confidence,
+        detection_layer=request.detection_layer,
+        value_hash=compute_value_hash(request.raw_value),
+        severity=severity_from_confidence(request.confidence),
+        code_context=request.code_context,
+        remediation_hint=HIPAA_REMEDIATION_GUIDANCE.get(
+            request.hipaa_category, _NO_REMEDIATION_HINT
+        ),
     )

--- a/phi_scan/hl7_scanner.py
+++ b/phi_scan/hl7_scanner.py
@@ -36,7 +36,11 @@ from phi_scan.constants import (
     PhiCategory,
 )
 from phi_scan.exceptions import MissingOptionalDependencyError
-from phi_scan.hashing import StructuredFindingRequest, build_structured_finding
+from phi_scan.hashing import (
+    StructuredFindingRequest,
+    build_structured_finding,
+    compute_value_hash,
+)
 from phi_scan.models import Hl7ScanContext, ScanFinding
 
 __all__ = [
@@ -175,7 +179,7 @@ def _build_hl7_finding(
             hipaa_category=phi_category,
             confidence=_HL7_FIELD_BASE_CONFIDENCE,
             detection_layer=DetectionLayer.HL7,
-            raw_value=field_value,
+            value_hash=compute_value_hash(field_value),
             code_context=f"{context.segment_type}: {CODE_CONTEXT_REDACTED_VALUE}",
         )
     )

--- a/phi_scan/hl7_scanner.py
+++ b/phi_scan/hl7_scanner.py
@@ -32,12 +32,11 @@ from phi_scan.constants import (
     CONFIDENCE_HIGH_FLOOR,
     CONFIDENCE_STRUCTURED_MAX,
     CONFIDENCE_STRUCTURED_MIN,
-    HIPAA_REMEDIATION_GUIDANCE,
     DetectionLayer,
     PhiCategory,
 )
 from phi_scan.exceptions import MissingOptionalDependencyError
-from phi_scan.hashing import compute_value_hash, severity_from_confidence
+from phi_scan.hashing import build_structured_finding
 from phi_scan.models import Hl7ScanContext, ScanFinding
 
 __all__ = [
@@ -156,7 +155,9 @@ def _build_hl7_finding(
     """Construct a ScanFinding from a single HL7 field match.
 
     The raw field value is hashed immediately; only the digest is stored
-    (HIPAA audit requirement).
+    (HIPAA audit requirement). Delegates hash + severity + remediation
+    derivation to build_structured_finding to keep this pattern consistent
+    across layers.
 
     Args:
         field_value: Raw string content of the HL7 field.
@@ -166,19 +167,15 @@ def _build_hl7_finding(
     Returns:
         Immutable ScanFinding for this HL7 field detection.
     """
-    confidence = _HL7_FIELD_BASE_CONFIDENCE
-    line_number = context.segment_index + _LINE_NUMBER_START
-    return ScanFinding(
+    return build_structured_finding(
         file_path=context.file_path,
-        line_number=line_number,
+        line_number=context.segment_index + _LINE_NUMBER_START,
         entity_type=phi_category.value,
         hipaa_category=phi_category,
-        confidence=confidence,
+        confidence=_HL7_FIELD_BASE_CONFIDENCE,
         detection_layer=DetectionLayer.HL7,
-        value_hash=compute_value_hash(field_value),
-        severity=severity_from_confidence(confidence),
+        raw_value=field_value,
         code_context=f"{context.segment_type}: {CODE_CONTEXT_REDACTED_VALUE}",
-        remediation_hint=HIPAA_REMEDIATION_GUIDANCE.get(phi_category, ""),
     )
 
 

--- a/phi_scan/hl7_scanner.py
+++ b/phi_scan/hl7_scanner.py
@@ -36,7 +36,7 @@ from phi_scan.constants import (
     PhiCategory,
 )
 from phi_scan.exceptions import MissingOptionalDependencyError
-from phi_scan.hashing import build_structured_finding
+from phi_scan.hashing import StructuredFindingRequest, build_structured_finding
 from phi_scan.models import Hl7ScanContext, ScanFinding
 
 __all__ = [
@@ -168,14 +168,16 @@ def _build_hl7_finding(
         Immutable ScanFinding for this HL7 field detection.
     """
     return build_structured_finding(
-        file_path=context.file_path,
-        line_number=context.segment_index + _LINE_NUMBER_START,
-        entity_type=phi_category.value,
-        hipaa_category=phi_category,
-        confidence=_HL7_FIELD_BASE_CONFIDENCE,
-        detection_layer=DetectionLayer.HL7,
-        raw_value=field_value,
-        code_context=f"{context.segment_type}: {CODE_CONTEXT_REDACTED_VALUE}",
+        StructuredFindingRequest(
+            file_path=context.file_path,
+            line_number=context.segment_index + _LINE_NUMBER_START,
+            entity_type=phi_category.value,
+            hipaa_category=phi_category,
+            confidence=_HL7_FIELD_BASE_CONFIDENCE,
+            detection_layer=DetectionLayer.HL7,
+            raw_value=field_value,
+            code_context=f"{context.segment_type}: {CODE_CONTEXT_REDACTED_VALUE}",
+        )
     )
 
 

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -263,15 +263,15 @@ def _build_webhook_scan_summary(
     """
     truncated_findings = tuple(
         {
-            "file_path": str(f.file_path),
-            "line_number": f.line_number,
-            "entity_type": f.entity_type,
-            "hipaa_category": f.hipaa_category.value,
-            "severity": f.severity.value,
-            "confidence": f.confidence,
-            "value_hash": f.value_hash,
+            "file_path": str(finding.file_path),
+            "line_number": finding.line_number,
+            "entity_type": finding.entity_type,
+            "hipaa_category": finding.hipaa_category.value,
+            "severity": finding.severity.value,
+            "confidence": finding.confidence,
+            "value_hash": finding.value_hash,
         }
-        for f in scan_result.findings[:_MAX_FINDINGS_IN_NOTIFICATION]
+        for finding in scan_result.findings[:_MAX_FINDINGS_IN_NOTIFICATION]
     )
     return _WebhookScanSummary(
         is_clean=scan_result.is_clean,

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -39,6 +39,7 @@ from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any
 from urllib.parse import urlparse
 
@@ -270,7 +271,7 @@ class _WebhookScanSummary:
     repository: str
     branch: str
     scanner_version: str
-    truncated_findings: tuple[dict[str, Any], ...]
+    truncated_findings: tuple[MappingProxyType[str, Any], ...]
 
 
 def _truncate_findings_for_notification(
@@ -287,15 +288,17 @@ def _truncate_findings_for_notification(
         Tuple of finding dicts safe for inclusion in a webhook payload.
     """
     return tuple(
-        {
-            _FINDING_KEY_FILE_PATH: str(finding.file_path),
-            _FINDING_KEY_LINE_NUMBER: finding.line_number,
-            _FINDING_KEY_ENTITY_TYPE: finding.entity_type,
-            _FINDING_KEY_HIPAA_CATEGORY: finding.hipaa_category.value,
-            _FINDING_KEY_SEVERITY: finding.severity.value,
-            _FINDING_KEY_CONFIDENCE: finding.confidence,
-            _FINDING_KEY_VALUE_HASH: finding.value_hash,
-        }
+        MappingProxyType(
+            {
+                _FINDING_KEY_FILE_PATH: str(finding.file_path),
+                _FINDING_KEY_LINE_NUMBER: finding.line_number,
+                _FINDING_KEY_ENTITY_TYPE: finding.entity_type,
+                _FINDING_KEY_HIPAA_CATEGORY: finding.hipaa_category.value,
+                _FINDING_KEY_SEVERITY: finding.severity.value,
+                _FINDING_KEY_CONFIDENCE: finding.confidence,
+                _FINDING_KEY_VALUE_HASH: finding.value_hash,
+            }
+        )
         for finding in scan_result.findings[:_MAX_FINDINGS_IN_NOTIFICATION]
     )
 
@@ -612,7 +615,7 @@ def _build_generic_payload(scan_summary: _WebhookScanSummary) -> dict[str, Any]:
         "files_scanned": scan_summary.files_scanned,
         "scan_duration": scan_summary.scan_duration,
         "action_taken": scan_summary.action_taken,
-        "findings": list(scan_summary.truncated_findings),
+        "findings": [dict(finding) for finding in scan_summary.truncated_findings],
     }
 
 

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -6,7 +6,7 @@ Implements two delivery channels:
   Email (5A) — ``send_email_notification``
     Sends a Rich-formatted HTML email via SMTP/STARTTLS when PHI is detected.
     TLS is required; plaintext SMTP connections are rejected at delivery time.
-    Subject format: ``[PHI ALERT] {risk_level} — {findings_count} findings in {repo}/{branch}``.
+    Subject format: see NOTIFICATION_SUBJECT_FORMAT in constants.py.
     An HTML or PDF report may be attached when a report_path is provided.
 
   Webhooks (5B) — ``send_webhook_notification``
@@ -155,7 +155,7 @@ _HTML_EMAIL_TEMPLATE: str = """\
     </tr>
     <tr>
       <td style="padding:8px;border:1px solid #ddd;"><strong>Repository</strong></td>
-      <td style="padding:8px;border:1px solid #ddd;">{repo}</td>
+      <td style="padding:8px;border:1px solid #ddd;">{repository}</td>
     </tr>
     <tr style="background:#f9f9f9;">
       <td style="padding:8px;border:1px solid #ddd;"><strong>Branch</strong></td>
@@ -238,7 +238,7 @@ class _WebhookScanSummary:
     files_scanned: int
     scan_duration: float
     action_taken: str
-    repo: str
+    repository: str
     branch: str
     scanner_version: str
     truncated_findings: tuple[dict[str, Any], ...]
@@ -246,7 +246,7 @@ class _WebhookScanSummary:
 
 def _build_webhook_scan_summary(
     scan_result: ScanResult,
-    repo: str,
+    repository: str,
     branch: str,
     scanner_version: str,
 ) -> _WebhookScanSummary:
@@ -254,7 +254,7 @@ def _build_webhook_scan_summary(
 
     Args:
         scan_result: Completed scan result.
-        repo: Repository identifier.
+        repository: Repository identifier.
         branch: Branch name.
         scanner_version: phi-scan version string.
 
@@ -281,7 +281,7 @@ def _build_webhook_scan_summary(
         files_scanned=scan_result.files_scanned,
         scan_duration=scan_result.scan_duration,
         action_taken=ACTION_TAKEN_PASS if scan_result.is_clean else ACTION_TAKEN_FAIL,
-        repo=repo,
+        repository=repository,
         branch=branch,
         scanner_version=scanner_version,
         truncated_findings=truncated_findings,
@@ -338,12 +338,12 @@ def _build_findings_table_html(scan_result: ScanResult) -> str:
     return "".join(rows)
 
 
-def _build_email_subject(scan_result: ScanResult, repo: str, branch: str) -> str:
+def _build_email_subject(scan_result: ScanResult, repository: str, branch: str) -> str:
     """Return the formatted email subject line.
 
     Args:
         scan_result: Completed scan result.
-        repo: Repository name or path hash (never raw PHI).
+        repository: Repository name or path hash (never raw PHI).
         branch: Branch name or hash (never raw PHI).
 
     Returns:
@@ -352,19 +352,19 @@ def _build_email_subject(scan_result: ScanResult, repo: str, branch: str) -> str
     return NOTIFICATION_SUBJECT_FORMAT.format(
         risk_level=scan_result.risk_level.value.upper(),
         findings_count=len(scan_result.findings),
-        repo=repo,
+        repository=repository,
         branch=branch,
     )
 
 
 def _build_email_html_body(
-    scan_result: ScanResult, repo: str, branch: str, scanner_version: str
+    scan_result: ScanResult, repository: str, branch: str, scanner_version: str
 ) -> str:
     """Render the HTML email body.
 
     Args:
         scan_result: Completed scan result.
-        repo: Repository identifier string.
+        repository: Repository identifier string.
         branch: Branch name string.
         scanner_version: phi-scan version string from phi_scan.__version__.
 
@@ -375,7 +375,7 @@ def _build_email_html_body(
     return _HTML_EMAIL_TEMPLATE.format(
         risk_level=html.escape(scan_result.risk_level.value.upper()),
         findings_count=len(scan_result.findings),
-        repo=html.escape(repo),
+        repository=html.escape(repository),
         branch=html.escape(branch),
         scanner_version=html.escape(scanner_version),
         files_scanned=scan_result.files_scanned,
@@ -503,7 +503,8 @@ def _build_slack_payload(summary: _WebhookScanSummary) -> dict[str, Any]:
                         "text": {
                             "type": "mrkdwn",
                             "text": (
-                                f":shield: *phi-scan Alert* | {summary.repo}/{summary.branch}\n"
+                                f":shield: *phi-scan Alert* | "
+                                f"{summary.repository}/{summary.branch}\n"
                                 f"{status_text}\n"
                                 f"Files scanned: {summary.files_scanned} | "
                                 f"Scanner: {summary.scanner_version}"
@@ -538,10 +539,10 @@ def _build_teams_payload(summary: _WebhookScanSummary) -> dict[str, Any]:
         "summary": f"phi-scan {status_text}",
         "sections": [
             {
-                "activityTitle": f"phi-scan Alert — {summary.repo}/{summary.branch}",
+                "activityTitle": f"phi-scan Alert — {summary.repository}/{summary.branch}",
                 "activitySubtitle": status_text,
                 "facts": [
-                    {"name": "Risk Level", "value": summary.risk_level_label},
+                    {"name": "Risk Level", "value": summary.risk_level_value},
                     # phi-scan:ignore-next-line
                     {"name": "Findings", "value": str(summary.findings_count)},
                     {"name": "Files Scanned", "value": str(summary.files_scanned)},
@@ -568,7 +569,7 @@ def _build_generic_payload(summary: _WebhookScanSummary) -> dict[str, Any]:
     return {
         "event": "phi_scan_complete",
         "scanner_version": summary.scanner_version,
-        "repository": summary.repo,
+        "repository": summary.repository,
         "branch": summary.branch,
         "risk_level": summary.risk_level_value,
         "is_clean": summary.is_clean,
@@ -583,7 +584,7 @@ def _build_generic_payload(summary: _WebhookScanSummary) -> dict[str, Any]:
 def _build_webhook_payload(
     webhook_type: WebhookType,
     scan_result: ScanResult,
-    repo: str,
+    repository: str,
     branch: str,
     scanner_version: str,
 ) -> dict[str, Any]:
@@ -592,14 +593,14 @@ def _build_webhook_payload(
     Args:
         webhook_type: The target webhook format.
         scan_result: Completed scan result.
-        repo: Repository identifier.
+        repository: Repository identifier.
         branch: Branch name.
         scanner_version: phi-scan version string.
 
     Returns:
         Payload dict appropriate for the webhook_type.
     """
-    summary = _build_webhook_scan_summary(scan_result, repo, branch, scanner_version)
+    summary = _build_webhook_scan_summary(scan_result, repository, branch, scanner_version)
     if webhook_type is WebhookType.SLACK:
         return _build_slack_payload(summary)
     if webhook_type is WebhookType.TEAMS:
@@ -765,7 +766,7 @@ def _post_with_retry(
 def send_email_notification(
     config: NotificationConfig,
     scan_result: ScanResult,
-    repo: str,
+    repository: str,
     branch: str,
     scanner_version: str,
     report_path: Path | None = None,
@@ -783,7 +784,7 @@ def send_email_notification(
         config: Notification configuration (smtp_host, smtp_port, smtp_from,
             smtp_recipients, smtp_use_tls).
         scan_result: Completed scan result to summarise in the email.
-        repo: Repository name or identifier (used in subject and body).
+        repository: Repository name or identifier (used in subject and body).
         branch: Branch name (used in subject and body).
         scanner_version: phi-scan version string (e.g. "0.5.0").
         report_path: Optional path to a PDF or HTML report to attach.
@@ -799,14 +800,14 @@ def send_email_notification(
         raise NotificationError(_NO_SMTP_FROM_ERROR)
     if not config.smtp_recipients:
         raise NotificationError(_NO_RECIPIENTS_ERROR)
-    subject = _build_email_subject(scan_result, repo, branch)
-    html_body = _build_email_html_body(scan_result, repo, branch, scanner_version)
+    subject = _build_email_subject(scan_result, repository, branch)
+    html_body = _build_email_html_body(scan_result, repository, branch, scanner_version)
     message = _build_mime_message(config, subject, html_body, report_path)
     _deliver_via_smtp(config, message)
     _logger.info(
         "Email notification sent to %d recipient(s) for %s/%s",
         len(config.smtp_recipients),
-        repo,
+        repository,
         branch,
     )
 
@@ -814,7 +815,7 @@ def send_email_notification(
 def send_webhook_notification(
     config: NotificationConfig,
     scan_result: ScanResult,
-    repo: str,
+    repository: str,
     branch: str,
     scanner_version: str,
 ) -> None:
@@ -831,7 +832,7 @@ def send_webhook_notification(
         config: Notification configuration (webhook_url, webhook_type,
             webhook_retry_count).
         scan_result: Completed scan result to include in the payload.
-        repo: Repository name or identifier.
+        repository: Repository name or identifier.
         branch: Branch name.
         scanner_version: phi-scan version string.
 
@@ -843,13 +844,13 @@ def send_webhook_notification(
         raise NotificationError(_NO_WEBHOOK_URL_ERROR)
     _validate_webhook_url(config.webhook_url, config.is_private_webhook_url_allowed)
     payload = _build_webhook_payload(
-        config.webhook_type, scan_result, repo, branch, scanner_version
+        config.webhook_type, scan_result, repository, branch, scanner_version
     )
     _post_with_retry(config.webhook_url, payload, config.webhook_retry_count)
     _logger.info(
         "Webhook notification delivered to %r (%s) for %s/%s",
         config.webhook_url,
         config.webhook_type.value,
-        repo,
+        repository,
         branch,
     )

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -244,6 +244,33 @@ class _WebhookScanSummary:
     truncated_findings: tuple[dict[str, Any], ...]
 
 
+def _truncate_findings_for_notification(
+    scan_result: ScanResult,
+) -> tuple[dict[str, Any], ...]:
+    """Serialise at most _MAX_FINDINGS_IN_NOTIFICATION findings as plain dicts.
+
+    Only hashed metadata is included — no raw PHI values or code_context.
+
+    Args:
+        scan_result: Completed scan result.
+
+    Returns:
+        Tuple of finding dicts safe for inclusion in a webhook payload.
+    """
+    return tuple(
+        {
+            "file_path": str(finding.file_path),
+            "line_number": finding.line_number,
+            "entity_type": finding.entity_type,
+            "hipaa_category": finding.hipaa_category.value,
+            "severity": finding.severity.value,
+            "confidence": finding.confidence,
+            "value_hash": finding.value_hash,
+        }
+        for finding in scan_result.findings[:_MAX_FINDINGS_IN_NOTIFICATION]
+    )
+
+
 def _build_webhook_scan_summary(
     scan_result: ScanResult,
     repository: str,
@@ -261,18 +288,6 @@ def _build_webhook_scan_summary(
     Returns:
         Immutable summary of scan metadata for use by payload builders.
     """
-    truncated_findings = tuple(
-        {
-            "file_path": str(finding.file_path),
-            "line_number": finding.line_number,
-            "entity_type": finding.entity_type,
-            "hipaa_category": finding.hipaa_category.value,
-            "severity": finding.severity.value,
-            "confidence": finding.confidence,
-            "value_hash": finding.value_hash,
-        }
-        for finding in scan_result.findings[:_MAX_FINDINGS_IN_NOTIFICATION]
-    )
     return _WebhookScanSummary(
         is_clean=scan_result.is_clean,
         risk_level_label=scan_result.risk_level.value.upper(),
@@ -284,7 +299,7 @@ def _build_webhook_scan_summary(
         repository=repository,
         branch=branch,
         scanner_version=scanner_version,
-        truncated_findings=truncated_findings,
+        truncated_findings=_truncate_findings_for_notification(scan_result),
     )
 
 

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -54,7 +54,7 @@ from phi_scan.constants import (
 )
 from phi_scan.exceptions import NotificationError
 from phi_scan.hashing import compute_value_hash
-from phi_scan.models import NotificationConfig, ScanResult
+from phi_scan.models import NotificationConfig, ScanFinding, ScanResult
 
 __all__ = ["NotificationRequest", "send_email_notification", "send_webhook_notification"]
 
@@ -274,10 +274,33 @@ class _WebhookScanSummary:
     truncated_findings: tuple[MappingProxyType[str, Any], ...]
 
 
+def _serialise_finding(finding: ScanFinding) -> MappingProxyType[str, Any]:
+    """Serialise a single finding as a read-only metadata dict.
+
+    Only hashed metadata is included — no raw PHI values or code_context.
+
+    Args:
+        finding: The scan finding to serialise.
+
+    Returns:
+        Immutable mapping of finding metadata safe for webhook payloads.
+    """
+    finding_dict: dict[str, Any] = {
+        _FINDING_KEY_FILE_PATH: str(finding.file_path),
+        _FINDING_KEY_LINE_NUMBER: finding.line_number,
+        _FINDING_KEY_ENTITY_TYPE: finding.entity_type,
+        _FINDING_KEY_HIPAA_CATEGORY: finding.hipaa_category.value,
+        _FINDING_KEY_SEVERITY: finding.severity.value,
+        _FINDING_KEY_CONFIDENCE: finding.confidence,
+        _FINDING_KEY_VALUE_HASH: finding.value_hash,
+    }
+    return MappingProxyType(finding_dict)
+
+
 def _truncate_findings_for_notification(
     scan_result: ScanResult,
-) -> tuple[dict[str, Any], ...]:
-    """Serialise at most _MAX_FINDINGS_IN_NOTIFICATION findings as plain dicts.
+) -> tuple[MappingProxyType[str, Any], ...]:
+    """Serialise at most _MAX_FINDINGS_IN_NOTIFICATION findings as read-only dicts.
 
     Only hashed metadata is included — no raw PHI values or code_context.
 
@@ -285,20 +308,10 @@ def _truncate_findings_for_notification(
         scan_result: Completed scan result.
 
     Returns:
-        Tuple of finding dicts safe for inclusion in a webhook payload.
+        Tuple of immutable finding mappings safe for inclusion in a webhook payload.
     """
     return tuple(
-        MappingProxyType(
-            {
-                _FINDING_KEY_FILE_PATH: str(finding.file_path),
-                _FINDING_KEY_LINE_NUMBER: finding.line_number,
-                _FINDING_KEY_ENTITY_TYPE: finding.entity_type,
-                _FINDING_KEY_HIPAA_CATEGORY: finding.hipaa_category.value,
-                _FINDING_KEY_SEVERITY: finding.severity.value,
-                _FINDING_KEY_CONFIDENCE: finding.confidence,
-                _FINDING_KEY_VALUE_HASH: finding.value_hash,
-            }
-        )
+        _serialise_finding(finding)
         for finding in scan_result.findings[:_MAX_FINDINGS_IN_NOTIFICATION]
     )
 

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -217,6 +217,13 @@ _TEAMS_THEME_COLOR_RED: str = "FF0000"
 _TEAMS_THEME_COLOR_GREEN: str = "00AA00"
 _MAX_FINDINGS_IN_NOTIFICATION: int = 20  # prevent oversized payloads
 _WEBHOOK_EVENT_NAME: str = "phi_scan_complete"
+_FINDING_KEY_FILE_PATH: str = "file_path"
+_FINDING_KEY_LINE_NUMBER: str = "line_number"
+_FINDING_KEY_ENTITY_TYPE: str = "entity_type"
+_FINDING_KEY_HIPAA_CATEGORY: str = "hipaa_category"
+_FINDING_KEY_SEVERITY: str = "severity"
+_FINDING_KEY_CONFIDENCE: str = "confidence"
+_FINDING_KEY_VALUE_HASH: str = "value_hash"
 
 # ---------------------------------------------------------------------------
 # Notification request model
@@ -281,13 +288,13 @@ def _truncate_findings_for_notification(
     """
     return tuple(
         {
-            "file_path": str(finding.file_path),
-            "line_number": finding.line_number,
-            "entity_type": finding.entity_type,
-            "hipaa_category": finding.hipaa_category.value,
-            "severity": finding.severity.value,
-            "confidence": finding.confidence,
-            "value_hash": finding.value_hash,
+            _FINDING_KEY_FILE_PATH: str(finding.file_path),
+            _FINDING_KEY_LINE_NUMBER: finding.line_number,
+            _FINDING_KEY_ENTITY_TYPE: finding.entity_type,
+            _FINDING_KEY_HIPAA_CATEGORY: finding.hipaa_category.value,
+            _FINDING_KEY_SEVERITY: finding.severity.value,
+            _FINDING_KEY_CONFIDENCE: finding.confidence,
+            _FINDING_KEY_VALUE_HASH: finding.value_hash,
         }
         for finding in scan_result.findings[:_MAX_FINDINGS_IN_NOTIFICATION]
     )

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -55,7 +55,7 @@ from phi_scan.exceptions import NotificationError
 from phi_scan.hashing import compute_value_hash
 from phi_scan.models import NotificationConfig, ScanResult
 
-__all__ = ["send_email_notification", "send_webhook_notification"]
+__all__ = ["NotificationRequest", "send_email_notification", "send_webhook_notification"]
 
 _logger: logging.Logger = logging.getLogger(__name__)
 
@@ -218,6 +218,27 @@ _TEAMS_THEME_COLOR_GREEN: str = "00AA00"
 _MAX_FINDINGS_IN_NOTIFICATION: int = 20  # prevent oversized payloads
 
 # ---------------------------------------------------------------------------
+# Notification request model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NotificationRequest:
+    """Scan context required by both email and webhook notification channels.
+
+    Bundles the 4–5 scan-related inputs that are common to
+    send_email_notification and send_webhook_notification, satisfying the
+    ≤3 argument rule for those functions.
+    """
+
+    scan_result: ScanResult
+    repository: str
+    branch: str
+    scanner_version: str
+    report_path: Path | None = None
+
+
+# ---------------------------------------------------------------------------
 # Webhook scan summary model
 # ---------------------------------------------------------------------------
 
@@ -271,23 +292,16 @@ def _truncate_findings_for_notification(
     )
 
 
-def _build_webhook_scan_summary(
-    scan_result: ScanResult,
-    repository: str,
-    branch: str,
-    scanner_version: str,
-) -> _WebhookScanSummary:
-    """Derive all shared webhook metadata from a completed scan result.
+def _build_webhook_scan_summary(request: NotificationRequest) -> _WebhookScanSummary:
+    """Derive all shared webhook metadata from a notification request.
 
     Args:
-        scan_result: Completed scan result.
-        repository: Repository identifier.
-        branch: Branch name.
-        scanner_version: phi-scan version string.
+        request: Notification request bundling scan result and scan context.
 
     Returns:
         Immutable summary of scan metadata for use by payload builders.
     """
+    scan_result = request.scan_result
     return _WebhookScanSummary(
         is_clean=scan_result.is_clean,
         risk_level_label=scan_result.risk_level.value.upper(),
@@ -296,9 +310,9 @@ def _build_webhook_scan_summary(
         files_scanned=scan_result.files_scanned,
         scan_duration=scan_result.scan_duration,
         action_taken=ACTION_TAKEN_PASS if scan_result.is_clean else ACTION_TAKEN_FAIL,
-        repository=repository,
-        branch=branch,
-        scanner_version=scanner_version,
+        repository=request.repository,
+        branch=request.branch,
+        scanner_version=request.scanner_version,
         truncated_findings=_truncate_findings_for_notification(scan_result),
     )
 
@@ -372,27 +386,23 @@ def _build_email_subject(scan_result: ScanResult, repository: str, branch: str) 
     )
 
 
-def _build_email_html_body(
-    scan_result: ScanResult, repository: str, branch: str, scanner_version: str
-) -> str:
+def _build_email_html_body(request: NotificationRequest) -> str:
     """Render the HTML email body.
 
     Args:
-        scan_result: Completed scan result.
-        repository: Repository identifier string.
-        branch: Branch name string.
-        scanner_version: phi-scan version string from phi_scan.__version__.
+        request: Notification request bundling scan result and scan context.
 
     Returns:
         Complete HTML document string for the email body.
     """
+    scan_result = request.scan_result
     findings_table = _build_findings_table_html(scan_result)
     return _HTML_EMAIL_TEMPLATE.format(
         risk_level=html.escape(scan_result.risk_level.value.upper()),
         findings_count=len(scan_result.findings),
-        repository=html.escape(repository),
-        branch=html.escape(branch),
-        scanner_version=html.escape(scanner_version),
+        repository=html.escape(request.repository),
+        branch=html.escape(request.branch),
+        scanner_version=html.escape(request.scanner_version),
         files_scanned=scan_result.files_scanned,
         scan_duration=scan_result.scan_duration,
         findings_table=findings_table,
@@ -598,24 +608,18 @@ def _build_generic_payload(summary: _WebhookScanSummary) -> dict[str, Any]:
 
 def _build_webhook_payload(
     webhook_type: WebhookType,
-    scan_result: ScanResult,
-    repository: str,
-    branch: str,
-    scanner_version: str,
+    request: NotificationRequest,
 ) -> dict[str, Any]:
     """Dispatch to the appropriate payload builder for the given webhook_type.
 
     Args:
         webhook_type: The target webhook format.
-        scan_result: Completed scan result.
-        repository: Repository identifier.
-        branch: Branch name.
-        scanner_version: phi-scan version string.
+        request: Notification request bundling scan result and scan context.
 
     Returns:
         Payload dict appropriate for the webhook_type.
     """
-    summary = _build_webhook_scan_summary(scan_result, repository, branch, scanner_version)
+    summary = _build_webhook_scan_summary(request)
     if webhook_type is WebhookType.SLACK:
         return _build_slack_payload(summary)
     if webhook_type is WebhookType.TEAMS:
@@ -780,17 +784,13 @@ def _post_with_retry(
 
 def send_email_notification(
     config: NotificationConfig,
-    scan_result: ScanResult,
-    repository: str,
-    branch: str,
-    scanner_version: str,
-    report_path: Path | None = None,
+    request: NotificationRequest,
 ) -> None:
     """Send an email notification for a completed scan.
 
     Builds an HTML email summarising the scan result and delivers it via
-    SMTP/STARTTLS. When ``report_path`` is provided and the file exists, it is
-    attached to the email.
+    SMTP/STARTTLS. When ``request.report_path`` is provided and the file exists,
+    it is attached to the email.
 
     This function is best-effort: callers must catch ``NotificationError`` and
     log a warning rather than aborting the scan workflow.
@@ -798,11 +798,7 @@ def send_email_notification(
     Args:
         config: Notification configuration (smtp_host, smtp_port, smtp_from,
             smtp_recipients, smtp_use_tls).
-        scan_result: Completed scan result to summarise in the email.
-        repository: Repository name or identifier (used in subject and body).
-        branch: Branch name (used in subject and body).
-        scanner_version: phi-scan version string (e.g. "0.5.0").
-        report_path: Optional path to a PDF or HTML report to attach.
+        request: Notification request bundling scan result and scan context.
 
     Raises:
         NotificationError: If email delivery fails for any reason.
@@ -815,24 +811,21 @@ def send_email_notification(
         raise NotificationError(_NO_SMTP_FROM_ERROR)
     if not config.smtp_recipients:
         raise NotificationError(_NO_RECIPIENTS_ERROR)
-    subject = _build_email_subject(scan_result, repository, branch)
-    html_body = _build_email_html_body(scan_result, repository, branch, scanner_version)
-    message = _build_mime_message(config, subject, html_body, report_path)
+    subject = _build_email_subject(request.scan_result, request.repository, request.branch)
+    html_body = _build_email_html_body(request)
+    message = _build_mime_message(config, subject, html_body, request.report_path)
     _deliver_via_smtp(config, message)
     _logger.info(
         "Email notification sent to %d recipient(s) for %s/%s",
         len(config.smtp_recipients),
-        repository,
-        branch,
+        request.repository,
+        request.branch,
     )
 
 
 def send_webhook_notification(
     config: NotificationConfig,
-    scan_result: ScanResult,
-    repository: str,
-    branch: str,
-    scanner_version: str,
+    request: NotificationRequest,
 ) -> None:
     """POST a findings notification to the configured webhook URL.
 
@@ -846,10 +839,7 @@ def send_webhook_notification(
     Args:
         config: Notification configuration (webhook_url, webhook_type,
             webhook_retry_count).
-        scan_result: Completed scan result to include in the payload.
-        repository: Repository name or identifier.
-        branch: Branch name.
-        scanner_version: phi-scan version string.
+        request: Notification request bundling scan result and scan context.
 
     Raises:
         NotificationError: If webhook_url is empty or delivery fails after all
@@ -858,14 +848,12 @@ def send_webhook_notification(
     if not config.webhook_url:
         raise NotificationError(_NO_WEBHOOK_URL_ERROR)
     _validate_webhook_url(config.webhook_url, config.is_private_webhook_url_allowed)
-    payload = _build_webhook_payload(
-        config.webhook_type, scan_result, repository, branch, scanner_version
-    )
+    payload = _build_webhook_payload(config.webhook_type, request)
     _post_with_retry(config.webhook_url, payload, config.webhook_retry_count)
     _logger.info(
         "Webhook notification delivered to %r (%s) for %s/%s",
         config.webhook_url,
         config.webhook_type.value,
-        repository,
-        branch,
+        request.repository,
+        request.branch,
     )

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -233,6 +233,7 @@ class _WebhookScanSummary:
 
     is_clean: bool
     risk_level_label: str
+    risk_level_value: str
     findings_count: int
     files_scanned: int
     scan_duration: float
@@ -240,6 +241,7 @@ class _WebhookScanSummary:
     repo: str
     branch: str
     scanner_version: str
+    truncated_findings: tuple[dict[str, Any], ...]
 
 
 def _build_webhook_scan_summary(
@@ -259,9 +261,22 @@ def _build_webhook_scan_summary(
     Returns:
         Immutable summary of scan metadata for use by payload builders.
     """
+    truncated_findings = tuple(
+        {
+            "file_path": str(f.file_path),
+            "line_number": f.line_number,
+            "entity_type": f.entity_type,
+            "hipaa_category": f.hipaa_category.value,
+            "severity": f.severity.value,
+            "confidence": f.confidence,
+            "value_hash": f.value_hash,
+        }
+        for f in scan_result.findings[:_MAX_FINDINGS_IN_NOTIFICATION]
+    )
     return _WebhookScanSummary(
         is_clean=scan_result.is_clean,
         risk_level_label=scan_result.risk_level.value.upper(),
+        risk_level_value=scan_result.risk_level.value,
         findings_count=len(scan_result.findings),
         files_scanned=scan_result.files_scanned,
         scan_duration=scan_result.scan_duration,
@@ -269,6 +284,7 @@ def _build_webhook_scan_summary(
         repo=repo,
         branch=branch,
         scanner_version=scanner_version,
+        truncated_findings=truncated_findings,
     )
 
 
@@ -536,10 +552,7 @@ def _build_teams_payload(summary: _WebhookScanSummary) -> dict[str, Any]:
     }
 
 
-def _build_generic_payload(
-    summary: _WebhookScanSummary,
-    scan_result: ScanResult,
-) -> dict[str, Any]:
+def _build_generic_payload(summary: _WebhookScanSummary) -> dict[str, Any]:
     """Build a generic JSON webhook payload.
 
     The payload includes only hashed metadata — no raw PHI values or
@@ -548,35 +561,22 @@ def _build_generic_payload(
 
     Args:
         summary: Pre-computed scan metadata from _build_webhook_scan_summary.
-        scan_result: Completed scan result (used for the per-finding list only).
 
     Returns:
         Generic JSON payload dict.
     """
-    findings_payload = [
-        {
-            "file_path": str(f.file_path),
-            "line_number": f.line_number,
-            "entity_type": f.entity_type,
-            "hipaa_category": f.hipaa_category.value,
-            "severity": f.severity.value,
-            "confidence": f.confidence,
-            "value_hash": f.value_hash,
-        }
-        for f in scan_result.findings[:_MAX_FINDINGS_IN_NOTIFICATION]
-    ]
     return {
         "event": "phi_scan_complete",
         "scanner_version": summary.scanner_version,
         "repository": summary.repo,
         "branch": summary.branch,
-        "risk_level": summary.risk_level_label,
+        "risk_level": summary.risk_level_value,
         "is_clean": summary.is_clean,
         "findings_count": summary.findings_count,
         "files_scanned": summary.files_scanned,
         "scan_duration": summary.scan_duration,
         "action_taken": summary.action_taken,
-        "findings": findings_payload,
+        "findings": list(summary.truncated_findings),
     }
 
 
@@ -604,7 +604,7 @@ def _build_webhook_payload(
         return _build_slack_payload(summary)
     if webhook_type is WebhookType.TEAMS:
         return _build_teams_payload(summary)
-    return _build_generic_payload(summary, scan_result)
+    return _build_generic_payload(summary)
 
 
 def _resolve_hostname_addresses(  # phi-scan:ignore

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -216,6 +216,7 @@ _SLACK_COLOR_GOOD: str = "good"
 _TEAMS_THEME_COLOR_RED: str = "FF0000"
 _TEAMS_THEME_COLOR_GREEN: str = "00AA00"
 _MAX_FINDINGS_IN_NOTIFICATION: int = 20  # prevent oversized payloads
+_WEBHOOK_EVENT_NAME: str = "phi_scan_complete"
 
 # ---------------------------------------------------------------------------
 # Notification request model
@@ -247,7 +248,7 @@ class NotificationRequest:
 class _WebhookScanSummary:
     """Pre-computed scan metadata shared by all webhook payload builders.
 
-    Constructed once by _build_webhook_scan_summary and passed to each
+    Constructed once by _derive_webhook_scan_summary and passed to each
     builder, eliminating duplicate derivation across Slack, Teams, and
     generic payload formats.
     """
@@ -292,7 +293,7 @@ def _truncate_findings_for_notification(
     )
 
 
-def _build_webhook_scan_summary(request: NotificationRequest) -> _WebhookScanSummary:
+def _derive_webhook_scan_summary(request: NotificationRequest) -> _WebhookScanSummary:
     """Derive all shared webhook metadata from a notification request.
 
     Args:
@@ -367,22 +368,20 @@ def _build_findings_table_html(scan_result: ScanResult) -> str:
     return "".join(rows)
 
 
-def _build_email_subject(scan_result: ScanResult, repository: str, branch: str) -> str:
+def _build_email_subject(request: NotificationRequest) -> str:
     """Return the formatted email subject line.
 
     Args:
-        scan_result: Completed scan result.
-        repository: Repository name or path hash (never raw PHI).
-        branch: Branch name or hash (never raw PHI).
+        request: Notification request bundling scan result and scan context.
 
     Returns:
         Subject string formatted per NOTIFICATION_SUBJECT_FORMAT.
     """
     return NOTIFICATION_SUBJECT_FORMAT.format(
-        risk_level=scan_result.risk_level.value.upper(),
-        findings_count=len(scan_result.findings),
-        repository=repository,
-        branch=branch,
+        risk_level=request.scan_result.risk_level.value.upper(),
+        findings_count=len(request.scan_result.findings),
+        repository=request.repository,
+        branch=request.branch,
     )
 
 
@@ -503,20 +502,22 @@ def _deliver_via_smtp(
 # ---------------------------------------------------------------------------
 
 
-def _build_slack_payload(summary: _WebhookScanSummary) -> dict[str, Any]:
+def _build_slack_payload(scan_summary: _WebhookScanSummary) -> dict[str, Any]:
     """Build a Slack Block Kit message payload.
 
     Args:
-        summary: Pre-computed scan metadata from _build_webhook_scan_summary.
+        scan_summary: Pre-computed scan metadata from _derive_webhook_scan_summary.
 
     Returns:
         Slack Block Kit payload dict ready for JSON serialisation.
     """
-    color = _SLACK_COLOR_GOOD if summary.is_clean else _SLACK_COLOR_DANGER
+    color = _SLACK_COLOR_GOOD if scan_summary.is_clean else _SLACK_COLOR_DANGER
     status_text = (
         "*CLEAN* — no PHI detected"
-        if summary.is_clean
-        else f"*{summary.risk_level_label}* — {summary.findings_count} finding(s) detected"
+        if scan_summary.is_clean
+        else (
+            f"*{scan_summary.risk_level_label}* — {scan_summary.findings_count} finding(s) detected"
+        )
     )
     return {
         "attachments": [
@@ -529,10 +530,10 @@ def _build_slack_payload(summary: _WebhookScanSummary) -> dict[str, Any]:
                             "type": "mrkdwn",
                             "text": (
                                 f":shield: *phi-scan Alert* | "
-                                f"{summary.repository}/{summary.branch}\n"
+                                f"{scan_summary.repository}/{scan_summary.branch}\n"
                                 f"{status_text}\n"
-                                f"Files scanned: {summary.files_scanned} | "
-                                f"Scanner: {summary.scanner_version}"
+                                f"Files scanned: {scan_summary.files_scanned} | "
+                                f"Scanner: {scan_summary.scanner_version}"
                             ),
                         },
                     }
@@ -542,20 +543,20 @@ def _build_slack_payload(summary: _WebhookScanSummary) -> dict[str, Any]:
     }
 
 
-def _build_teams_payload(summary: _WebhookScanSummary) -> dict[str, Any]:
+def _build_teams_payload(scan_summary: _WebhookScanSummary) -> dict[str, Any]:
     """Build a Microsoft Teams Adaptive Card payload.
 
     Args:
-        summary: Pre-computed scan metadata from _build_webhook_scan_summary.
+        scan_summary: Pre-computed scan metadata from _derive_webhook_scan_summary.
 
     Returns:
         Teams connector card payload dict ready for JSON serialisation.
     """
-    theme_color = _TEAMS_THEME_COLOR_GREEN if summary.is_clean else _TEAMS_THEME_COLOR_RED
+    theme_color = _TEAMS_THEME_COLOR_GREEN if scan_summary.is_clean else _TEAMS_THEME_COLOR_RED
     status_text = (
         "CLEAN — no PHI detected"
-        if summary.is_clean
-        else f"{summary.risk_level_label} — {summary.findings_count} finding(s) detected"
+        if scan_summary.is_clean
+        else f"{scan_summary.risk_level_label} — {scan_summary.findings_count} finding(s) detected"
     )
     return {
         "@type": "MessageCard",
@@ -564,21 +565,23 @@ def _build_teams_payload(summary: _WebhookScanSummary) -> dict[str, Any]:
         "summary": f"phi-scan {status_text}",
         "sections": [
             {
-                "activityTitle": f"phi-scan Alert — {summary.repository}/{summary.branch}",
+                "activityTitle": (
+                    f"phi-scan Alert — {scan_summary.repository}/{scan_summary.branch}"
+                ),
                 "activitySubtitle": status_text,
                 "facts": [
-                    {"name": "Risk Level", "value": summary.risk_level_value},
+                    {"name": "Risk Level", "value": scan_summary.risk_level_value},
                     # phi-scan:ignore-next-line
-                    {"name": "Findings", "value": str(summary.findings_count)},
-                    {"name": "Files Scanned", "value": str(summary.files_scanned)},
-                    {"name": "Scanner Version", "value": summary.scanner_version},
+                    {"name": "Findings", "value": str(scan_summary.findings_count)},
+                    {"name": "Files Scanned", "value": str(scan_summary.files_scanned)},
+                    {"name": "Scanner Version", "value": scan_summary.scanner_version},
                 ],
             }
         ],
     }
 
 
-def _build_generic_payload(summary: _WebhookScanSummary) -> dict[str, Any]:
+def _build_generic_payload(scan_summary: _WebhookScanSummary) -> dict[str, Any]:
     """Build a generic JSON webhook payload.
 
     The payload includes only hashed metadata — no raw PHI values or
@@ -586,23 +589,23 @@ def _build_generic_payload(summary: _WebhookScanSummary) -> dict[str, Any]:
     digest of the detected value; it cannot be reversed to recover the PHI.
 
     Args:
-        summary: Pre-computed scan metadata from _build_webhook_scan_summary.
+        scan_summary: Pre-computed scan metadata from _derive_webhook_scan_summary.
 
     Returns:
         Generic JSON payload dict.
     """
     return {
-        "event": "phi_scan_complete",
-        "scanner_version": summary.scanner_version,
-        "repository": summary.repository,
-        "branch": summary.branch,
-        "risk_level": summary.risk_level_value,
-        "is_clean": summary.is_clean,
-        "findings_count": summary.findings_count,
-        "files_scanned": summary.files_scanned,
-        "scan_duration": summary.scan_duration,
-        "action_taken": summary.action_taken,
-        "findings": list(summary.truncated_findings),
+        "event": _WEBHOOK_EVENT_NAME,
+        "scanner_version": scan_summary.scanner_version,
+        "repository": scan_summary.repository,
+        "branch": scan_summary.branch,
+        "risk_level": scan_summary.risk_level_value,
+        "is_clean": scan_summary.is_clean,
+        "findings_count": scan_summary.findings_count,
+        "files_scanned": scan_summary.files_scanned,
+        "scan_duration": scan_summary.scan_duration,
+        "action_taken": scan_summary.action_taken,
+        "findings": list(scan_summary.truncated_findings),
     }
 
 
@@ -619,12 +622,12 @@ def _build_webhook_payload(
     Returns:
         Payload dict appropriate for the webhook_type.
     """
-    summary = _build_webhook_scan_summary(request)
+    scan_summary = _derive_webhook_scan_summary(request)
     if webhook_type is WebhookType.SLACK:
-        return _build_slack_payload(summary)
+        return _build_slack_payload(scan_summary)
     if webhook_type is WebhookType.TEAMS:
-        return _build_teams_payload(summary)
-    return _build_generic_payload(summary)
+        return _build_teams_payload(scan_summary)
+    return _build_generic_payload(scan_summary)
 
 
 def _resolve_hostname_addresses(  # phi-scan:ignore
@@ -811,7 +814,7 @@ def send_email_notification(
         raise NotificationError(_NO_SMTP_FROM_ERROR)
     if not config.smtp_recipients:
         raise NotificationError(_NO_RECIPIENTS_ERROR)
-    subject = _build_email_subject(request.scan_result, request.repository, request.branch)
+    subject = _build_email_subject(request)
     html_body = _build_email_html_body(request)
     message = _build_mime_message(config, subject, html_body, request.report_path)
     _deliver_via_smtp(config, message)

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -34,6 +34,7 @@ import logging
 import os
 import smtplib
 import socket
+from dataclasses import dataclass
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -215,6 +216,60 @@ _SLACK_COLOR_GOOD: str = "good"
 _TEAMS_THEME_COLOR_RED: str = "FF0000"
 _TEAMS_THEME_COLOR_GREEN: str = "00AA00"
 _MAX_FINDINGS_IN_NOTIFICATION: int = 20  # prevent oversized payloads
+
+# ---------------------------------------------------------------------------
+# Webhook scan summary model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _WebhookScanSummary:
+    """Pre-computed scan metadata shared by all webhook payload builders.
+
+    Constructed once by _build_webhook_scan_summary and passed to each
+    builder, eliminating duplicate derivation across Slack, Teams, and
+    generic payload formats.
+    """
+
+    is_clean: bool
+    risk_level_label: str
+    findings_count: int
+    files_scanned: int
+    scan_duration: float
+    action_taken: str
+    repo: str
+    branch: str
+    scanner_version: str
+
+
+def _build_webhook_scan_summary(
+    scan_result: ScanResult,
+    repo: str,
+    branch: str,
+    scanner_version: str,
+) -> _WebhookScanSummary:
+    """Derive all shared webhook metadata from a completed scan result.
+
+    Args:
+        scan_result: Completed scan result.
+        repo: Repository identifier.
+        branch: Branch name.
+        scanner_version: phi-scan version string.
+
+    Returns:
+        Immutable summary of scan metadata for use by payload builders.
+    """
+    return _WebhookScanSummary(
+        is_clean=scan_result.is_clean,
+        risk_level_label=scan_result.risk_level.value.upper(),
+        findings_count=len(scan_result.findings),
+        files_scanned=scan_result.files_scanned,
+        scan_duration=scan_result.scan_duration,
+        action_taken=ACTION_TAKEN_PASS if scan_result.is_clean else ACTION_TAKEN_FAIL,
+        repo=repo,
+        branch=branch,
+        scanner_version=scanner_version,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -407,27 +462,20 @@ def _deliver_via_smtp(
 # ---------------------------------------------------------------------------
 
 
-def _build_slack_payload(
-    scan_result: ScanResult, repo: str, branch: str, scanner_version: str
-) -> dict[str, Any]:
+def _build_slack_payload(summary: _WebhookScanSummary) -> dict[str, Any]:
     """Build a Slack Block Kit message payload.
 
     Args:
-        scan_result: Completed scan result.
-        repo: Repository identifier.
-        branch: Branch name.
-        scanner_version: phi-scan version string.
+        summary: Pre-computed scan metadata from _build_webhook_scan_summary.
 
     Returns:
         Slack Block Kit payload dict ready for JSON serialisation.
     """
-    is_clean = scan_result.is_clean
-    color = _SLACK_COLOR_GOOD if is_clean else _SLACK_COLOR_DANGER
+    color = _SLACK_COLOR_GOOD if summary.is_clean else _SLACK_COLOR_DANGER
     status_text = (
         "*CLEAN* — no PHI detected"
-        if is_clean
-        else f"*{scan_result.risk_level.value.upper()}* — "
-        f"{len(scan_result.findings)} finding(s) detected"
+        if summary.is_clean
+        else f"*{summary.risk_level_label}* — {summary.findings_count} finding(s) detected"
     )
     return {
         "attachments": [
@@ -439,10 +487,10 @@ def _build_slack_payload(
                         "text": {
                             "type": "mrkdwn",
                             "text": (
-                                f":shield: *phi-scan Alert* | {repo}/{branch}\n"
+                                f":shield: *phi-scan Alert* | {summary.repo}/{summary.branch}\n"
                                 f"{status_text}\n"
-                                f"Files scanned: {scan_result.files_scanned} | "
-                                f"Scanner: {scanner_version}"
+                                f"Files scanned: {summary.files_scanned} | "
+                                f"Scanner: {summary.scanner_version}"
                             ),
                         },
                     }
@@ -452,27 +500,20 @@ def _build_slack_payload(
     }
 
 
-def _build_teams_payload(
-    scan_result: ScanResult, repo: str, branch: str, scanner_version: str
-) -> dict[str, Any]:
+def _build_teams_payload(summary: _WebhookScanSummary) -> dict[str, Any]:
     """Build a Microsoft Teams Adaptive Card payload.
 
     Args:
-        scan_result: Completed scan result.
-        repo: Repository identifier.
-        branch: Branch name.
-        scanner_version: phi-scan version string.
+        summary: Pre-computed scan metadata from _build_webhook_scan_summary.
 
     Returns:
         Teams connector card payload dict ready for JSON serialisation.
     """
-    is_clean = scan_result.is_clean
-    theme_color = _TEAMS_THEME_COLOR_GREEN if is_clean else _TEAMS_THEME_COLOR_RED
+    theme_color = _TEAMS_THEME_COLOR_GREEN if summary.is_clean else _TEAMS_THEME_COLOR_RED
     status_text = (
         "CLEAN — no PHI detected"
-        if is_clean
-        else f"{scan_result.risk_level.value.upper()} — "
-        f"{len(scan_result.findings)} finding(s) detected"
+        if summary.is_clean
+        else f"{summary.risk_level_label} — {summary.findings_count} finding(s) detected"
     )
     return {
         "@type": "MessageCard",
@@ -481,14 +522,14 @@ def _build_teams_payload(
         "summary": f"phi-scan {status_text}",
         "sections": [
             {
-                "activityTitle": f"phi-scan Alert — {repo}/{branch}",
+                "activityTitle": f"phi-scan Alert — {summary.repo}/{summary.branch}",
                 "activitySubtitle": status_text,
                 "facts": [
-                    {"name": "Risk Level", "value": scan_result.risk_level.value},
+                    {"name": "Risk Level", "value": summary.risk_level_label},
                     # phi-scan:ignore-next-line
-                    {"name": "Findings", "value": str(len(scan_result.findings))},
-                    {"name": "Files Scanned", "value": str(scan_result.files_scanned)},
-                    {"name": "Scanner Version", "value": scanner_version},
+                    {"name": "Findings", "value": str(summary.findings_count)},
+                    {"name": "Files Scanned", "value": str(summary.files_scanned)},
+                    {"name": "Scanner Version", "value": summary.scanner_version},
                 ],
             }
         ],
@@ -496,7 +537,8 @@ def _build_teams_payload(
 
 
 def _build_generic_payload(
-    scan_result: ScanResult, repo: str, branch: str, scanner_version: str
+    summary: _WebhookScanSummary,
+    scan_result: ScanResult,
 ) -> dict[str, Any]:
     """Build a generic JSON webhook payload.
 
@@ -505,10 +547,8 @@ def _build_generic_payload(
     digest of the detected value; it cannot be reversed to recover the PHI.
 
     Args:
-        scan_result: Completed scan result.
-        repo: Repository identifier.
-        branch: Branch name.
-        scanner_version: phi-scan version string.
+        summary: Pre-computed scan metadata from _build_webhook_scan_summary.
+        scan_result: Completed scan result (used for the per-finding list only).
 
     Returns:
         Generic JSON payload dict.
@@ -527,15 +567,15 @@ def _build_generic_payload(
     ]
     return {
         "event": "phi_scan_complete",
-        "scanner_version": scanner_version,
-        "repository": repo,
-        "branch": branch,
-        "risk_level": scan_result.risk_level.value,
-        "is_clean": scan_result.is_clean,
-        "findings_count": len(scan_result.findings),
-        "files_scanned": scan_result.files_scanned,
-        "scan_duration": scan_result.scan_duration,
-        "action_taken": ACTION_TAKEN_PASS if scan_result.is_clean else ACTION_TAKEN_FAIL,
+        "scanner_version": summary.scanner_version,
+        "repository": summary.repo,
+        "branch": summary.branch,
+        "risk_level": summary.risk_level_label,
+        "is_clean": summary.is_clean,
+        "findings_count": summary.findings_count,
+        "files_scanned": summary.files_scanned,
+        "scan_duration": summary.scan_duration,
+        "action_taken": summary.action_taken,
         "findings": findings_payload,
     }
 
@@ -559,11 +599,12 @@ def _build_webhook_payload(
     Returns:
         Payload dict appropriate for the webhook_type.
     """
+    summary = _build_webhook_scan_summary(scan_result, repo, branch, scanner_version)
     if webhook_type is WebhookType.SLACK:
-        return _build_slack_payload(scan_result, repo, branch, scanner_version)
+        return _build_slack_payload(summary)
     if webhook_type is WebhookType.TEAMS:
-        return _build_teams_payload(scan_result, repo, branch, scanner_version)
-    return _build_generic_payload(scan_result, repo, branch, scanner_version)
+        return _build_teams_payload(summary)
+    return _build_generic_payload(summary, scan_result)
 
 
 def _resolve_hostname_addresses(  # phi-scan:ignore

--- a/tests/test_fhir_recognizer.py
+++ b/tests/test_fhir_recognizer.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import logging
 from pathlib import Path
 
@@ -31,6 +30,7 @@ from phi_scan.fhir_recognizer import (  # type: ignore[attr-defined]
 from phi_scan.hashing import (
     StructuredFindingRequest,
     build_structured_finding,
+    compute_value_hash,
     severity_from_confidence,
 )
 
@@ -42,8 +42,8 @@ _FAKE_FILE_PATH: Path = Path("fake/test_patient.json")
 _FAKE_FAMILY_NAME: str = "TestFamilyName"
 _FAKE_BIRTH_DATE: str = "1990-01-01"
 _FAKE_CITY_NAME: str = "TestCity"
-_EXPECTED_FAMILY_HASH: str = hashlib.sha256(_FAKE_FAMILY_NAME.encode()).hexdigest()
-_EXPECTED_BIRTH_DATE_HASH: str = hashlib.sha256(_FAKE_BIRTH_DATE.encode()).hexdigest()
+_EXPECTED_FAMILY_HASH: str = compute_value_hash(_FAKE_FAMILY_NAME)
+_EXPECTED_BIRTH_DATE_HASH: str = compute_value_hash(_FAKE_BIRTH_DATE)
 
 _JSON_FAMILY_LINE: str = f'  "family": "{_FAKE_FAMILY_NAME}"'
 _XML_ATTR_BIRTH_DATE_LINE: str = f'  <birthDate value="{_FAKE_BIRTH_DATE}"/>'
@@ -369,9 +369,9 @@ def test_fhir_field_base_confidence_is_within_layer_three_range():
 # ---------------------------------------------------------------------------
 
 
-def test_build_structured_finding_hashes_raw_value() -> None:
-    """build_structured_finding must store value_hash, never the raw value."""
-    raw = _FAKE_FAMILY_NAME
+def test_build_structured_finding_stores_provided_value_hash() -> None:
+    """build_structured_finding must store the caller-supplied value_hash unchanged."""
+    expected_hash = compute_value_hash(_FAKE_FAMILY_NAME)
     finding = build_structured_finding(
         StructuredFindingRequest(
             file_path=_FAKE_FILE_PATH,
@@ -380,11 +380,11 @@ def test_build_structured_finding_hashes_raw_value() -> None:
             hipaa_category=PhiCategory.NAME,
             confidence=_FHIR_FIELD_BASE_CONFIDENCE,
             detection_layer=DetectionLayer.FHIR,
-            raw_value=raw,
+            value_hash=expected_hash,
             code_context=f'"family": {CODE_CONTEXT_REDACTED_VALUE}',
         )
     )
-    assert finding.value_hash == hashlib.sha256(raw.encode()).hexdigest()
+    assert finding.value_hash == expected_hash
 
 
 def test_build_structured_finding_derives_severity_from_confidence() -> None:
@@ -397,7 +397,7 @@ def test_build_structured_finding_derives_severity_from_confidence() -> None:
             hipaa_category=PhiCategory.NAME,
             confidence=_FHIR_FIELD_BASE_CONFIDENCE,
             detection_layer=DetectionLayer.FHIR,
-            raw_value=_FAKE_FAMILY_NAME,
+            value_hash=compute_value_hash(_FAKE_FAMILY_NAME),
             code_context=f'"family": {CODE_CONTEXT_REDACTED_VALUE}',
         )
     )
@@ -414,7 +414,7 @@ def test_build_structured_finding_populates_remediation_hint() -> None:
             hipaa_category=PhiCategory.NAME,
             confidence=_FHIR_FIELD_BASE_CONFIDENCE,
             detection_layer=DetectionLayer.FHIR,
-            raw_value=_FAKE_FAMILY_NAME,
+            value_hash=compute_value_hash(_FAKE_FAMILY_NAME),
             code_context=f'"family": {CODE_CONTEXT_REDACTED_VALUE}',
         )
     )

--- a/tests/test_fhir_recognizer.py
+++ b/tests/test_fhir_recognizer.py
@@ -13,6 +13,7 @@ from phi_scan.constants import (
     CONFIDENCE_MEDIUM_FLOOR,
     CONFIDENCE_STRUCTURED_MAX,
     CONFIDENCE_STRUCTURED_MIN,
+    HIPAA_REMEDIATION_GUIDANCE,
     DetectionLayer,
     PhiCategory,
     SeverityLevel,
@@ -405,8 +406,6 @@ def test_build_structured_finding_derives_severity_from_confidence() -> None:
 
 def test_build_structured_finding_populates_remediation_hint() -> None:
     """build_structured_finding must look up remediation_hint from HIPAA guidance."""
-    from phi_scan.constants import HIPAA_REMEDIATION_GUIDANCE
-
     finding = build_structured_finding(
         StructuredFindingRequest(
             file_path=_FAKE_FILE_PATH,

--- a/tests/test_fhir_recognizer.py
+++ b/tests/test_fhir_recognizer.py
@@ -370,8 +370,6 @@ def test_fhir_field_base_confidence_is_within_layer_three_range():
 
 def test_build_structured_finding_hashes_raw_value() -> None:
     """build_structured_finding must store value_hash, never the raw value."""
-    import hashlib
-
     raw = _FAKE_FAMILY_NAME
     finding = build_structured_finding(
         StructuredFindingRequest(

--- a/tests/test_fhir_recognizer.py
+++ b/tests/test_fhir_recognizer.py
@@ -27,7 +27,11 @@ from phi_scan.fhir_recognizer import (  # type: ignore[attr-defined]
     _is_null_or_empty_fhir_value,
     detect_phi_in_structured_content,
 )
-from phi_scan.hashing import build_structured_finding, severity_from_confidence
+from phi_scan.hashing import (
+    StructuredFindingRequest,
+    build_structured_finding,
+    severity_from_confidence,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -370,14 +374,16 @@ def test_build_structured_finding_hashes_raw_value() -> None:
 
     raw = _FAKE_FAMILY_NAME
     finding = build_structured_finding(
-        file_path=_FAKE_FILE_PATH,
-        line_number=1,
-        entity_type="family",
-        hipaa_category=PhiCategory.NAME,
-        confidence=_FHIR_FIELD_BASE_CONFIDENCE,
-        detection_layer=DetectionLayer.FHIR,
-        raw_value=raw,
-        code_context=f'"family": {CODE_CONTEXT_REDACTED_VALUE}',
+        StructuredFindingRequest(
+            file_path=_FAKE_FILE_PATH,
+            line_number=1,
+            entity_type="family",
+            hipaa_category=PhiCategory.NAME,
+            confidence=_FHIR_FIELD_BASE_CONFIDENCE,
+            detection_layer=DetectionLayer.FHIR,
+            raw_value=raw,
+            code_context=f'"family": {CODE_CONTEXT_REDACTED_VALUE}',
+        )
     )
     assert finding.value_hash == hashlib.sha256(raw.encode()).hexdigest()
 
@@ -385,14 +391,16 @@ def test_build_structured_finding_hashes_raw_value() -> None:
 def test_build_structured_finding_derives_severity_from_confidence() -> None:
     """build_structured_finding severity must match severity_from_confidence."""
     finding = build_structured_finding(
-        file_path=_FAKE_FILE_PATH,
-        line_number=1,
-        entity_type="family",
-        hipaa_category=PhiCategory.NAME,
-        confidence=_FHIR_FIELD_BASE_CONFIDENCE,
-        detection_layer=DetectionLayer.FHIR,
-        raw_value=_FAKE_FAMILY_NAME,
-        code_context=f'"family": {CODE_CONTEXT_REDACTED_VALUE}',
+        StructuredFindingRequest(
+            file_path=_FAKE_FILE_PATH,
+            line_number=1,
+            entity_type="family",
+            hipaa_category=PhiCategory.NAME,
+            confidence=_FHIR_FIELD_BASE_CONFIDENCE,
+            detection_layer=DetectionLayer.FHIR,
+            raw_value=_FAKE_FAMILY_NAME,
+            code_context=f'"family": {CODE_CONTEXT_REDACTED_VALUE}',
+        )
     )
     assert finding.severity == severity_from_confidence(_FHIR_FIELD_BASE_CONFIDENCE)
 
@@ -402,13 +410,15 @@ def test_build_structured_finding_populates_remediation_hint() -> None:
     from phi_scan.constants import HIPAA_REMEDIATION_GUIDANCE
 
     finding = build_structured_finding(
-        file_path=_FAKE_FILE_PATH,
-        line_number=1,
-        entity_type="family",
-        hipaa_category=PhiCategory.NAME,
-        confidence=_FHIR_FIELD_BASE_CONFIDENCE,
-        detection_layer=DetectionLayer.FHIR,
-        raw_value=_FAKE_FAMILY_NAME,
-        code_context=f'"family": {CODE_CONTEXT_REDACTED_VALUE}',
+        StructuredFindingRequest(
+            file_path=_FAKE_FILE_PATH,
+            line_number=1,
+            entity_type="family",
+            hipaa_category=PhiCategory.NAME,
+            confidence=_FHIR_FIELD_BASE_CONFIDENCE,
+            detection_layer=DetectionLayer.FHIR,
+            raw_value=_FAKE_FAMILY_NAME,
+            code_context=f'"family": {CODE_CONTEXT_REDACTED_VALUE}',
+        )
     )
     assert finding.remediation_hint == HIPAA_REMEDIATION_GUIDANCE.get(PhiCategory.NAME, "")

--- a/tests/test_fhir_recognizer.py
+++ b/tests/test_fhir_recognizer.py
@@ -27,7 +27,7 @@ from phi_scan.fhir_recognizer import (  # type: ignore[attr-defined]
     _is_null_or_empty_fhir_value,
     detect_phi_in_structured_content,
 )
-from phi_scan.hashing import severity_from_confidence
+from phi_scan.hashing import build_structured_finding, severity_from_confidence
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -357,3 +357,58 @@ def test_detect_phi_in_structured_content_logs_warning_and_returns_empty_when_hl
 
 def test_fhir_field_base_confidence_is_within_layer_three_range():
     assert CONFIDENCE_STRUCTURED_MIN <= _FHIR_FIELD_BASE_CONFIDENCE <= CONFIDENCE_STRUCTURED_MAX
+
+
+# ---------------------------------------------------------------------------
+# build_structured_finding factory
+# ---------------------------------------------------------------------------
+
+
+def test_build_structured_finding_hashes_raw_value() -> None:
+    """build_structured_finding must store value_hash, never the raw value."""
+    import hashlib
+
+    raw = _FAKE_FAMILY_NAME
+    finding = build_structured_finding(
+        file_path=_FAKE_FILE_PATH,
+        line_number=1,
+        entity_type="family",
+        hipaa_category=PhiCategory.NAME,
+        confidence=_FHIR_FIELD_BASE_CONFIDENCE,
+        detection_layer=DetectionLayer.FHIR,
+        raw_value=raw,
+        code_context=f'"family": {CODE_CONTEXT_REDACTED_VALUE}',
+    )
+    assert finding.value_hash == hashlib.sha256(raw.encode()).hexdigest()
+
+
+def test_build_structured_finding_derives_severity_from_confidence() -> None:
+    """build_structured_finding severity must match severity_from_confidence."""
+    finding = build_structured_finding(
+        file_path=_FAKE_FILE_PATH,
+        line_number=1,
+        entity_type="family",
+        hipaa_category=PhiCategory.NAME,
+        confidence=_FHIR_FIELD_BASE_CONFIDENCE,
+        detection_layer=DetectionLayer.FHIR,
+        raw_value=_FAKE_FAMILY_NAME,
+        code_context=f'"family": {CODE_CONTEXT_REDACTED_VALUE}',
+    )
+    assert finding.severity == severity_from_confidence(_FHIR_FIELD_BASE_CONFIDENCE)
+
+
+def test_build_structured_finding_populates_remediation_hint() -> None:
+    """build_structured_finding must look up remediation_hint from HIPAA guidance."""
+    from phi_scan.constants import HIPAA_REMEDIATION_GUIDANCE
+
+    finding = build_structured_finding(
+        file_path=_FAKE_FILE_PATH,
+        line_number=1,
+        entity_type="family",
+        hipaa_category=PhiCategory.NAME,
+        confidence=_FHIR_FIELD_BASE_CONFIDENCE,
+        detection_layer=DetectionLayer.FHIR,
+        raw_value=_FAKE_FAMILY_NAME,
+        code_context=f'"family": {CODE_CONTEXT_REDACTED_VALUE}',
+    )
+    assert finding.remediation_hint == HIPAA_REMEDIATION_GUIDANCE.get(PhiCategory.NAME, "")

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -33,6 +33,7 @@ from phi_scan.constants import (
 from phi_scan.exceptions import NotificationError
 from phi_scan.models import NotificationConfig, ScanFinding, ScanResult
 from phi_scan.notifier import (
+    NotificationRequest,
     _build_email_html_body,  # noqa: PLC2701
     _build_email_subject,
     _build_generic_payload,
@@ -207,7 +208,13 @@ def test_send_email_raises_when_smtp_host_empty() -> None:
     )
     with pytest.raises(NotificationError):
         send_email_notification(
-            config, _make_dirty_result(), _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
+            config,
+            NotificationRequest(
+                scan_result=_make_dirty_result(),
+                repository=_SAMPLE_REPO,
+                branch=_SAMPLE_BRANCH,
+                scanner_version=_SAMPLE_SCANNER_VERSION,
+            ),
         )
 
 
@@ -221,7 +228,13 @@ def test_send_email_raises_when_smtp_from_empty() -> None:
     )
     with pytest.raises(NotificationError):
         send_email_notification(
-            config, _make_dirty_result(), _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
+            config,
+            NotificationRequest(
+                scan_result=_make_dirty_result(),
+                repository=_SAMPLE_REPO,
+                branch=_SAMPLE_BRANCH,
+                scanner_version=_SAMPLE_SCANNER_VERSION,
+            ),
         )
 
 
@@ -235,7 +248,13 @@ def test_send_email_raises_when_no_recipients() -> None:
     )
     with pytest.raises(NotificationError):
         send_email_notification(
-            config, _make_dirty_result(), _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
+            config,
+            NotificationRequest(
+                scan_result=_make_dirty_result(),
+                repository=_SAMPLE_REPO,
+                branch=_SAMPLE_BRANCH,
+                scanner_version=_SAMPLE_SCANNER_VERSION,
+            ),
         )
 
 
@@ -244,7 +263,13 @@ def test_send_email_raises_when_tls_disabled() -> None:
     config = _make_email_config(smtp_use_tls=False)
     with pytest.raises(NotificationError, match="[Pp]laintext"):
         send_email_notification(
-            config, _make_dirty_result(), _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
+            config,
+            NotificationRequest(
+                scan_result=_make_dirty_result(),
+                repository=_SAMPLE_REPO,
+                branch=_SAMPLE_BRANCH,
+                scanner_version=_SAMPLE_SCANNER_VERSION,
+            ),
         )
 
 
@@ -256,10 +281,12 @@ def test_send_email_raises_on_smtp_exception() -> None:
         with pytest.raises(NotificationError):
             send_email_notification(
                 config,
-                _make_dirty_result(),
-                _SAMPLE_REPO,
-                _SAMPLE_BRANCH,
-                _SAMPLE_SCANNER_VERSION,
+                NotificationRequest(
+                    scan_result=_make_dirty_result(),
+                    repository=_SAMPLE_REPO,
+                    branch=_SAMPLE_BRANCH,
+                    scanner_version=_SAMPLE_SCANNER_VERSION,
+                ),
             )
 
 
@@ -272,10 +299,12 @@ def test_send_email_succeeds_with_mock_smtp() -> None:
     with patch("smtplib.SMTP", return_value=mock_smtp):
         send_email_notification(
             config,
-            _make_dirty_result(),
-            _SAMPLE_REPO,
-            _SAMPLE_BRANCH,
-            _SAMPLE_SCANNER_VERSION,
+            NotificationRequest(
+                scan_result=_make_dirty_result(),
+                repository=_SAMPLE_REPO,
+                branch=_SAMPLE_BRANCH,
+                scanner_version=_SAMPLE_SCANNER_VERSION,
+            ),
         )
 
 
@@ -313,7 +342,12 @@ def test_generic_payload_contains_event_field() -> None:
     """Generic webhook payload must include an 'event' field."""
     scan_result = _make_dirty_result()
     summary = _build_webhook_scan_summary(
-        scan_result, _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
+        NotificationRequest(
+            scan_result=scan_result,
+            repository=_SAMPLE_REPO,
+            branch=_SAMPLE_BRANCH,
+            scanner_version=_SAMPLE_SCANNER_VERSION,
+        )
     )
     payload = _build_generic_payload(summary)
     assert "event" in payload
@@ -323,7 +357,12 @@ def test_generic_payload_contains_findings_count() -> None:
     """Generic webhook payload findings_count must match scan result."""
     scan_result = _make_dirty_result()
     summary = _build_webhook_scan_summary(
-        scan_result, _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
+        NotificationRequest(
+            scan_result=scan_result,
+            repository=_SAMPLE_REPO,
+            branch=_SAMPLE_BRANCH,
+            scanner_version=_SAMPLE_SCANNER_VERSION,
+        )
     )
     payload = _build_generic_payload(summary)
     assert payload["findings_count"] == len(scan_result.findings)
@@ -333,7 +372,12 @@ def test_generic_payload_no_raw_phi_values() -> None:
     """Generic payload findings must not include code_context or remediation_hint."""
     scan_result = _make_dirty_result()
     summary = _build_webhook_scan_summary(
-        scan_result, _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
+        NotificationRequest(
+            scan_result=scan_result,
+            repository=_SAMPLE_REPO,
+            branch=_SAMPLE_BRANCH,
+            scanner_version=_SAMPLE_SCANNER_VERSION,
+        )
     )
     payload = _build_generic_payload(summary)
     for finding_payload in payload.get("findings", []):
@@ -345,7 +389,12 @@ def test_generic_payload_contains_value_hash_not_raw_value() -> None:
     """Generic payload findings must contain value_hash (not the raw PHI value)."""
     scan_result = _make_dirty_result()
     summary = _build_webhook_scan_summary(
-        scan_result, _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
+        NotificationRequest(
+            scan_result=scan_result,
+            repository=_SAMPLE_REPO,
+            branch=_SAMPLE_BRANCH,
+            scanner_version=_SAMPLE_SCANNER_VERSION,
+        )
     )
     payload = _build_generic_payload(summary)
     for finding_payload in payload.get("findings", []):
@@ -355,7 +404,12 @@ def test_generic_payload_contains_value_hash_not_raw_value() -> None:
 def test_slack_payload_has_attachments_key() -> None:
     """Slack payload must use the 'attachments' key for Block Kit compatibility."""
     summary = _build_webhook_scan_summary(
-        _make_dirty_result(), _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
+        NotificationRequest(
+            scan_result=_make_dirty_result(),
+            repository=_SAMPLE_REPO,
+            branch=_SAMPLE_BRANCH,
+            scanner_version=_SAMPLE_SCANNER_VERSION,
+        )
     )
     payload = _build_slack_payload(summary)
     assert "attachments" in payload
@@ -364,7 +418,12 @@ def test_slack_payload_has_attachments_key() -> None:
 def test_teams_payload_has_message_card_type() -> None:
     """Teams payload must have '@type': 'MessageCard'."""
     summary = _build_webhook_scan_summary(
-        _make_dirty_result(), _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
+        NotificationRequest(
+            scan_result=_make_dirty_result(),
+            repository=_SAMPLE_REPO,
+            branch=_SAMPLE_BRANCH,
+            scanner_version=_SAMPLE_SCANNER_VERSION,
+        )
     )
     payload = _build_teams_payload(summary)
     assert payload.get("@type") == "MessageCard"
@@ -374,7 +433,12 @@ def test_build_webhook_scan_summary_derives_fields_correctly() -> None:
     """_build_webhook_scan_summary must derive all metadata fields from ScanResult."""
     scan_result = _make_dirty_result()
     summary = _build_webhook_scan_summary(
-        scan_result, _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
+        NotificationRequest(
+            scan_result=scan_result,
+            repository=_SAMPLE_REPO,
+            branch=_SAMPLE_BRANCH,
+            scanner_version=_SAMPLE_SCANNER_VERSION,
+        )
     )
     assert summary.is_clean == scan_result.is_clean
     assert summary.risk_level_label == scan_result.risk_level.value.upper()
@@ -390,10 +454,12 @@ def test_build_webhook_payload_dispatches_slack() -> None:
     """_build_webhook_payload must produce a Slack payload for WebhookType.SLACK."""
     payload = _build_webhook_payload(
         WebhookType.SLACK,
-        _make_dirty_result(),
-        _SAMPLE_REPO,
-        _SAMPLE_BRANCH,
-        _SAMPLE_SCANNER_VERSION,
+        NotificationRequest(
+            scan_result=_make_dirty_result(),
+            repository=_SAMPLE_REPO,
+            branch=_SAMPLE_BRANCH,
+            scanner_version=_SAMPLE_SCANNER_VERSION,
+        ),
     )
     assert "attachments" in payload
 
@@ -402,10 +468,12 @@ def test_build_webhook_payload_dispatches_teams() -> None:
     """_build_webhook_payload must produce a Teams payload for WebhookType.TEAMS."""
     payload = _build_webhook_payload(
         WebhookType.TEAMS,
-        _make_dirty_result(),
-        _SAMPLE_REPO,
-        _SAMPLE_BRANCH,
-        _SAMPLE_SCANNER_VERSION,
+        NotificationRequest(
+            scan_result=_make_dirty_result(),
+            repository=_SAMPLE_REPO,
+            branch=_SAMPLE_BRANCH,
+            scanner_version=_SAMPLE_SCANNER_VERSION,
+        ),
     )
     assert payload.get("@type") == "MessageCard"
 
@@ -414,10 +482,12 @@ def test_build_webhook_payload_dispatches_generic() -> None:
     """_build_webhook_payload must produce a generic payload for WebhookType.GENERIC."""
     payload = _build_webhook_payload(
         WebhookType.GENERIC,
-        _make_dirty_result(),
-        _SAMPLE_REPO,
-        _SAMPLE_BRANCH,
-        _SAMPLE_SCANNER_VERSION,
+        NotificationRequest(
+            scan_result=_make_dirty_result(),
+            repository=_SAMPLE_REPO,
+            branch=_SAMPLE_BRANCH,
+            scanner_version=_SAMPLE_SCANNER_VERSION,
+        ),
     )
     assert "event" in payload
 
@@ -432,7 +502,13 @@ def test_send_webhook_raises_when_url_empty() -> None:
     config = NotificationConfig(is_webhook_enabled=True, webhook_url="")
     with pytest.raises(NotificationError):
         send_webhook_notification(
-            config, _make_dirty_result(), _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
+            config,
+            NotificationRequest(
+                scan_result=_make_dirty_result(),
+                repository=_SAMPLE_REPO,
+                branch=_SAMPLE_BRANCH,
+                scanner_version=_SAMPLE_SCANNER_VERSION,
+            ),
         )
 
 
@@ -450,10 +526,12 @@ def test_send_webhook_succeeds_on_http_200() -> None:
     ):
         send_webhook_notification(
             config,
-            _make_dirty_result(),
-            _SAMPLE_REPO,
-            _SAMPLE_BRANCH,
-            _SAMPLE_SCANNER_VERSION,
+            NotificationRequest(
+                scan_result=_make_dirty_result(),
+                repository=_SAMPLE_REPO,
+                branch=_SAMPLE_BRANCH,
+                scanner_version=_SAMPLE_SCANNER_VERSION,
+            ),
         )
 
 
@@ -467,10 +545,12 @@ def test_send_webhook_raises_after_all_retries_fail() -> None:
         with pytest.raises(NotificationError):
             send_webhook_notification(
                 config,
-                _make_dirty_result(),
-                _SAMPLE_REPO,
-                _SAMPLE_BRANCH,
-                _SAMPLE_SCANNER_VERSION,
+                NotificationRequest(
+                    scan_result=_make_dirty_result(),
+                    repository=_SAMPLE_REPO,
+                    branch=_SAMPLE_BRANCH,
+                    scanner_version=_SAMPLE_SCANNER_VERSION,
+                ),
             )
 
 
@@ -481,10 +561,12 @@ def test_send_webhook_raises_on_network_error() -> None:
         with pytest.raises(NotificationError):
             send_webhook_notification(
                 config,
-                _make_dirty_result(),
-                _SAMPLE_REPO,
-                _SAMPLE_BRANCH,
-                _SAMPLE_SCANNER_VERSION,
+                NotificationRequest(
+                    scan_result=_make_dirty_result(),
+                    repository=_SAMPLE_REPO,
+                    branch=_SAMPLE_BRANCH,
+                    scanner_version=_SAMPLE_SCANNER_VERSION,
+                ),
             )
 
 
@@ -504,10 +586,12 @@ def test_send_webhook_retries_on_failure() -> None:
         with pytest.raises(NotificationError):
             send_webhook_notification(
                 config,
-                _make_dirty_result(),
-                _SAMPLE_REPO,
-                _SAMPLE_BRANCH,
-                _SAMPLE_SCANNER_VERSION,
+                NotificationRequest(
+                    scan_result=_make_dirty_result(),
+                    repository=_SAMPLE_REPO,
+                    branch=_SAMPLE_BRANCH,
+                    scanner_version=_SAMPLE_SCANNER_VERSION,
+                ),
             )
         assert mock_post.call_count == 3
 
@@ -695,7 +779,13 @@ def test_send_webhook_rejects_http_url() -> None:
     )
     with pytest.raises(NotificationError, match="https"):
         send_webhook_notification(
-            config, _make_dirty_result(), _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
+            config,
+            NotificationRequest(
+                scan_result=_make_dirty_result(),
+                repository=_SAMPLE_REPO,
+                branch=_SAMPLE_BRANCH,
+                scanner_version=_SAMPLE_SCANNER_VERSION,
+            ),
         )
 
 
@@ -707,7 +797,13 @@ def test_send_webhook_rejects_private_ip_url() -> None:
     )
     with pytest.raises(NotificationError, match="blocked"):
         send_webhook_notification(
-            config, _make_dirty_result(), _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
+            config,
+            NotificationRequest(
+                scan_result=_make_dirty_result(),
+                repository=_SAMPLE_REPO,
+                branch=_SAMPLE_BRANCH,
+                scanner_version=_SAMPLE_SCANNER_VERSION,
+            ),
         )
 
 
@@ -719,10 +815,12 @@ def test_send_webhook_rejects_private_ip_url() -> None:
 def test_email_html_body_escapes_branch_name() -> None:
     """_build_email_html_body must HTML-escape the branch name."""
     html_body = _build_email_html_body(
-        _make_dirty_result(),
-        _SAMPLE_REPO,
-        _SCRIPT_INJECTION_BRANCH,
-        _SAMPLE_SCANNER_VERSION,
+        NotificationRequest(
+            scan_result=_make_dirty_result(),
+            repository=_SAMPLE_REPO,
+            branch=_SCRIPT_INJECTION_BRANCH,
+            scanner_version=_SAMPLE_SCANNER_VERSION,
+        )
     )
     assert "<script>" not in html_body
     assert "&lt;script&gt;" in html_body
@@ -731,10 +829,12 @@ def test_email_html_body_escapes_branch_name() -> None:
 def test_email_html_body_escapes_repo_name() -> None:
     """_build_email_html_body must HTML-escape the repo name."""
     html_body = _build_email_html_body(
-        _make_dirty_result(),
-        _SCRIPT_INJECTION_REPO,
-        _SAMPLE_BRANCH,
-        _SAMPLE_SCANNER_VERSION,
+        NotificationRequest(
+            scan_result=_make_dirty_result(),
+            repository=_SCRIPT_INJECTION_REPO,
+            branch=_SAMPLE_BRANCH,
+            scanner_version=_SAMPLE_SCANNER_VERSION,
+        )
     )
     assert "<b>" not in html_body
     assert "&lt;b&gt;" in html_body

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -33,6 +33,7 @@ from phi_scan.constants import (
 from phi_scan.exceptions import NotificationError
 from phi_scan.models import NotificationConfig, ScanFinding, ScanResult
 from phi_scan.notifier import (
+    _FINDING_KEY_VALUE_HASH,  # noqa: PLC2701
     NotificationRequest,
     _build_email_html_body,  # noqa: PLC2701
     _build_email_subject,
@@ -409,8 +410,8 @@ def test_generic_payload_no_raw_phi_values() -> None:
     )
     payload = _build_generic_payload(scan_summary)
     for finding_payload in payload.get("findings", []):
-        assert "code_context" not in finding_payload
-        assert "remediation_hint" not in finding_payload
+        assert "code_context" not in finding_payload  # never serialised — PHI constraint
+        assert "remediation_hint" not in finding_payload  # never serialised — PHI constraint
 
 
 def test_generic_payload_contains_value_hash_not_raw_value() -> None:
@@ -426,7 +427,7 @@ def test_generic_payload_contains_value_hash_not_raw_value() -> None:
     )
     payload = _build_generic_payload(scan_summary)
     for finding_payload in payload.get("findings", []):
-        assert "value_hash" in finding_payload
+        assert _FINDING_KEY_VALUE_HASH in finding_payload
 
 
 def test_slack_payload_has_attachments_key() -> None:

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -381,7 +381,7 @@ def test_build_webhook_scan_summary_derives_fields_correctly() -> None:
     assert summary.risk_level_value == scan_result.risk_level.value
     assert summary.findings_count == len(scan_result.findings)
     assert summary.files_scanned == scan_result.files_scanned
-    assert summary.repo == _SAMPLE_REPO
+    assert summary.repository == _SAMPLE_REPO
     assert summary.branch == _SAMPLE_BRANCH
     assert summary.scanner_version == _SAMPLE_SCANNER_VERSION
 

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -39,6 +39,7 @@ from phi_scan.notifier import (
     _build_slack_payload,
     _build_teams_payload,
     _build_webhook_payload,
+    _build_webhook_scan_summary,  # noqa: PLC2701
     _get_smtp_credentials,
     _reject_ssrf_resolved_addresses,  # noqa: PLC2701
     _resolve_hostname_addresses,  # noqa: PLC2701
@@ -310,26 +311,31 @@ def test_get_smtp_credentials_reads_from_env(monkeypatch: pytest.MonkeyPatch) ->
 
 def test_generic_payload_contains_event_field() -> None:
     """Generic webhook payload must include an 'event' field."""
-    payload = _build_generic_payload(
-        _make_dirty_result(), _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
+    scan_result = _make_dirty_result()
+    summary = _build_webhook_scan_summary(
+        scan_result, _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
     )
+    payload = _build_generic_payload(summary, scan_result)
     assert "event" in payload
 
 
 def test_generic_payload_contains_findings_count() -> None:
     """Generic webhook payload findings_count must match scan result."""
     scan_result = _make_dirty_result()
-    payload = _build_generic_payload(
+    summary = _build_webhook_scan_summary(
         scan_result, _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
     )
+    payload = _build_generic_payload(summary, scan_result)
     assert payload["findings_count"] == len(scan_result.findings)
 
 
 def test_generic_payload_no_raw_phi_values() -> None:
     """Generic payload findings must not include code_context or remediation_hint."""
-    payload = _build_generic_payload(
-        _make_dirty_result(), _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
+    scan_result = _make_dirty_result()
+    summary = _build_webhook_scan_summary(
+        scan_result, _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
     )
+    payload = _build_generic_payload(summary, scan_result)
     for finding_payload in payload.get("findings", []):
         assert "code_context" not in finding_payload
         assert "remediation_hint" not in finding_payload
@@ -337,27 +343,46 @@ def test_generic_payload_no_raw_phi_values() -> None:
 
 def test_generic_payload_contains_value_hash_not_raw_value() -> None:
     """Generic payload findings must contain value_hash (not the raw PHI value)."""
-    payload = _build_generic_payload(
-        _make_dirty_result(), _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
+    scan_result = _make_dirty_result()
+    summary = _build_webhook_scan_summary(
+        scan_result, _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
     )
+    payload = _build_generic_payload(summary, scan_result)
     for finding_payload in payload.get("findings", []):
         assert "value_hash" in finding_payload
 
 
 def test_slack_payload_has_attachments_key() -> None:
     """Slack payload must use the 'attachments' key for Block Kit compatibility."""
-    payload = _build_slack_payload(
+    summary = _build_webhook_scan_summary(
         _make_dirty_result(), _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
     )
+    payload = _build_slack_payload(summary)
     assert "attachments" in payload
 
 
 def test_teams_payload_has_message_card_type() -> None:
     """Teams payload must have '@type': 'MessageCard'."""
-    payload = _build_teams_payload(
+    summary = _build_webhook_scan_summary(
         _make_dirty_result(), _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
     )
+    payload = _build_teams_payload(summary)
     assert payload.get("@type") == "MessageCard"
+
+
+def test_build_webhook_scan_summary_derives_fields_correctly() -> None:
+    """_build_webhook_scan_summary must derive all metadata fields from ScanResult."""
+    scan_result = _make_dirty_result()
+    summary = _build_webhook_scan_summary(
+        scan_result, _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
+    )
+    assert summary.is_clean == scan_result.is_clean
+    assert summary.risk_level_label == scan_result.risk_level.value.upper()
+    assert summary.findings_count == len(scan_result.findings)
+    assert summary.files_scanned == scan_result.files_scanned
+    assert summary.repo == _SAMPLE_REPO
+    assert summary.branch == _SAMPLE_BRANCH
+    assert summary.scanner_version == _SAMPLE_SCANNER_VERSION
 
 
 def test_build_webhook_payload_dispatches_slack() -> None:

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -40,7 +40,7 @@ from phi_scan.notifier import (
     _build_slack_payload,
     _build_teams_payload,
     _build_webhook_payload,
-    _build_webhook_scan_summary,  # noqa: PLC2701
+    _derive_webhook_scan_summary,  # noqa: PLC2701
     _get_smtp_credentials,
     _reject_ssrf_resolved_addresses,  # noqa: PLC2701
     _resolve_hostname_addresses,  # noqa: PLC2701
@@ -170,26 +170,54 @@ def _make_webhook_config(
 
 def test_email_subject_contains_risk_level() -> None:
     """Email subject must include the risk level in uppercase."""
-    subject = _build_email_subject(_make_dirty_result(), _SAMPLE_REPO, _SAMPLE_BRANCH)
+    subject = _build_email_subject(
+        NotificationRequest(
+            scan_result=_make_dirty_result(),
+            repository=_SAMPLE_REPO,
+            branch=_SAMPLE_BRANCH,
+            scanner_version=_SAMPLE_SCANNER_VERSION,
+        )
+    )
     assert "HIGH" in subject
 
 
 def test_email_subject_contains_findings_count() -> None:
     """Email subject must include the findings count."""
-    subject = _build_email_subject(_make_dirty_result(), _SAMPLE_REPO, _SAMPLE_BRANCH)
+    subject = _build_email_subject(
+        NotificationRequest(
+            scan_result=_make_dirty_result(),
+            repository=_SAMPLE_REPO,
+            branch=_SAMPLE_BRANCH,
+            scanner_version=_SAMPLE_SCANNER_VERSION,
+        )
+    )
     assert str(_ONE_FINDING) in subject
 
 
 def test_email_subject_contains_repo_and_branch() -> None:
     """Email subject must include the repository and branch."""
-    subject = _build_email_subject(_make_dirty_result(), _SAMPLE_REPO, _SAMPLE_BRANCH)
+    subject = _build_email_subject(
+        NotificationRequest(
+            scan_result=_make_dirty_result(),
+            repository=_SAMPLE_REPO,
+            branch=_SAMPLE_BRANCH,
+            scanner_version=_SAMPLE_SCANNER_VERSION,
+        )
+    )
     assert _SAMPLE_REPO in subject
     assert _SAMPLE_BRANCH in subject
 
 
 def test_email_subject_phi_alert_prefix() -> None:
     """Email subject must begin with the [PHI ALERT] prefix."""
-    subject = _build_email_subject(_make_dirty_result(), _SAMPLE_REPO, _SAMPLE_BRANCH)
+    subject = _build_email_subject(
+        NotificationRequest(
+            scan_result=_make_dirty_result(),
+            repository=_SAMPLE_REPO,
+            branch=_SAMPLE_BRANCH,
+            scanner_version=_SAMPLE_SCANNER_VERSION,
+        )
+    )
     assert subject.startswith("[PHI ALERT]")
 
 
@@ -341,7 +369,7 @@ def test_get_smtp_credentials_reads_from_env(monkeypatch: pytest.MonkeyPatch) ->
 def test_generic_payload_contains_event_field() -> None:
     """Generic webhook payload must include an 'event' field."""
     scan_result = _make_dirty_result()
-    summary = _build_webhook_scan_summary(
+    scan_summary = _derive_webhook_scan_summary(
         NotificationRequest(
             scan_result=scan_result,
             repository=_SAMPLE_REPO,
@@ -349,14 +377,14 @@ def test_generic_payload_contains_event_field() -> None:
             scanner_version=_SAMPLE_SCANNER_VERSION,
         )
     )
-    payload = _build_generic_payload(summary)
+    payload = _build_generic_payload(scan_summary)
     assert "event" in payload
 
 
 def test_generic_payload_contains_findings_count() -> None:
     """Generic webhook payload findings_count must match scan result."""
     scan_result = _make_dirty_result()
-    summary = _build_webhook_scan_summary(
+    scan_summary = _derive_webhook_scan_summary(
         NotificationRequest(
             scan_result=scan_result,
             repository=_SAMPLE_REPO,
@@ -364,14 +392,14 @@ def test_generic_payload_contains_findings_count() -> None:
             scanner_version=_SAMPLE_SCANNER_VERSION,
         )
     )
-    payload = _build_generic_payload(summary)
+    payload = _build_generic_payload(scan_summary)
     assert payload["findings_count"] == len(scan_result.findings)
 
 
 def test_generic_payload_no_raw_phi_values() -> None:
     """Generic payload findings must not include code_context or remediation_hint."""
     scan_result = _make_dirty_result()
-    summary = _build_webhook_scan_summary(
+    scan_summary = _derive_webhook_scan_summary(
         NotificationRequest(
             scan_result=scan_result,
             repository=_SAMPLE_REPO,
@@ -379,7 +407,7 @@ def test_generic_payload_no_raw_phi_values() -> None:
             scanner_version=_SAMPLE_SCANNER_VERSION,
         )
     )
-    payload = _build_generic_payload(summary)
+    payload = _build_generic_payload(scan_summary)
     for finding_payload in payload.get("findings", []):
         assert "code_context" not in finding_payload
         assert "remediation_hint" not in finding_payload
@@ -388,7 +416,7 @@ def test_generic_payload_no_raw_phi_values() -> None:
 def test_generic_payload_contains_value_hash_not_raw_value() -> None:
     """Generic payload findings must contain value_hash (not the raw PHI value)."""
     scan_result = _make_dirty_result()
-    summary = _build_webhook_scan_summary(
+    scan_summary = _derive_webhook_scan_summary(
         NotificationRequest(
             scan_result=scan_result,
             repository=_SAMPLE_REPO,
@@ -396,14 +424,14 @@ def test_generic_payload_contains_value_hash_not_raw_value() -> None:
             scanner_version=_SAMPLE_SCANNER_VERSION,
         )
     )
-    payload = _build_generic_payload(summary)
+    payload = _build_generic_payload(scan_summary)
     for finding_payload in payload.get("findings", []):
         assert "value_hash" in finding_payload
 
 
 def test_slack_payload_has_attachments_key() -> None:
     """Slack payload must use the 'attachments' key for Block Kit compatibility."""
-    summary = _build_webhook_scan_summary(
+    scan_summary = _derive_webhook_scan_summary(
         NotificationRequest(
             scan_result=_make_dirty_result(),
             repository=_SAMPLE_REPO,
@@ -411,13 +439,13 @@ def test_slack_payload_has_attachments_key() -> None:
             scanner_version=_SAMPLE_SCANNER_VERSION,
         )
     )
-    payload = _build_slack_payload(summary)
+    payload = _build_slack_payload(scan_summary)
     assert "attachments" in payload
 
 
 def test_teams_payload_has_message_card_type() -> None:
     """Teams payload must have '@type': 'MessageCard'."""
-    summary = _build_webhook_scan_summary(
+    scan_summary = _derive_webhook_scan_summary(
         NotificationRequest(
             scan_result=_make_dirty_result(),
             repository=_SAMPLE_REPO,
@@ -425,14 +453,14 @@ def test_teams_payload_has_message_card_type() -> None:
             scanner_version=_SAMPLE_SCANNER_VERSION,
         )
     )
-    payload = _build_teams_payload(summary)
+    payload = _build_teams_payload(scan_summary)
     assert payload.get("@type") == "MessageCard"
 
 
-def test_build_webhook_scan_summary_derives_fields_correctly() -> None:
-    """_build_webhook_scan_summary must derive all metadata fields from ScanResult."""
+def test_derive_webhook_scan_summary_derives_fields_correctly() -> None:
+    """_derive_webhook_scan_summary must derive all metadata fields from ScanResult."""
     scan_result = _make_dirty_result()
-    summary = _build_webhook_scan_summary(
+    scan_summary = _derive_webhook_scan_summary(
         NotificationRequest(
             scan_result=scan_result,
             repository=_SAMPLE_REPO,
@@ -440,14 +468,14 @@ def test_build_webhook_scan_summary_derives_fields_correctly() -> None:
             scanner_version=_SAMPLE_SCANNER_VERSION,
         )
     )
-    assert summary.is_clean == scan_result.is_clean
-    assert summary.risk_level_label == scan_result.risk_level.value.upper()
-    assert summary.risk_level_value == scan_result.risk_level.value
-    assert summary.findings_count == len(scan_result.findings)
-    assert summary.files_scanned == scan_result.files_scanned
-    assert summary.repository == _SAMPLE_REPO
-    assert summary.branch == _SAMPLE_BRANCH
-    assert summary.scanner_version == _SAMPLE_SCANNER_VERSION
+    assert scan_summary.is_clean == scan_result.is_clean
+    assert scan_summary.risk_level_label == scan_result.risk_level.value.upper()
+    assert scan_summary.risk_level_value == scan_result.risk_level.value
+    assert scan_summary.findings_count == len(scan_result.findings)
+    assert scan_summary.files_scanned == scan_result.files_scanned
+    assert scan_summary.repository == _SAMPLE_REPO
+    assert scan_summary.branch == _SAMPLE_BRANCH
+    assert scan_summary.scanner_version == _SAMPLE_SCANNER_VERSION
 
 
 def test_build_webhook_payload_dispatches_slack() -> None:

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -315,7 +315,7 @@ def test_generic_payload_contains_event_field() -> None:
     summary = _build_webhook_scan_summary(
         scan_result, _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
     )
-    payload = _build_generic_payload(summary, scan_result)
+    payload = _build_generic_payload(summary)
     assert "event" in payload
 
 
@@ -325,7 +325,7 @@ def test_generic_payload_contains_findings_count() -> None:
     summary = _build_webhook_scan_summary(
         scan_result, _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
     )
-    payload = _build_generic_payload(summary, scan_result)
+    payload = _build_generic_payload(summary)
     assert payload["findings_count"] == len(scan_result.findings)
 
 
@@ -335,7 +335,7 @@ def test_generic_payload_no_raw_phi_values() -> None:
     summary = _build_webhook_scan_summary(
         scan_result, _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
     )
-    payload = _build_generic_payload(summary, scan_result)
+    payload = _build_generic_payload(summary)
     for finding_payload in payload.get("findings", []):
         assert "code_context" not in finding_payload
         assert "remediation_hint" not in finding_payload
@@ -347,7 +347,7 @@ def test_generic_payload_contains_value_hash_not_raw_value() -> None:
     summary = _build_webhook_scan_summary(
         scan_result, _SAMPLE_REPO, _SAMPLE_BRANCH, _SAMPLE_SCANNER_VERSION
     )
-    payload = _build_generic_payload(summary, scan_result)
+    payload = _build_generic_payload(summary)
     for finding_payload in payload.get("findings", []):
         assert "value_hash" in finding_payload
 
@@ -378,6 +378,7 @@ def test_build_webhook_scan_summary_derives_fields_correctly() -> None:
     )
     assert summary.is_clean == scan_result.is_clean
     assert summary.risk_level_label == scan_result.risk_level.value.upper()
+    assert summary.risk_level_value == scan_result.risk_level.value
     assert summary.findings_count == len(scan_result.findings)
     assert summary.files_scanned == scan_result.files_scanned
     assert summary.repo == _SAMPLE_REPO


### PR DESCRIPTION
## Summary

- **7H.1 `SECURITY.md`** — Replaced the absolute "no PHI transmitted externally" claim with qualified language. The optional AI review layer (`ai.enable_ai_review`, disabled by default) sends redacted code structure — never raw PHI — to the configured provider when enabled. Closes the policy ambiguity flagged in the external review.

- **7H.2 `notifier.py`** — Extracted `_WebhookScanSummary` frozen dataclass and `_build_webhook_scan_summary` factory. The three webhook payload builders (`_build_slack_payload`, `_build_teams_payload`, `_build_generic_payload`) previously each re-derived the same 7 metadata fields independently from 4 loose args. They now each take a single `_WebhookScanSummary`; `_build_webhook_payload` constructs the summary once and dispatches.

- **7H.3 `hashing.py`** — Added `build_structured_finding` factory centralising the `compute_value_hash` + `severity_from_confidence` + `HIPAA_REMEDIATION_GUIDANCE.get` pattern that `_build_fhir_finding` and `_build_hl7_finding` previously duplicated. Both structured detectors now delegate to this factory; layer-specific inputs (entity_type, code_context, detection_layer) remain local.

## Test plan

- [ ] `make test` — 1729 tests pass (4 new: `_build_webhook_scan_summary` field derivation, `build_structured_finding` hash/severity/remediation)
- [ ] `make lint` — ruff clean
- [ ] `make typecheck` — mypy strict passes
- [ ] `make scan` — `phi_scan/` itself is clean