### PR TITLE
[7J] Security hardening: value_hash lowercase enforcement + DNS TOCTOU fix

### DIFF
--- a/phi_scan/hashing.py
+++ b/phi_scan/hashing.py
@@ -41,8 +41,8 @@ __all__ = [
 
 _NO_REMEDIATION_HINT: str = ""
 _SHA256_HEX_DIGEST_LENGTH: int = 64
-# Computed once at import time — avoids repeated str.lower() calls inside the
-# all() check in StructuredFindingRequest.__post_init__.
+# Lowercase-only hex digits — rejects uppercase A–F that string.hexdigits would
+# permit, enforcing that value_hash always holds a SHA-256 lowercase digest.
 _LOWERCASE_HEX_DIGITS: frozenset[str] = frozenset(string.hexdigits.lower())
 
 

--- a/phi_scan/hashing.py
+++ b/phi_scan/hashing.py
@@ -41,6 +41,9 @@ __all__ = [
 
 _NO_REMEDIATION_HINT: str = ""
 _SHA256_HEX_DIGEST_LENGTH: int = 64
+# Computed once at import time — avoids repeated str.lower() calls inside the
+# all() check in StructuredFindingRequest.__post_init__.
+_LOWERCASE_HEX_DIGITS: frozenset[str] = frozenset(string.hexdigits.lower())
 
 
 @dataclass(frozen=True)
@@ -69,7 +72,7 @@ class StructuredFindingRequest:
             ValueError: If value_hash is not exactly 64 lowercase hex characters.
         """
         is_valid_length = len(self.value_hash) == _SHA256_HEX_DIGEST_LENGTH
-        is_valid_hex = all(character in string.hexdigits.lower() for character in self.value_hash)
+        is_valid_hex = all(character in _LOWERCASE_HEX_DIGITS for character in self.value_hash)
         if not is_valid_length or not is_valid_hex:
             raise ValueError(
                 "value_hash must be a 64-character lowercase hex digest; "

--- a/phi_scan/hashing.py
+++ b/phi_scan/hashing.py
@@ -69,10 +69,11 @@ class StructuredFindingRequest:
             ValueError: If value_hash is not exactly 64 lowercase hex characters.
         """
         is_valid_length = len(self.value_hash) == _SHA256_HEX_DIGEST_LENGTH
-        is_valid_hex = all(character in string.hexdigits for character in self.value_hash)
+        is_valid_hex = all(character in string.hexdigits.lower() for character in self.value_hash)
         if not is_valid_length or not is_valid_hex:
             raise ValueError(
-                f"value_hash must be a 64-character hex digest; got length {len(self.value_hash)}"
+                "value_hash must be a 64-character lowercase hex digest; "
+                f"got length {len(self.value_hash)}"
             )
 
 

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -113,10 +113,11 @@ _WEBHOOK_DNS_BLOCKED_ADDRESS_ERROR: str = (
 # SSRF validation, preventing DNS rebinding between validation and request.
 _PINNED_HOST_HEADER: str = "Host"
 _CONTENT_TYPE_HEADER: str = "Content-Type"
-_SINGLE_HOSTNAME_REPLACEMENT_COUNT: int = 1
 _MISSING_HOSTNAME_ERROR_MESSAGE: str = "cannot pin request: URL has no parseable hostname"
 _IPV6_ADDRESS_COLON: str = ":"
 _IPV6_NETLOC_BRACKET_TEMPLATE: str = "[{hostname}]"
+_NETLOC_PORT_TEMPLATE: str = ":{port}"
+_EMPTY_PORT_SEGMENT: str = ""
 
 # IP networks blocked by SSRF protection when is_private_webhook_url_allowed=False.
 # Covers RFC1918 private ranges, link-local, loopback, CGNAT, cloud metadata,
@@ -773,10 +774,10 @@ def _validate_webhook_url(
 
 
 @dataclass(frozen=True)
-class _PinnedRequestArguments:
+class _PinnedWebhookRequest:
     """Pre-computed URL and headers for a TOCTOU-safe webhook POST.
 
-    Produced by ``_build_pinned_request_arguments`` and consumed by ``_post_with_retry``
+    Produced by ``_build_pinned_webhook_request`` and consumed by ``_post_with_retry``
     so that URL rewriting and header construction are isolated from the retry loop.
     """
 
@@ -801,13 +802,14 @@ def _netloc_host_segment(hostname: str) -> str:
     return hostname
 
 
-def _build_pinned_url(url: str, pinned_ip: str) -> str:
-    """Rewrite ``url`` replacing its hostname with ``pinned_ip``.
+def _rewrite_url_hostname_to_ip(url: str, pinned_ip: str) -> str:
+    """Return ``url`` with its hostname replaced by ``pinned_ip``.
 
-    Substitutes the hostname in the netloc so httpx connects to the
-    pre-resolved IP, preventing DNS rebinding between SSRF validation and
-    delivery. The original hostname travels in the Host header (see
-    ``_build_pinned_request_arguments``) so TLS SNI and server routing are preserved.
+    Reconstructs the netloc from parsed parts (host + port) rather than
+    string-substituting the original netloc, which is fragile when the
+    hostname appears as a substring of the port or other netloc components.
+    The original hostname travels in the Host header (see
+    ``_build_pinned_webhook_request``) so TLS SNI and server routing are preserved.
     Both IPv4 and IPv6 pinned addresses are handled: IPv6 addresses are
     bracketed in the netloc (e.g. ``[2001:db8::1]``).
 
@@ -824,15 +826,14 @@ def _build_pinned_url(url: str, pinned_ip: str) -> str:
     parsed = urlparse(url)
     if not parsed.hostname:
         raise NotificationError(_MISSING_HOSTNAME_ERROR_MESSAGE)
-    original_netloc_host = _netloc_host_segment(parsed.hostname)
     pinned_netloc_host = _netloc_host_segment(pinned_ip)
-    pinned_netloc = parsed.netloc.replace(
-        original_netloc_host, pinned_netloc_host, _SINGLE_HOSTNAME_REPLACEMENT_COUNT
+    port_segment = (
+        _NETLOC_PORT_TEMPLATE.format(port=parsed.port) if parsed.port else _EMPTY_PORT_SEGMENT
     )
-    return urlunparse(parsed._replace(netloc=pinned_netloc))
+    return urlunparse(parsed._replace(netloc=f"{pinned_netloc_host}{port_segment}"))
 
 
-def _build_pinned_request_arguments(url: str, pinned_ip: str | None) -> _PinnedRequestArguments:
+def _build_pinned_webhook_request(url: str, pinned_ip: str | None) -> _PinnedWebhookRequest:
     """Build the target URL and headers for a webhook POST.
 
     When ``pinned_ip`` is provided, rewrites the URL to connect to the
@@ -844,13 +845,13 @@ def _build_pinned_request_arguments(url: str, pinned_ip: str | None) -> _PinnedR
         pinned_ip: IP returned by ``_validate_webhook_url``, or None.
 
     Returns:
-        ``_PinnedRequestArguments`` with target_url and headers ready for httpx.
+        ``_PinnedWebhookRequest`` with target_url and headers ready for httpx.
 
     Raises:
         NotificationError: If pinned_ip is set but the URL has no parseable hostname.
     """
     if pinned_ip is None:
-        return _PinnedRequestArguments(
+        return _PinnedWebhookRequest(
             target_url=url,
             headers=MappingProxyType({_CONTENT_TYPE_HEADER: _WEBHOOK_CONTENT_TYPE}),
         )
@@ -858,12 +859,14 @@ def _build_pinned_request_arguments(url: str, pinned_ip: str | None) -> _PinnedR
     original_hostname = parsed.hostname
     if not original_hostname:
         raise NotificationError(_MISSING_HOSTNAME_ERROR_MESSAGE)
-    return _PinnedRequestArguments(
-        target_url=_build_pinned_url(url, pinned_ip),
-        headers=MappingProxyType({
-            _CONTENT_TYPE_HEADER: _WEBHOOK_CONTENT_TYPE,
-            _PINNED_HOST_HEADER: original_hostname,
-        }),
+    return _PinnedWebhookRequest(
+        target_url=_rewrite_url_hostname_to_ip(url, pinned_ip),
+        headers=MappingProxyType(
+            {
+                _CONTENT_TYPE_HEADER: _WEBHOOK_CONTENT_TYPE,
+                _PINNED_HOST_HEADER: original_hostname,
+            }
+        ),
     )
 
 
@@ -889,7 +892,7 @@ def _post_with_retry(
     Raises:
         NotificationError: If all attempts fail.
     """
-    request_args = _build_pinned_request_arguments(url, pinned_ip)
+    request_args = _build_pinned_webhook_request(url, pinned_ip)
     last_error: Exception | None = None
     for attempt in range(1, retry_count + 1):
         try:

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -892,14 +892,14 @@ def _post_with_retry(
     Raises:
         NotificationError: If all attempts fail.
     """
-    request_args = _build_pinned_webhook_request(url, pinned_ip)
+    pinned_request = _build_pinned_webhook_request(url, pinned_ip)
     last_error: Exception | None = None
     for attempt in range(1, retry_count + 1):
         try:
             response = httpx.post(
-                request_args.target_url,
+                pinned_request.target_url,
                 json=payload,
-                headers=request_args.headers,
+                headers=pinned_request.headers,
                 timeout=WEBHOOK_DEFAULT_TIMEOUT_SECONDS,
             )
             if response.is_success:

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -113,7 +113,6 @@ _WEBHOOK_DNS_BLOCKED_ADDRESS_ERROR: str = (
 # SSRF validation, preventing DNS rebinding between validation and request.
 _PINNED_HOST_HEADER: str = "Host"
 _CONTENT_TYPE_HEADER: str = "Content-Type"
-_URL_REWRITE_NO_HOSTNAME_ERROR: str = "cannot rewrite URL hostname: no parseable hostname in URL"
 _WEBHOOK_BUILD_NO_HOSTNAME_ERROR: str = "cannot build pinned request: URL has no parseable hostname"
 _IPV6_ADDRESS_COLON: str = ":"
 _IPV6_NETLOC_BRACKET_TEMPLATE: str = "[{hostname}]"
@@ -800,8 +799,8 @@ class _WebhookPostRequest:
     pinned_ip: str | None
 
 
-def _netloc_host_segment(hostname: str) -> str:
-    """Return hostname as it appears in a URL netloc.
+def _format_netloc_host_segment(hostname: str) -> str:
+    """Return hostname formatted for insertion into a URL netloc string.
 
     IPv6 addresses must be bracketed in netloc (e.g. ``[2001:db8::1]``);
     IPv4 addresses and DNS names are used as-is.
@@ -817,7 +816,7 @@ def _netloc_host_segment(hostname: str) -> str:
     return hostname
 
 
-def _rewrite_url_hostname_to_ip(url: str, pinned_ip: str) -> str:
+def _rewrite_url_hostname_to_ip(url: str, pinned_ip: str, original_hostname: str) -> str:
     """Return ``url`` with its hostname replaced by ``pinned_ip``.
 
     Reconstructs the netloc from parsed parts (host + port) rather than
@@ -831,21 +830,20 @@ def _rewrite_url_hostname_to_ip(url: str, pinned_ip: str) -> str:
     Args:
         url: Original webhook URL.
         pinned_ip: IP address string returned by ``_validate_webhook_url``.
+        original_hostname: Pre-parsed hostname from ``url`` (avoids a second
+            ``urlparse`` call in the caller that already holds this value).
 
     Returns:
         URL with hostname replaced by ``pinned_ip``.
-
-    Raises:
-        NotificationError: If the URL has no parseable hostname.
     """
-    parsed = urlparse(url)
-    if not parsed.hostname:
-        raise NotificationError(_URL_REWRITE_NO_HOSTNAME_ERROR)
-    pinned_netloc_host = _netloc_host_segment(pinned_ip)
+    parsed_webhook_url = urlparse(url)
+    pinned_netloc_host = _format_netloc_host_segment(pinned_ip)
     port_segment = (
-        _NETLOC_PORT_TEMPLATE.format(port=parsed.port) if parsed.port else _EMPTY_PORT_SEGMENT
+        _NETLOC_PORT_TEMPLATE.format(port=parsed_webhook_url.port)
+        if parsed_webhook_url.port
+        else _EMPTY_PORT_SEGMENT
     )
-    return urlunparse(parsed._replace(netloc=f"{pinned_netloc_host}{port_segment}"))
+    return urlunparse(parsed_webhook_url._replace(netloc=f"{pinned_netloc_host}{port_segment}"))
 
 
 def _build_pinned_webhook_request(url: str, pinned_ip: str | None) -> _PinnedWebhookRequest:
@@ -870,12 +868,12 @@ def _build_pinned_webhook_request(url: str, pinned_ip: str | None) -> _PinnedWeb
             target_url=url,
             headers=MappingProxyType({_CONTENT_TYPE_HEADER: _WEBHOOK_CONTENT_TYPE}),
         )
-    parsed = urlparse(url)
-    original_hostname = parsed.hostname
+    parsed_webhook_url = urlparse(url)
+    original_hostname = parsed_webhook_url.hostname
     if not original_hostname:
         raise NotificationError(_WEBHOOK_BUILD_NO_HOSTNAME_ERROR)
     return _PinnedWebhookRequest(
-        target_url=_rewrite_url_hostname_to_ip(url, pinned_ip),
+        target_url=_rewrite_url_hostname_to_ip(url, pinned_ip, original_hostname),
         headers=MappingProxyType(
             {
                 _CONTENT_TYPE_HEADER: _WEBHOOK_CONTENT_TYPE,

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -41,7 +41,7 @@ from email.mime.text import MIMEText
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import ParseResult, urlparse, urlunparse
 
 import httpx
 
@@ -740,7 +740,8 @@ def _validate_webhook_url(
 
     Returns:
         Pinned IP string to connect to, or None when is_private_webhook_url_allowed
-        is True or the hostname is already a literal IP address.
+        is True or the hostname is already a literal IP address (public or private —
+        literal IPs require no DNS resolution and therefore no pinning).
 
     Raises:
         NotificationError: If the URL fails any enabled check.
@@ -816,8 +817,8 @@ def _format_netloc_host_segment(hostname: str) -> str:
     return hostname
 
 
-def _rewrite_url_hostname_to_ip(url: str, pinned_ip: str, original_hostname: str) -> str:
-    """Return ``url`` with its hostname replaced by ``pinned_ip``.
+def _rewrite_url_hostname_to_ip(parsed_webhook_url: ParseResult, pinned_ip: str) -> str:
+    """Return a rewritten URL with its hostname replaced by ``pinned_ip``.
 
     Reconstructs the netloc from parsed parts (host + port) rather than
     string-substituting the original netloc, which is fragile when the
@@ -828,15 +829,13 @@ def _rewrite_url_hostname_to_ip(url: str, pinned_ip: str, original_hostname: str
     bracketed in the netloc (e.g. ``[2001:db8::1]``).
 
     Args:
-        url: Original webhook URL.
+        parsed_webhook_url: Pre-parsed webhook URL from the caller (avoids a
+            redundant ``urlparse`` call when the caller already holds this value).
         pinned_ip: IP address string returned by ``_validate_webhook_url``.
-        original_hostname: Pre-parsed hostname from ``url`` (avoids a second
-            ``urlparse`` call in the caller that already holds this value).
 
     Returns:
         URL with hostname replaced by ``pinned_ip``.
     """
-    parsed_webhook_url = urlparse(url)
     pinned_netloc_host = _format_netloc_host_segment(pinned_ip)
     port_segment = (
         _NETLOC_PORT_TEMPLATE.format(port=parsed_webhook_url.port)
@@ -873,7 +872,7 @@ def _build_pinned_webhook_request(url: str, pinned_ip: str | None) -> _PinnedWeb
     if not original_hostname:
         raise NotificationError(_WEBHOOK_BUILD_NO_HOSTNAME_ERROR)
     return _PinnedWebhookRequest(
-        target_url=_rewrite_url_hostname_to_ip(url, pinned_ip, original_hostname),
+        target_url=_rewrite_url_hostname_to_ip(parsed_webhook_url, pinned_ip),
         headers=MappingProxyType(
             {
                 _CONTENT_TYPE_HEADER: _WEBHOOK_CONTENT_TYPE,

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -113,7 +113,8 @@ _WEBHOOK_DNS_BLOCKED_ADDRESS_ERROR: str = (
 # SSRF validation, preventing DNS rebinding between validation and request.
 _PINNED_HOST_HEADER: str = "Host"
 _CONTENT_TYPE_HEADER: str = "Content-Type"
-_MISSING_HOSTNAME_ERROR_MESSAGE: str = "cannot pin request: URL has no parseable hostname"
+_URL_REWRITE_NO_HOSTNAME_ERROR: str = "cannot rewrite URL hostname: no parseable hostname in URL"
+_WEBHOOK_BUILD_NO_HOSTNAME_ERROR: str = "cannot build pinned request: URL has no parseable hostname"
 _IPV6_ADDRESS_COLON: str = ":"
 _IPV6_NETLOC_BRACKET_TEMPLATE: str = "[{hostname}]"
 _NETLOC_PORT_TEMPLATE: str = ":{port}"
@@ -785,6 +786,20 @@ class _PinnedWebhookRequest:
     headers: MappingProxyType[str, str]
 
 
+@dataclass(frozen=True)
+class _WebhookPostRequest:
+    """Input bundle for _post_with_retry.
+
+    Groups the four delivery parameters so the function signature stays within
+    the three-argument limit.
+    """
+
+    url: str
+    payload: dict[str, Any]
+    retry_count: int
+    pinned_ip: str | None
+
+
 def _netloc_host_segment(hostname: str) -> str:
     """Return hostname as it appears in a URL netloc.
 
@@ -825,7 +840,7 @@ def _rewrite_url_hostname_to_ip(url: str, pinned_ip: str) -> str:
     """
     parsed = urlparse(url)
     if not parsed.hostname:
-        raise NotificationError(_MISSING_HOSTNAME_ERROR_MESSAGE)
+        raise NotificationError(_URL_REWRITE_NO_HOSTNAME_ERROR)
     pinned_netloc_host = _netloc_host_segment(pinned_ip)
     port_segment = (
         _NETLOC_PORT_TEMPLATE.format(port=parsed.port) if parsed.port else _EMPTY_PORT_SEGMENT
@@ -858,7 +873,7 @@ def _build_pinned_webhook_request(url: str, pinned_ip: str | None) -> _PinnedWeb
     parsed = urlparse(url)
     original_hostname = parsed.hostname
     if not original_hostname:
-        raise NotificationError(_MISSING_HOSTNAME_ERROR_MESSAGE)
+        raise NotificationError(_WEBHOOK_BUILD_NO_HOSTNAME_ERROR)
     return _PinnedWebhookRequest(
         target_url=_rewrite_url_hostname_to_ip(url, pinned_ip),
         headers=MappingProxyType(
@@ -870,35 +885,25 @@ def _build_pinned_webhook_request(url: str, pinned_ip: str | None) -> _PinnedWeb
     )
 
 
-def _post_with_retry(
-    url: str,
-    payload: dict[str, Any],
-    retry_count: int,
-    pinned_ip: str | None = None,
-) -> None:
+def _post_with_retry(post_request: _WebhookPostRequest) -> None:
     """POST a JSON payload to a URL with linear retry on failure.
 
     Uses ``httpx`` sync client. Retries on HTTP 4xx/5xx and on network errors.
     The final attempt raises ``NotificationError`` if still failing.
 
     Args:
-        url: The webhook endpoint URL.
-        payload: JSON-serialisable payload dict.
-        retry_count: Total number of attempts (1 = no retry).
-        pinned_ip: Pre-resolved IP from ``_validate_webhook_url``. When set,
-            the TCP connection is pinned to this IP to prevent DNS rebinding
-            (TOCTOU mitigation). When None, httpx resolves the hostname normally.
+        post_request: Delivery parameters bundled as a ``_WebhookPostRequest``.
 
     Raises:
         NotificationError: If all attempts fail.
     """
-    pinned_request = _build_pinned_webhook_request(url, pinned_ip)
+    pinned_request = _build_pinned_webhook_request(post_request.url, post_request.pinned_ip)
     last_error: Exception | None = None
-    for attempt in range(1, retry_count + 1):
+    for attempt in range(1, post_request.retry_count + 1):
         try:
             response = httpx.post(
                 pinned_request.target_url,
-                json=payload,
+                json=post_request.payload,
                 headers=pinned_request.headers,
                 timeout=WEBHOOK_DEFAULT_TIMEOUT_SECONDS,
             )
@@ -909,21 +914,23 @@ def _post_with_retry(
             )
             _logger.warning(
                 "Webhook POST to %r returned %d (attempt %d/%d)",
-                url,
+                post_request.url,
                 response.status_code,
                 attempt,
-                retry_count,
+                post_request.retry_count,
             )
         except httpx.RequestError as request_error:
             last_error = request_error
             _logger.warning(
                 "Webhook POST to %r failed (attempt %d/%d): %s",
-                url,
+                post_request.url,
                 attempt,
-                retry_count,
+                post_request.retry_count,
                 request_error,
             )
-    raise NotificationError(_WEBHOOK_SEND_ERROR.format(url=url, detail=last_error)) from last_error
+    raise NotificationError(
+        _WEBHOOK_SEND_ERROR.format(url=post_request.url, detail=last_error)
+    ) from last_error
 
 
 # ---------------------------------------------------------------------------
@@ -998,7 +1005,14 @@ def send_webhook_notification(
         raise NotificationError(_NO_WEBHOOK_URL_ERROR)
     pinned_ip = _validate_webhook_url(config.webhook_url, config.is_private_webhook_url_allowed)
     payload = _build_webhook_payload(config.webhook_type, request)
-    _post_with_retry(config.webhook_url, payload, config.webhook_retry_count, pinned_ip)
+    _post_with_retry(
+        _WebhookPostRequest(
+            url=config.webhook_url,
+            payload=payload,
+            retry_count=config.webhook_retry_count,
+            pinned_ip=pinned_ip,
+        )
+    )
     _logger.info(
         "Webhook notification delivered to %r (%s) for %s/%s",
         config.webhook_url,

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -925,9 +925,12 @@ def _post_with_retry(post_request: _WebhookPostRequest) -> None:
                 post_request.retry_count,
                 request_error,
             )
-    raise NotificationError(
+    final_error = NotificationError(
         _WEBHOOK_SEND_ERROR.format(url=post_request.url, detail=last_error)
-    ) from last_error
+    )
+    if last_error is not None:
+        raise final_error from last_error
+    raise final_error
 
 
 # ---------------------------------------------------------------------------

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -41,7 +41,7 @@ from email.mime.text import MIMEText
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 import httpx
 
@@ -112,7 +112,7 @@ _WEBHOOK_DNS_BLOCKED_ADDRESS_ERROR: str = (
 # Transport URL format used to pin the TCP connection to the IP resolved during
 # SSRF validation, preventing DNS rebinding between validation and request.
 _PINNED_HOST_HEADER: str = "Host"
-_PINNED_URL_SCHEME_HOST_TEMPLATE: str = "{scheme}://{hostname}"
+_CONTENT_TYPE_HEADER: str = "Content-Type"
 
 # IP networks blocked by SSRF protection when is_private_webhook_url_allowed=False.
 # Covers RFC1918 private ranges, link-local, loopback, CGNAT, cloud metadata,
@@ -796,13 +796,8 @@ def _build_pinned_url(url: str, pinned_ip: str) -> str:
         URL with hostname replaced by ``pinned_ip``.
     """
     parsed = urlparse(url)
-    original_prefix = _PINNED_URL_SCHEME_HOST_TEMPLATE.format(
-        scheme=parsed.scheme, hostname=parsed.hostname
-    )
-    pinned_prefix = _PINNED_URL_SCHEME_HOST_TEMPLATE.format(
-        scheme=parsed.scheme, hostname=pinned_ip
-    )
-    return url.replace(original_prefix, pinned_prefix, 1)
+    pinned_netloc = parsed.netloc.replace(parsed.hostname or "", pinned_ip, 1)
+    return urlunparse(parsed._replace(netloc=pinned_netloc))
 
 
 def _build_pinned_request_args(url: str, pinned_ip: str | None) -> _PinnedRequestArgs:
@@ -822,13 +817,13 @@ def _build_pinned_request_args(url: str, pinned_ip: str | None) -> _PinnedReques
     if pinned_ip is None:
         return _PinnedRequestArgs(
             target_url=url,
-            headers={"Content-Type": _WEBHOOK_CONTENT_TYPE},
+            headers={_CONTENT_TYPE_HEADER: _WEBHOOK_CONTENT_TYPE},
         )
     parsed = urlparse(url)
     return _PinnedRequestArgs(
         target_url=_build_pinned_url(url, pinned_ip),
         headers={
-            "Content-Type": _WEBHOOK_CONTENT_TYPE,
+            _CONTENT_TYPE_HEADER: _WEBHOOK_CONTENT_TYPE,
             _PINNED_HOST_HEADER: parsed.hostname or "",
         },
     )

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -113,6 +113,8 @@ _WEBHOOK_DNS_BLOCKED_ADDRESS_ERROR: str = (
 # SSRF validation, preventing DNS rebinding between validation and request.
 _PINNED_HOST_HEADER: str = "Host"
 _CONTENT_TYPE_HEADER: str = "Content-Type"
+_EMPTY_HOSTNAME: str = ""
+_SINGLE_HOSTNAME_REPLACEMENT_COUNT: int = 1
 
 # IP networks blocked by SSRF protection when is_private_webhook_url_allowed=False.
 # Covers RFC1918 private ranges, link-local, loopback, CGNAT, cloud metadata,
@@ -769,10 +771,10 @@ def _validate_webhook_url(
 
 
 @dataclass(frozen=True)
-class _PinnedRequestArgs:
+class _PinnedRequestArguments:
     """Pre-computed URL and headers for a TOCTOU-safe webhook POST.
 
-    Produced by ``_build_pinned_request_args`` and consumed by ``_post_with_retry``
+    Produced by ``_build_pinned_request_arguments`` and consumed by ``_post_with_retry``
     so that URL rewriting and header construction are isolated from the retry loop.
     """
 
@@ -783,24 +785,33 @@ class _PinnedRequestArgs:
 def _build_pinned_url(url: str, pinned_ip: str) -> str:
     """Rewrite ``url`` replacing its hostname with ``pinned_ip``.
 
-    Substitutes the scheme://hostname prefix so httpx connects to the
+    Substitutes the hostname in the netloc so httpx connects to the
     pre-resolved IP, preventing DNS rebinding between SSRF validation and
     delivery. The original hostname travels in the Host header (see
-    ``_build_pinned_request_args``) so TLS SNI and server routing are preserved.
+    ``_build_pinned_request_arguments``) so TLS SNI and server routing are preserved.
+
+    Note: IPv6 literal addresses in the URL (e.g. ``[::1]:443``) are out of
+    scope — SSRF validation blocks all private/loopback addresses before this
+    function is reached, so a valid pinned_ip will always be a public IPv4 address.
 
     Args:
         url: Original webhook URL.
         pinned_ip: IP address string returned by ``_validate_webhook_url``.
 
     Returns:
-        URL with hostname replaced by ``pinned_ip``.
+        URL with hostname replaced by ``pinned_ip``, or ``url`` unchanged if
+        the URL has no parseable hostname.
     """
     parsed = urlparse(url)
-    pinned_netloc = parsed.netloc.replace(parsed.hostname or "", pinned_ip, 1)
+    if not parsed.hostname:
+        return url
+    pinned_netloc = parsed.netloc.replace(
+        parsed.hostname, pinned_ip, _SINGLE_HOSTNAME_REPLACEMENT_COUNT
+    )
     return urlunparse(parsed._replace(netloc=pinned_netloc))
 
 
-def _build_pinned_request_args(url: str, pinned_ip: str | None) -> _PinnedRequestArgs:
+def _build_pinned_request_arguments(url: str, pinned_ip: str | None) -> _PinnedRequestArguments:
     """Build the target URL and headers for a webhook POST.
 
     When ``pinned_ip`` is provided, rewrites the URL to connect to the
@@ -812,19 +823,19 @@ def _build_pinned_request_args(url: str, pinned_ip: str | None) -> _PinnedReques
         pinned_ip: IP returned by ``_validate_webhook_url``, or None.
 
     Returns:
-        ``_PinnedRequestArgs`` with target_url and headers ready for httpx.
+        ``_PinnedRequestArguments`` with target_url and headers ready for httpx.
     """
     if pinned_ip is None:
-        return _PinnedRequestArgs(
+        return _PinnedRequestArguments(
             target_url=url,
             headers={_CONTENT_TYPE_HEADER: _WEBHOOK_CONTENT_TYPE},
         )
     parsed = urlparse(url)
-    return _PinnedRequestArgs(
+    return _PinnedRequestArguments(
         target_url=_build_pinned_url(url, pinned_ip),
         headers={
             _CONTENT_TYPE_HEADER: _WEBHOOK_CONTENT_TYPE,
-            _PINNED_HOST_HEADER: parsed.hostname or "",
+            _PINNED_HOST_HEADER: parsed.hostname or _EMPTY_HOSTNAME,
         },
     )
 
@@ -851,7 +862,7 @@ def _post_with_retry(
     Raises:
         NotificationError: If all attempts fail.
     """
-    request_args = _build_pinned_request_args(url, pinned_ip)
+    request_args = _build_pinned_request_arguments(url, pinned_ip)
     last_error: Exception | None = None
     for attempt in range(1, retry_count + 1):
         try:

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -109,6 +109,9 @@ _WEBHOOK_DNS_BLOCKED_ADDRESS_ERROR: str = (
     "ranges are blocked by default. "
     "Set is_private_webhook_url_allowed=True in NotificationConfig to allow self-hosted targets."
 )
+# Transport URL format used to pin the TCP connection to the IP resolved during
+# SSRF validation, preventing DNS rebinding between validation and request.
+_PINNED_TRANSPORT_URL: str = "https://{pinned_ip}"
 
 # IP networks blocked by SSRF protection when is_private_webhook_url_allowed=False.
 # Covers RFC1918 private ranges, link-local, loopback, CGNAT, cloud metadata,
@@ -705,8 +708,11 @@ def _reject_ssrf_resolved_addresses(  # phi-scan:ignore
             )
 
 
-def _validate_webhook_url(url: str, is_private_webhook_url_allowed: bool) -> None:
-    """Raise NotificationError if the webhook URL fails SSRF safety checks.
+def _validate_webhook_url(
+    url: str,
+    is_private_webhook_url_allowed: bool,
+) -> str | None:
+    """Validate the webhook URL against SSRF safety checks and return a pinned IP.
 
     Enforces four guards (1–2 always, 3–4 when is_private_webhook_url_allowed is False):
     1. Scheme must be 'https' — plaintext http is rejected.
@@ -716,11 +722,19 @@ def _validate_webhook_url(url: str, is_private_webhook_url_allowed: bool) -> Non
     4. Hostname, if a domain name, is resolved via DNS and every returned address
        is validated against the same blocked ranges (closes DNS-rebinding bypass).
 
+    Returns the first resolved IP address as a string so the caller can pin the
+    TCP connection to it, preventing DNS rebinding between validation and delivery.
+    Returns None when the hostname is already a literal IP (no resolution needed).
+
     Args:
         url: The webhook endpoint URL to validate.
         is_private_webhook_url_allowed: When True, skip both the literal-IP check
             and the DNS resolution check (opt-out for self-hosted targets on private
             networks).
+
+    Returns:
+        Pinned IP string to connect to, or None when is_private_webhook_url_allowed
+        is True or the hostname is already a literal IP address.
 
     Raises:
         NotificationError: If the URL fails any enabled check.
@@ -737,46 +751,75 @@ def _validate_webhook_url(url: str, is_private_webhook_url_allowed: bool) -> Non
             _WEBHOOK_MISSING_HOSTNAME_ERROR.format(url_hash=compute_value_hash(url))
         )
     if is_private_webhook_url_allowed:
-        return
+        return None
     try:
         address = ipaddress.ip_address(hostname)  # phi-scan:ignore
     except ValueError:
         resolved_addresses = _resolve_hostname_addresses(hostname)  # phi-scan:ignore
         _reject_ssrf_resolved_addresses(hostname, resolved_addresses)
-        return
+        return str(resolved_addresses[0])  # phi-scan:ignore
     if any(address in network for network in _BLOCKED_IP_NETWORKS):  # phi-scan:ignore
         raise NotificationError(
             _WEBHOOK_PRIVATE_IP_ERROR.format(
                 url_hash=compute_value_hash(url), address_hash=compute_value_hash(str(address))
             )
         )
+    return None
 
 
 def _post_with_retry(
     url: str,
     payload: dict[str, Any],
     retry_count: int,
+    pinned_ip: str | None = None,
 ) -> None:
     """POST a JSON payload to a URL with linear retry on failure.
 
     Uses ``httpx`` sync client. Retries on HTTP 4xx/5xx and on network errors.
     The final attempt raises ``NotificationError`` if still failing.
 
+    When ``pinned_ip`` is provided, the TCP connection is made directly to that
+    IP address with the original hostname in the Host header. This prevents DNS
+    rebinding between the SSRF validation step and the actual HTTP request
+    (TOCTOU mitigation).
+
     Args:
         url: The webhook endpoint URL.
         payload: JSON-serialisable payload dict.
         retry_count: Total number of attempts (1 = no retry).
+        pinned_ip: Pre-resolved IP to connect to directly. When None, httpx
+            resolves the hostname normally (used when is_private_webhook_url_allowed
+            is True or the hostname was already a literal IP).
 
     Raises:
         NotificationError: If all attempts fail.
     """
+    parsed = urlparse(url)
+    if pinned_ip is not None:
+        # Replace the hostname in the URL with the pre-resolved IP so httpx
+        # connects to the exact address validated during SSRF checks, preventing
+        # DNS rebinding between validation and delivery (TOCTOU mitigation).
+        # The original hostname is preserved in the Host header so TLS SNI and
+        # server-side routing continue to work correctly.
+        pinned_url = url.replace(
+            f"{parsed.scheme}://{parsed.hostname}",
+            _PINNED_TRANSPORT_URL.format(pinned_ip=pinned_ip),
+            1,
+        )
+        request_headers: dict[str, str] = {
+            "Content-Type": _WEBHOOK_CONTENT_TYPE,
+            "Host": parsed.hostname or "",
+        }
+    else:
+        pinned_url = url
+        request_headers = {"Content-Type": _WEBHOOK_CONTENT_TYPE}
     last_error: Exception | None = None
     for attempt in range(1, retry_count + 1):
         try:
             response = httpx.post(
-                url,
+                pinned_url,
                 json=payload,
-                headers={"Content-Type": _WEBHOOK_CONTENT_TYPE},
+                headers=request_headers,
                 timeout=WEBHOOK_DEFAULT_TIMEOUT_SECONDS,
             )
             if response.is_success:
@@ -873,9 +916,9 @@ def send_webhook_notification(
     """
     if not config.webhook_url:
         raise NotificationError(_NO_WEBHOOK_URL_ERROR)
-    _validate_webhook_url(config.webhook_url, config.is_private_webhook_url_allowed)
+    pinned_ip = _validate_webhook_url(config.webhook_url, config.is_private_webhook_url_allowed)
     payload = _build_webhook_payload(config.webhook_type, request)
-    _post_with_retry(config.webhook_url, payload, config.webhook_retry_count)
+    _post_with_retry(config.webhook_url, payload, config.webhook_retry_count, pinned_ip)
     _logger.info(
         "Webhook notification delivered to %r (%s) for %s/%s",
         config.webhook_url,

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -117,7 +117,6 @@ _WEBHOOK_BUILD_NO_HOSTNAME_ERROR: str = "cannot build pinned request: URL has no
 _IPV6_ADDRESS_COLON: str = ":"
 _IPV6_NETLOC_BRACKET_TEMPLATE: str = "[{hostname}]"
 _NETLOC_PORT_TEMPLATE: str = ":{port}"
-_EMPTY_PORT_SEGMENT: str = ""
 
 # IP networks blocked by SSRF protection when is_private_webhook_url_allowed=False.
 # Covers RFC1918 private ranges, link-local, loopback, CGNAT, cloud metadata,
@@ -837,12 +836,21 @@ def _rewrite_url_hostname_to_ip(parsed_webhook_url: ParseResult, pinned_ip: str)
         URL with hostname replaced by ``pinned_ip``.
     """
     pinned_netloc_host = _format_netloc_host_segment(pinned_ip)
-    port_segment = (
-        _NETLOC_PORT_TEMPLATE.format(port=parsed_webhook_url.port)
-        if parsed_webhook_url.port
-        else _EMPTY_PORT_SEGMENT
+    if parsed_webhook_url.port:
+        port_suffix = _NETLOC_PORT_TEMPLATE.format(port=parsed_webhook_url.port)
+        pinned_netloc = f"{pinned_netloc_host}{port_suffix}"
+    else:
+        pinned_netloc = pinned_netloc_host
+    return urlunparse(
+        (
+            parsed_webhook_url.scheme,
+            pinned_netloc,
+            parsed_webhook_url.path,
+            parsed_webhook_url.params,
+            parsed_webhook_url.query,
+            parsed_webhook_url.fragment,
+        )
     )
-    return urlunparse(parsed_webhook_url._replace(netloc=f"{pinned_netloc_host}{port_segment}"))
 
 
 def _build_pinned_webhook_request(url: str, pinned_ip: str | None) -> _PinnedWebhookRequest:

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -113,8 +113,10 @@ _WEBHOOK_DNS_BLOCKED_ADDRESS_ERROR: str = (
 # SSRF validation, preventing DNS rebinding between validation and request.
 _PINNED_HOST_HEADER: str = "Host"
 _CONTENT_TYPE_HEADER: str = "Content-Type"
-_EMPTY_HOSTNAME: str = ""
 _SINGLE_HOSTNAME_REPLACEMENT_COUNT: int = 1
+_MISSING_HOSTNAME_ERROR_MESSAGE: str = "cannot pin request: URL has no parseable hostname"
+_IPV6_ADDRESS_COLON: str = ":"
+_IPV6_NETLOC_BRACKET_TEMPLATE: str = "[{hostname}]"
 
 # IP networks blocked by SSRF protection when is_private_webhook_url_allowed=False.
 # Covers RFC1918 private ranges, link-local, loopback, CGNAT, cloud metadata,
@@ -779,7 +781,24 @@ class _PinnedRequestArguments:
     """
 
     target_url: str
-    headers: dict[str, str]
+    headers: MappingProxyType[str, str]
+
+
+def _netloc_host_segment(hostname: str) -> str:
+    """Return hostname as it appears in a URL netloc.
+
+    IPv6 addresses must be bracketed in netloc (e.g. ``[2001:db8::1]``);
+    IPv4 addresses and DNS names are used as-is.
+
+    Args:
+        hostname: Bare hostname or IP address string (no brackets).
+
+    Returns:
+        Hostname ready for insertion into a netloc string.
+    """
+    if _IPV6_ADDRESS_COLON in hostname:
+        return _IPV6_NETLOC_BRACKET_TEMPLATE.format(hostname=hostname)
+    return hostname
 
 
 def _build_pinned_url(url: str, pinned_ip: str) -> str:
@@ -789,24 +808,26 @@ def _build_pinned_url(url: str, pinned_ip: str) -> str:
     pre-resolved IP, preventing DNS rebinding between SSRF validation and
     delivery. The original hostname travels in the Host header (see
     ``_build_pinned_request_arguments``) so TLS SNI and server routing are preserved.
-
-    Note: IPv6 literal addresses in the URL (e.g. ``[::1]:443``) are out of
-    scope — SSRF validation blocks all private/loopback addresses before this
-    function is reached, so a valid pinned_ip will always be a public IPv4 address.
+    Both IPv4 and IPv6 pinned addresses are handled: IPv6 addresses are
+    bracketed in the netloc (e.g. ``[2001:db8::1]``).
 
     Args:
         url: Original webhook URL.
         pinned_ip: IP address string returned by ``_validate_webhook_url``.
 
     Returns:
-        URL with hostname replaced by ``pinned_ip``, or ``url`` unchanged if
-        the URL has no parseable hostname.
+        URL with hostname replaced by ``pinned_ip``.
+
+    Raises:
+        NotificationError: If the URL has no parseable hostname.
     """
     parsed = urlparse(url)
     if not parsed.hostname:
-        return url
+        raise NotificationError(_MISSING_HOSTNAME_ERROR_MESSAGE)
+    original_netloc_host = _netloc_host_segment(parsed.hostname)
+    pinned_netloc_host = _netloc_host_segment(pinned_ip)
     pinned_netloc = parsed.netloc.replace(
-        parsed.hostname, pinned_ip, _SINGLE_HOSTNAME_REPLACEMENT_COUNT
+        original_netloc_host, pinned_netloc_host, _SINGLE_HOSTNAME_REPLACEMENT_COUNT
     )
     return urlunparse(parsed._replace(netloc=pinned_netloc))
 
@@ -824,19 +845,25 @@ def _build_pinned_request_arguments(url: str, pinned_ip: str | None) -> _PinnedR
 
     Returns:
         ``_PinnedRequestArguments`` with target_url and headers ready for httpx.
+
+    Raises:
+        NotificationError: If pinned_ip is set but the URL has no parseable hostname.
     """
     if pinned_ip is None:
         return _PinnedRequestArguments(
             target_url=url,
-            headers={_CONTENT_TYPE_HEADER: _WEBHOOK_CONTENT_TYPE},
+            headers=MappingProxyType({_CONTENT_TYPE_HEADER: _WEBHOOK_CONTENT_TYPE}),
         )
     parsed = urlparse(url)
+    original_hostname = parsed.hostname
+    if not original_hostname:
+        raise NotificationError(_MISSING_HOSTNAME_ERROR_MESSAGE)
     return _PinnedRequestArguments(
         target_url=_build_pinned_url(url, pinned_ip),
-        headers={
+        headers=MappingProxyType({
             _CONTENT_TYPE_HEADER: _WEBHOOK_CONTENT_TYPE,
-            _PINNED_HOST_HEADER: parsed.hostname or _EMPTY_HOSTNAME,
-        },
+            _PINNED_HOST_HEADER: original_hostname,
+        }),
     )
 
 

--- a/phi_scan/notifier.py
+++ b/phi_scan/notifier.py
@@ -111,7 +111,8 @@ _WEBHOOK_DNS_BLOCKED_ADDRESS_ERROR: str = (
 )
 # Transport URL format used to pin the TCP connection to the IP resolved during
 # SSRF validation, preventing DNS rebinding between validation and request.
-_PINNED_TRANSPORT_URL: str = "https://{pinned_ip}"
+_PINNED_HOST_HEADER: str = "Host"
+_PINNED_URL_SCHEME_HOST_TEMPLATE: str = "{scheme}://{hostname}"
 
 # IP networks blocked by SSRF protection when is_private_webhook_url_allowed=False.
 # Covers RFC1918 private ranges, link-local, loopback, CGNAT, cloud metadata,
@@ -767,6 +768,72 @@ def _validate_webhook_url(
     return None
 
 
+@dataclass(frozen=True)
+class _PinnedRequestArgs:
+    """Pre-computed URL and headers for a TOCTOU-safe webhook POST.
+
+    Produced by ``_build_pinned_request_args`` and consumed by ``_post_with_retry``
+    so that URL rewriting and header construction are isolated from the retry loop.
+    """
+
+    target_url: str
+    headers: dict[str, str]
+
+
+def _build_pinned_url(url: str, pinned_ip: str) -> str:
+    """Rewrite ``url`` replacing its hostname with ``pinned_ip``.
+
+    Substitutes the scheme://hostname prefix so httpx connects to the
+    pre-resolved IP, preventing DNS rebinding between SSRF validation and
+    delivery. The original hostname travels in the Host header (see
+    ``_build_pinned_request_args``) so TLS SNI and server routing are preserved.
+
+    Args:
+        url: Original webhook URL.
+        pinned_ip: IP address string returned by ``_validate_webhook_url``.
+
+    Returns:
+        URL with hostname replaced by ``pinned_ip``.
+    """
+    parsed = urlparse(url)
+    original_prefix = _PINNED_URL_SCHEME_HOST_TEMPLATE.format(
+        scheme=parsed.scheme, hostname=parsed.hostname
+    )
+    pinned_prefix = _PINNED_URL_SCHEME_HOST_TEMPLATE.format(
+        scheme=parsed.scheme, hostname=pinned_ip
+    )
+    return url.replace(original_prefix, pinned_prefix, 1)
+
+
+def _build_pinned_request_args(url: str, pinned_ip: str | None) -> _PinnedRequestArgs:
+    """Build the target URL and headers for a webhook POST.
+
+    When ``pinned_ip`` is provided, rewrites the URL to connect to the
+    pre-resolved IP and adds a Host header with the original hostname (TOCTOU
+    mitigation). When None, the URL and headers are used as-is.
+
+    Args:
+        url: Webhook endpoint URL.
+        pinned_ip: IP returned by ``_validate_webhook_url``, or None.
+
+    Returns:
+        ``_PinnedRequestArgs`` with target_url and headers ready for httpx.
+    """
+    if pinned_ip is None:
+        return _PinnedRequestArgs(
+            target_url=url,
+            headers={"Content-Type": _WEBHOOK_CONTENT_TYPE},
+        )
+    parsed = urlparse(url)
+    return _PinnedRequestArgs(
+        target_url=_build_pinned_url(url, pinned_ip),
+        headers={
+            "Content-Type": _WEBHOOK_CONTENT_TYPE,
+            _PINNED_HOST_HEADER: parsed.hostname or "",
+        },
+    )
+
+
 def _post_with_retry(
     url: str,
     payload: dict[str, Any],
@@ -778,48 +845,25 @@ def _post_with_retry(
     Uses ``httpx`` sync client. Retries on HTTP 4xx/5xx and on network errors.
     The final attempt raises ``NotificationError`` if still failing.
 
-    When ``pinned_ip`` is provided, the TCP connection is made directly to that
-    IP address with the original hostname in the Host header. This prevents DNS
-    rebinding between the SSRF validation step and the actual HTTP request
-    (TOCTOU mitigation).
-
     Args:
         url: The webhook endpoint URL.
         payload: JSON-serialisable payload dict.
         retry_count: Total number of attempts (1 = no retry).
-        pinned_ip: Pre-resolved IP to connect to directly. When None, httpx
-            resolves the hostname normally (used when is_private_webhook_url_allowed
-            is True or the hostname was already a literal IP).
+        pinned_ip: Pre-resolved IP from ``_validate_webhook_url``. When set,
+            the TCP connection is pinned to this IP to prevent DNS rebinding
+            (TOCTOU mitigation). When None, httpx resolves the hostname normally.
 
     Raises:
         NotificationError: If all attempts fail.
     """
-    parsed = urlparse(url)
-    if pinned_ip is not None:
-        # Replace the hostname in the URL with the pre-resolved IP so httpx
-        # connects to the exact address validated during SSRF checks, preventing
-        # DNS rebinding between validation and delivery (TOCTOU mitigation).
-        # The original hostname is preserved in the Host header so TLS SNI and
-        # server-side routing continue to work correctly.
-        pinned_url = url.replace(
-            f"{parsed.scheme}://{parsed.hostname}",
-            _PINNED_TRANSPORT_URL.format(pinned_ip=pinned_ip),
-            1,
-        )
-        request_headers: dict[str, str] = {
-            "Content-Type": _WEBHOOK_CONTENT_TYPE,
-            "Host": parsed.hostname or "",
-        }
-    else:
-        pinned_url = url
-        request_headers = {"Content-Type": _WEBHOOK_CONTENT_TYPE}
+    request_args = _build_pinned_request_args(url, pinned_ip)
     last_error: Exception | None = None
     for attempt in range(1, retry_count + 1):
         try:
             response = httpx.post(
-                pinned_url,
+                request_args.target_url,
                 json=payload,
-                headers=request_headers,
+                headers=request_args.headers,
                 timeout=WEBHOOK_DEFAULT_TIMEOUT_SECONDS,
             )
             if response.is_success:

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -34,6 +34,7 @@ from phi_scan.exceptions import NotificationError
 from phi_scan.models import NotificationConfig, ScanFinding, ScanResult
 from phi_scan.notifier import (
     _FINDING_KEY_VALUE_HASH,  # noqa: PLC2701
+    _PINNED_HOST_HEADER,  # noqa: PLC2701
     NotificationRequest,
     _build_email_html_body,  # noqa: PLC2701
     _build_email_subject,
@@ -806,7 +807,7 @@ def test_validate_webhook_url_returns_none_when_private_allowed() -> None:
 
 def test_rewrite_url_hostname_to_ip_replaces_hostname() -> None:
     """_rewrite_url_hostname_to_ip must substitute the hostname with the pinned IP."""
-    pinned = _rewrite_url_hostname_to_ip(_DOMAIN_WEBHOOK_URL, _TEST_PINNED_IP)
+    pinned = _rewrite_url_hostname_to_ip(_DOMAIN_WEBHOOK_URL, _TEST_PINNED_IP, _DOMAIN_WEBHOOK_HOST)
     assert _TEST_PINNED_IP in pinned
     assert _DOMAIN_WEBHOOK_HOST not in pinned
 
@@ -814,7 +815,7 @@ def test_rewrite_url_hostname_to_ip_replaces_hostname() -> None:
 def test_build_pinned_webhook_request_sets_host_header() -> None:
     """_build_pinned_webhook_request must set Host header to the original hostname."""
     request_args = _build_pinned_webhook_request(_DOMAIN_WEBHOOK_URL, _TEST_PINNED_IP)
-    assert request_args.headers.get("Host") == _DOMAIN_WEBHOOK_HOST
+    assert request_args.headers.get(_PINNED_HOST_HEADER) == _DOMAIN_WEBHOOK_HOST
     assert _TEST_PINNED_IP in request_args.target_url
 
 
@@ -822,7 +823,7 @@ def test_build_pinned_webhook_request_returns_original_url_when_no_pin() -> None
     """_build_pinned_webhook_request must return original URL unchanged when pinned_ip is None."""
     request_args = _build_pinned_webhook_request(_DOMAIN_WEBHOOK_URL, None)
     assert request_args.target_url == _DOMAIN_WEBHOOK_URL
-    assert "Host" not in request_args.headers
+    assert _PINNED_HOST_HEADER not in request_args.headers
 
 
 def test_post_with_retry_pins_connection_to_resolved_ip() -> None:
@@ -850,13 +851,13 @@ def test_post_with_retry_pins_connection_to_resolved_ip() -> None:
     assert len(captured_calls) == 1
     assert _TEST_PINNED_IP in str(captured_calls[0][_CAPTURED_URL_KEY])
     assert _DOMAIN_WEBHOOK_HOST not in str(captured_calls[0][_CAPTURED_URL_KEY])
-    assert captured_calls[0][_CAPTURED_HEADERS_KEY].get("Host") == _DOMAIN_WEBHOOK_HOST
+    assert captured_calls[0][_CAPTURED_HEADERS_KEY].get(_PINNED_HOST_HEADER) == _DOMAIN_WEBHOOK_HOST
 
 
-def test_rewrite_url_hostname_to_ip_raises_when_no_hostname() -> None:
-    """_rewrite_url_hostname_to_ip must raise NotificationError when URL has no hostname."""
+def test_build_pinned_webhook_request_raises_when_no_hostname() -> None:
+    """_build_pinned_webhook_request must raise NotificationError when URL has no hostname."""
     with pytest.raises(NotificationError):
-        _rewrite_url_hostname_to_ip("file:///local/path", _TEST_PINNED_IP)
+        _build_pinned_webhook_request("file:///local/path", _TEST_PINNED_IP)
 
 
 _TEST_IPV6_HOST: str = "2001:db8::1"
@@ -865,7 +866,7 @@ _TEST_IPV6_WEBHOOK_URL: str = f"https://[{_TEST_IPV6_HOST}]:8443/notify"
 
 def test_rewrite_url_hostname_to_ip_handles_ipv6_url() -> None:
     """_rewrite_url_hostname_to_ip must produce a valid URL when the original host is IPv6."""
-    pinned = _rewrite_url_hostname_to_ip(_TEST_IPV6_WEBHOOK_URL, _TEST_PINNED_IP)
+    pinned = _rewrite_url_hostname_to_ip(_TEST_IPV6_WEBHOOK_URL, _TEST_PINNED_IP, _TEST_IPV6_HOST)
     assert _TEST_PINNED_IP in pinned
     assert _TEST_IPV6_HOST not in pinned
     assert ":8443" in pinned

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -87,6 +87,7 @@ _SMTP_ENV_USER: str = "PHI_SCAN_SMTP_USER"
 _SMTP_ENV_PASSWORD: str = "PHI_SCAN_SMTP_PASSWORD"
 _TEST_PINNED_IP: str = "93.184.216.34"  # example.com public IP — safe for test use
 _DOMAIN_WEBHOOK_HOST: str = "hooks.example.com"
+_HOOKS_WEBHOOK_URL: str = f"https://{_DOMAIN_WEBHOOK_HOST}/notify"
 
 
 # ---------------------------------------------------------------------------
@@ -804,25 +805,22 @@ def test_validate_webhook_url_returns_none_when_private_allowed() -> None:
 
 def test_build_pinned_url_replaces_hostname_with_ip() -> None:
     """_build_pinned_url must substitute the hostname with the pinned IP."""
-    original_url = f"https://{_DOMAIN_WEBHOOK_HOST}/notify"
-    pinned = _build_pinned_url(original_url, _TEST_PINNED_IP)
+    pinned = _build_pinned_url(_HOOKS_WEBHOOK_URL, _TEST_PINNED_IP)
     assert _TEST_PINNED_IP in pinned
     assert _DOMAIN_WEBHOOK_HOST not in pinned
 
 
 def test_build_pinned_request_args_sets_host_header() -> None:
     """_build_pinned_request_args must set Host header to the original hostname."""
-    original_url = f"https://{_DOMAIN_WEBHOOK_HOST}/notify"
-    request_args = _build_pinned_request_args(original_url, _TEST_PINNED_IP)
+    request_args = _build_pinned_request_args(_HOOKS_WEBHOOK_URL, _TEST_PINNED_IP)
     assert request_args.headers.get("Host") == _DOMAIN_WEBHOOK_HOST
     assert _TEST_PINNED_IP in request_args.target_url
 
 
 def test_build_pinned_request_args_returns_original_url_when_no_pin() -> None:
     """_build_pinned_request_args must return the original URL unchanged when pinned_ip is None."""
-    original_url = f"https://{_DOMAIN_WEBHOOK_HOST}/notify"
-    request_args = _build_pinned_request_args(original_url, None)
-    assert request_args.target_url == original_url
+    request_args = _build_pinned_request_args(_HOOKS_WEBHOOK_URL, None)
+    assert request_args.target_url == _HOOKS_WEBHOOK_URL
     assert "Host" not in request_args.headers
 
 
@@ -838,7 +836,7 @@ def test_post_with_retry_pins_connection_to_resolved_ip() -> None:
 
     with patch("phi_scan.notifier.httpx.post", side_effect=stub_post):
         _post_with_retry(
-            f"https://{_DOMAIN_WEBHOOK_HOST}/notify",
+            _HOOKS_WEBHOOK_URL,
             payload={"text": "test"},
             retry_count=1,
             pinned_ip=_TEST_PINNED_IP,

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -19,6 +19,7 @@ import socket
 from pathlib import Path
 from types import MappingProxyType
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 import httpx
 import pytest
@@ -807,7 +808,7 @@ def test_validate_webhook_url_returns_none_when_private_allowed() -> None:
 
 def test_rewrite_url_hostname_to_ip_replaces_hostname() -> None:
     """_rewrite_url_hostname_to_ip must substitute the hostname with the pinned IP."""
-    pinned = _rewrite_url_hostname_to_ip(_DOMAIN_WEBHOOK_URL, _TEST_PINNED_IP, _DOMAIN_WEBHOOK_HOST)
+    pinned = _rewrite_url_hostname_to_ip(urlparse(_DOMAIN_WEBHOOK_URL), _TEST_PINNED_IP)
     assert _TEST_PINNED_IP in pinned
     assert _DOMAIN_WEBHOOK_HOST not in pinned
 
@@ -866,7 +867,7 @@ _TEST_IPV6_WEBHOOK_URL: str = f"https://[{_TEST_IPV6_HOST}]:8443/notify"
 
 def test_rewrite_url_hostname_to_ip_handles_ipv6_url() -> None:
     """_rewrite_url_hostname_to_ip must produce a valid URL when the original host is IPv6."""
-    pinned = _rewrite_url_hostname_to_ip(_TEST_IPV6_WEBHOOK_URL, _TEST_PINNED_IP, _TEST_IPV6_HOST)
+    pinned = _rewrite_url_hostname_to_ip(urlparse(_TEST_IPV6_WEBHOOK_URL), _TEST_PINNED_IP)
     assert _TEST_PINNED_IP in pinned
     assert _TEST_IPV6_HOST not in pinned
     assert ":8443" in pinned

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -38,8 +38,7 @@ from phi_scan.notifier import (
     _build_email_html_body,  # noqa: PLC2701
     _build_email_subject,
     _build_generic_payload,
-    _build_pinned_request_arguments,  # noqa: PLC2701
-    _build_pinned_url,  # noqa: PLC2701
+    _build_pinned_webhook_request,  # noqa: PLC2701
     _build_slack_payload,
     _build_teams_payload,
     _build_webhook_payload,
@@ -48,6 +47,7 @@ from phi_scan.notifier import (
     _post_with_retry,  # noqa: PLC2701
     _reject_ssrf_resolved_addresses,  # noqa: PLC2701
     _resolve_hostname_addresses,  # noqa: PLC2701
+    _rewrite_url_hostname_to_ip,  # noqa: PLC2701
     _validate_webhook_url,  # noqa: PLC2701
     send_email_notification,
     send_webhook_notification,
@@ -745,6 +745,7 @@ def test_validate_webhook_url_private_ip_error_does_not_expose_raw_url() -> None
 # _reject_ssrf_resolved_addresses
 # ---------------------------------------------------------------------------
 
+
 def test_validate_webhook_url_blocks_hostname_resolving_to_loopback() -> None:
     """_validate_webhook_url must block a hostname that resolves to 127.0.0.1."""
     with patch("phi_scan.notifier._resolve_hostname_addresses") as stub_resolve:
@@ -800,23 +801,23 @@ def test_validate_webhook_url_returns_none_when_private_allowed() -> None:
     assert pinned_ip is None
 
 
-def test_build_pinned_url_replaces_hostname_with_ip() -> None:
-    """_build_pinned_url must substitute the hostname with the pinned IP."""
-    pinned = _build_pinned_url(_DOMAIN_WEBHOOK_URL, _TEST_PINNED_IP)
+def test_rewrite_url_hostname_to_ip_replaces_hostname() -> None:
+    """_rewrite_url_hostname_to_ip must substitute the hostname with the pinned IP."""
+    pinned = _rewrite_url_hostname_to_ip(_DOMAIN_WEBHOOK_URL, _TEST_PINNED_IP)
     assert _TEST_PINNED_IP in pinned
     assert _DOMAIN_WEBHOOK_HOST not in pinned
 
 
-def test_build_pinned_request_arguments_sets_host_header() -> None:
-    """_build_pinned_request_arguments must set Host header to the original hostname."""
-    request_args = _build_pinned_request_arguments(_DOMAIN_WEBHOOK_URL, _TEST_PINNED_IP)
+def test_build_pinned_webhook_request_sets_host_header() -> None:
+    """_build_pinned_webhook_request must set Host header to the original hostname."""
+    request_args = _build_pinned_webhook_request(_DOMAIN_WEBHOOK_URL, _TEST_PINNED_IP)
     assert request_args.headers.get("Host") == _DOMAIN_WEBHOOK_HOST
     assert _TEST_PINNED_IP in request_args.target_url
 
 
-def test_build_pinned_request_arguments_returns_original_url_when_no_pin() -> None:
-    """_build_pinned_request_arguments must return original URL unchanged when pinned_ip is None."""
-    request_args = _build_pinned_request_arguments(_DOMAIN_WEBHOOK_URL, None)
+def test_build_pinned_webhook_request_returns_original_url_when_no_pin() -> None:
+    """_build_pinned_webhook_request must return original URL unchanged when pinned_ip is None."""
+    request_args = _build_pinned_webhook_request(_DOMAIN_WEBHOOK_URL, None)
     assert request_args.target_url == _DOMAIN_WEBHOOK_URL
     assert "Host" not in request_args.headers
 
@@ -845,10 +846,10 @@ def test_post_with_retry_pins_connection_to_resolved_ip() -> None:
     assert captured_calls[0]["headers"].get("Host") == _DOMAIN_WEBHOOK_HOST
 
 
-def test_build_pinned_url_raises_when_hostname_is_missing() -> None:
-    """_build_pinned_url must raise NotificationError for a URL with no parseable hostname."""
+def test_rewrite_url_hostname_to_ip_raises_when_no_hostname() -> None:
+    """_rewrite_url_hostname_to_ip must raise NotificationError when URL has no hostname."""
     with pytest.raises(NotificationError):
-        _build_pinned_url("file:///local/path", _TEST_PINNED_IP)
+        _rewrite_url_hostname_to_ip("file:///local/path", _TEST_PINNED_IP)
 
 
 _TEST_IPV6_HOST: str = "2001:db8::1"
@@ -856,9 +857,9 @@ _TEST_IPV6_WEBHOOK_URL: str = f"https://[{_TEST_IPV6_HOST}]:8443/notify"
 _TEST_IPV4_PINNED_IP: str = "93.184.216.34"
 
 
-def test_build_pinned_url_handles_ipv6_url() -> None:
-    """_build_pinned_url must produce a valid URL when pinning an IPv6 address."""
-    pinned = _build_pinned_url(_TEST_IPV6_WEBHOOK_URL, _TEST_IPV4_PINNED_IP)
+def test_rewrite_url_hostname_to_ip_handles_ipv6_url() -> None:
+    """_rewrite_url_hostname_to_ip must produce a valid URL when the original host is IPv6."""
+    pinned = _rewrite_url_hostname_to_ip(_TEST_IPV6_WEBHOOK_URL, _TEST_IPV4_PINNED_IP)
     assert _TEST_IPV4_PINNED_IP in pinned
     assert _TEST_IPV6_HOST not in pinned
     assert ":8443" in pinned

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -49,6 +49,7 @@ from phi_scan.notifier import (
     _resolve_hostname_addresses,  # noqa: PLC2701
     _rewrite_url_hostname_to_ip,  # noqa: PLC2701
     _validate_webhook_url,  # noqa: PLC2701
+    _WebhookPostRequest,  # noqa: PLC2701
     send_email_notification,
     send_webhook_notification,
 )
@@ -88,6 +89,8 @@ _SMTP_ENV_PASSWORD: str = "PHI_SCAN_SMTP_PASSWORD"
 _TEST_PINNED_IP: str = "93.184.216.34"  # example.com public IP — safe for test use
 _DOMAIN_WEBHOOK_HOST: str = "hooks.example.com"
 _DOMAIN_WEBHOOK_URL: str = f"https://{_DOMAIN_WEBHOOK_HOST}/notify"
+_CAPTURED_URL_KEY: str = "url"
+_CAPTURED_HEADERS_KEY: str = "headers"
 
 
 # ---------------------------------------------------------------------------
@@ -827,18 +830,27 @@ def test_post_with_retry_pins_connection_to_resolved_ip() -> None:
     captured_calls: list[dict[str, object]] = []
 
     def stub_post(url: str, **kwargs: object) -> object:
-        captured_calls.append({"url": url, "headers": kwargs.get("headers", {})})
+        captured_calls.append(
+            {_CAPTURED_URL_KEY: url, _CAPTURED_HEADERS_KEY: kwargs.get("headers", {})}
+        )
         mock_response = MagicMock()
         mock_response.is_success = True
         return mock_response
 
     with patch("phi_scan.notifier.httpx.post", side_effect=stub_post):
-        _post_with_retry(_DOMAIN_WEBHOOK_URL, {"text": "test"}, 1, pinned_ip=_TEST_PINNED_IP)
+        _post_with_retry(
+            _WebhookPostRequest(
+                url=_DOMAIN_WEBHOOK_URL,
+                payload={"text": "test"},
+                retry_count=1,
+                pinned_ip=_TEST_PINNED_IP,
+            )
+        )
 
     assert len(captured_calls) == 1
-    assert _TEST_PINNED_IP in str(captured_calls[0]["url"])
-    assert _DOMAIN_WEBHOOK_HOST not in str(captured_calls[0]["url"])
-    assert captured_calls[0]["headers"].get("Host") == _DOMAIN_WEBHOOK_HOST
+    assert _TEST_PINNED_IP in str(captured_calls[0][_CAPTURED_URL_KEY])
+    assert _DOMAIN_WEBHOOK_HOST not in str(captured_calls[0][_CAPTURED_URL_KEY])
+    assert captured_calls[0][_CAPTURED_HEADERS_KEY].get("Host") == _DOMAIN_WEBHOOK_HOST
 
 
 def test_rewrite_url_hostname_to_ip_raises_when_no_hostname() -> None:

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -833,12 +833,7 @@ def test_post_with_retry_pins_connection_to_resolved_ip() -> None:
         return mock_response
 
     with patch("phi_scan.notifier.httpx.post", side_effect=stub_post):
-        _post_with_retry(
-            _DOMAIN_WEBHOOK_URL,
-            payload={"text": "test"},
-            retry_count=1,
-            pinned_ip=_TEST_PINNED_IP,
-        )
+        _post_with_retry(_DOMAIN_WEBHOOK_URL, {"text": "test"}, 1, pinned_ip=_TEST_PINNED_IP)
 
     assert len(captured_calls) == 1
     assert _TEST_PINNED_IP in str(captured_calls[0]["url"])
@@ -854,13 +849,12 @@ def test_rewrite_url_hostname_to_ip_raises_when_no_hostname() -> None:
 
 _TEST_IPV6_HOST: str = "2001:db8::1"
 _TEST_IPV6_WEBHOOK_URL: str = f"https://[{_TEST_IPV6_HOST}]:8443/notify"
-_TEST_IPV4_PINNED_IP: str = "93.184.216.34"
 
 
 def test_rewrite_url_hostname_to_ip_handles_ipv6_url() -> None:
     """_rewrite_url_hostname_to_ip must produce a valid URL when the original host is IPv6."""
-    pinned = _rewrite_url_hostname_to_ip(_TEST_IPV6_WEBHOOK_URL, _TEST_IPV4_PINNED_IP)
-    assert _TEST_IPV4_PINNED_IP in pinned
+    pinned = _rewrite_url_hostname_to_ip(_TEST_IPV6_WEBHOOK_URL, _TEST_PINNED_IP)
+    assert _TEST_PINNED_IP in pinned
     assert _TEST_IPV6_HOST not in pinned
     assert ":8443" in pinned
 

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -38,7 +38,7 @@ from phi_scan.notifier import (
     _build_email_html_body,  # noqa: PLC2701
     _build_email_subject,
     _build_generic_payload,
-    _build_pinned_request_args,  # noqa: PLC2701
+    _build_pinned_request_arguments,  # noqa: PLC2701
     _build_pinned_url,  # noqa: PLC2701
     _build_slack_payload,
     _build_teams_payload,
@@ -810,16 +810,16 @@ def test_build_pinned_url_replaces_hostname_with_ip() -> None:
     assert _DOMAIN_WEBHOOK_HOST not in pinned
 
 
-def test_build_pinned_request_args_sets_host_header() -> None:
-    """_build_pinned_request_args must set Host header to the original hostname."""
-    request_args = _build_pinned_request_args(_HOOKS_WEBHOOK_URL, _TEST_PINNED_IP)
+def test_build_pinned_request_arguments_sets_host_header() -> None:
+    """_build_pinned_request_arguments must set Host header to the original hostname."""
+    request_args = _build_pinned_request_arguments(_HOOKS_WEBHOOK_URL, _TEST_PINNED_IP)
     assert request_args.headers.get("Host") == _DOMAIN_WEBHOOK_HOST
     assert _TEST_PINNED_IP in request_args.target_url
 
 
-def test_build_pinned_request_args_returns_original_url_when_no_pin() -> None:
-    """_build_pinned_request_args must return the original URL unchanged when pinned_ip is None."""
-    request_args = _build_pinned_request_args(_HOOKS_WEBHOOK_URL, None)
+def test_build_pinned_request_arguments_returns_original_url_when_no_pin() -> None:
+    """_build_pinned_request_arguments must return original URL unchanged when pinned_ip is None."""
+    request_args = _build_pinned_request_arguments(_HOOKS_WEBHOOK_URL, None)
     assert request_args.target_url == _HOOKS_WEBHOOK_URL
     assert "Host" not in request_args.headers
 

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -43,6 +43,7 @@ from phi_scan.notifier import (
     _build_webhook_payload,
     _derive_webhook_scan_summary,  # noqa: PLC2701
     _get_smtp_credentials,
+    _post_with_retry,  # noqa: PLC2701
     _reject_ssrf_resolved_addresses,  # noqa: PLC2701
     _resolve_hostname_addresses,  # noqa: PLC2701
     _validate_webhook_url,  # noqa: PLC2701
@@ -778,6 +779,47 @@ def test_validate_webhook_url_skips_dns_when_private_allowed() -> None:
     with patch("phi_scan.notifier._resolve_hostname_addresses") as stub_resolve:
         _validate_webhook_url(_DOMAIN_WEBHOOK_URL, is_private_webhook_url_allowed=True)
         stub_resolve.assert_not_called()
+
+
+def test_validate_webhook_url_returns_pinned_ip_for_domain() -> None:
+    """_validate_webhook_url must return the first resolved IP for TOCTOU pinning."""
+    resolved_ip = ipaddress.ip_address("93.184.216.34")
+    with patch(
+        "phi_scan.notifier._resolve_hostname_addresses",
+        return_value=[resolved_ip],
+    ):
+        pinned_ip = _validate_webhook_url(_DOMAIN_WEBHOOK_URL, is_private_webhook_url_allowed=False)
+    assert pinned_ip == str(resolved_ip)
+
+
+def test_validate_webhook_url_returns_none_when_private_allowed() -> None:
+    """_validate_webhook_url must return None when SSRF checks are skipped."""
+    pinned_ip = _validate_webhook_url(_PRIVATE_IP_WEBHOOK_URL, is_private_webhook_url_allowed=True)
+    assert pinned_ip is None
+
+
+def test_post_with_retry_pins_connection_to_resolved_ip() -> None:
+    """_post_with_retry must rewrite the URL to the pinned IP and set the Host header."""
+    captured_calls: list[dict[str, object]] = []
+
+    def stub_post(url: str, **kwargs: object) -> object:
+        captured_calls.append({"url": url, "headers": kwargs.get("headers", {})})
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        return mock_response
+
+    with patch("phi_scan.notifier.httpx.post", side_effect=stub_post):
+        _post_with_retry(
+            "https://hooks.example.com/notify",
+            payload={"text": "test"},
+            retry_count=1,
+            pinned_ip="93.184.216.34",
+        )
+
+    assert len(captured_calls) == 1
+    assert "93.184.216.34" in str(captured_calls[0]["url"])
+    assert "hooks.example.com" not in str(captured_calls[0]["url"])
+    assert captured_calls[0]["headers"].get("Host") == "hooks.example.com"
 
 
 def test_resolve_hostname_addresses_raises_on_gaierror() -> None:

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -38,6 +38,8 @@ from phi_scan.notifier import (
     _build_email_html_body,  # noqa: PLC2701
     _build_email_subject,
     _build_generic_payload,
+    _build_pinned_request_args,  # noqa: PLC2701
+    _build_pinned_url,  # noqa: PLC2701
     _build_slack_payload,
     _build_teams_payload,
     _build_webhook_payload,
@@ -83,6 +85,8 @@ _ZERO_FINDINGS: int = 0
 _ONE_FINDING: int = 1
 _SMTP_ENV_USER: str = "PHI_SCAN_SMTP_USER"
 _SMTP_ENV_PASSWORD: str = "PHI_SCAN_SMTP_PASSWORD"
+_TEST_PINNED_IP: str = "93.184.216.34"  # example.com public IP — safe for test use
+_DOMAIN_WEBHOOK_HOST: str = "hooks.example.com"
 
 
 # ---------------------------------------------------------------------------
@@ -550,7 +554,7 @@ def test_send_webhook_succeeds_on_http_200() -> None:
     with (
         patch(
             "phi_scan.notifier._resolve_hostname_addresses",
-            return_value=[ipaddress.ip_address("93.184.216.34")],
+            return_value=[ipaddress.ip_address(_TEST_PINNED_IP)],
         ),
         patch("httpx.post", return_value=mock_response),
     ):
@@ -609,7 +613,7 @@ def test_send_webhook_retries_on_failure() -> None:
     with (
         patch(
             "phi_scan.notifier._resolve_hostname_addresses",
-            return_value=[ipaddress.ip_address("93.184.216.34")],
+            return_value=[ipaddress.ip_address(_TEST_PINNED_IP)],
         ),
         patch("httpx.post", return_value=mock_response) as mock_post,
     ):
@@ -653,7 +657,7 @@ def test_validate_webhook_url_accepts_https() -> None:
     """_validate_webhook_url must not raise for a valid https URL with a public IP."""
     with patch(
         "phi_scan.notifier._resolve_hostname_addresses",
-        return_value=[ipaddress.ip_address("93.184.216.34")],
+        return_value=[ipaddress.ip_address(_TEST_PINNED_IP)],
     ):
         _validate_webhook_url(_SAMPLE_WEBHOOK_URL, is_private_webhook_url_allowed=False)
 
@@ -783,7 +787,7 @@ def test_validate_webhook_url_skips_dns_when_private_allowed() -> None:
 
 def test_validate_webhook_url_returns_pinned_ip_for_domain() -> None:
     """_validate_webhook_url must return the first resolved IP for TOCTOU pinning."""
-    resolved_ip = ipaddress.ip_address("93.184.216.34")
+    resolved_ip = ipaddress.ip_address(_TEST_PINNED_IP)
     with patch(
         "phi_scan.notifier._resolve_hostname_addresses",
         return_value=[resolved_ip],
@@ -798,6 +802,30 @@ def test_validate_webhook_url_returns_none_when_private_allowed() -> None:
     assert pinned_ip is None
 
 
+def test_build_pinned_url_replaces_hostname_with_ip() -> None:
+    """_build_pinned_url must substitute the hostname with the pinned IP."""
+    original_url = f"https://{_DOMAIN_WEBHOOK_HOST}/notify"
+    pinned = _build_pinned_url(original_url, _TEST_PINNED_IP)
+    assert _TEST_PINNED_IP in pinned
+    assert _DOMAIN_WEBHOOK_HOST not in pinned
+
+
+def test_build_pinned_request_args_sets_host_header() -> None:
+    """_build_pinned_request_args must set Host header to the original hostname."""
+    original_url = f"https://{_DOMAIN_WEBHOOK_HOST}/notify"
+    request_args = _build_pinned_request_args(original_url, _TEST_PINNED_IP)
+    assert request_args.headers.get("Host") == _DOMAIN_WEBHOOK_HOST
+    assert _TEST_PINNED_IP in request_args.target_url
+
+
+def test_build_pinned_request_args_returns_original_url_when_no_pin() -> None:
+    """_build_pinned_request_args must return the original URL unchanged when pinned_ip is None."""
+    original_url = f"https://{_DOMAIN_WEBHOOK_HOST}/notify"
+    request_args = _build_pinned_request_args(original_url, None)
+    assert request_args.target_url == original_url
+    assert "Host" not in request_args.headers
+
+
 def test_post_with_retry_pins_connection_to_resolved_ip() -> None:
     """_post_with_retry must rewrite the URL to the pinned IP and set the Host header."""
     captured_calls: list[dict[str, object]] = []
@@ -810,16 +838,16 @@ def test_post_with_retry_pins_connection_to_resolved_ip() -> None:
 
     with patch("phi_scan.notifier.httpx.post", side_effect=stub_post):
         _post_with_retry(
-            "https://hooks.example.com/notify",
+            f"https://{_DOMAIN_WEBHOOK_HOST}/notify",
             payload={"text": "test"},
             retry_count=1,
-            pinned_ip="93.184.216.34",
+            pinned_ip=_TEST_PINNED_IP,
         )
 
     assert len(captured_calls) == 1
-    assert "93.184.216.34" in str(captured_calls[0]["url"])
-    assert "hooks.example.com" not in str(captured_calls[0]["url"])
-    assert captured_calls[0]["headers"].get("Host") == "hooks.example.com"
+    assert _TEST_PINNED_IP in str(captured_calls[0]["url"])
+    assert _DOMAIN_WEBHOOK_HOST not in str(captured_calls[0]["url"])
+    assert captured_calls[0]["headers"].get("Host") == _DOMAIN_WEBHOOK_HOST
 
 
 def test_resolve_hostname_addresses_raises_on_gaierror() -> None:
@@ -831,7 +859,7 @@ def test_resolve_hostname_addresses_raises_on_gaierror() -> None:
 
 def test_reject_ssrf_resolved_addresses_passes_for_public_ip() -> None:
     """_reject_ssrf_resolved_addresses must not raise for a public IP address."""
-    _reject_ssrf_resolved_addresses("example.com", [ipaddress.ip_address("93.184.216.34")])
+    _reject_ssrf_resolved_addresses("example.com", [ipaddress.ip_address(_TEST_PINNED_IP)])
 
 
 def test_reject_ssrf_resolved_addresses_blocks_private_ip() -> None:

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -87,7 +87,7 @@ _SMTP_ENV_USER: str = "PHI_SCAN_SMTP_USER"
 _SMTP_ENV_PASSWORD: str = "PHI_SCAN_SMTP_PASSWORD"
 _TEST_PINNED_IP: str = "93.184.216.34"  # example.com public IP — safe for test use
 _DOMAIN_WEBHOOK_HOST: str = "hooks.example.com"
-_HOOKS_WEBHOOK_URL: str = f"https://{_DOMAIN_WEBHOOK_HOST}/notify"
+_DOMAIN_WEBHOOK_URL: str = f"https://{_DOMAIN_WEBHOOK_HOST}/notify"
 
 
 # ---------------------------------------------------------------------------
@@ -745,9 +745,6 @@ def test_validate_webhook_url_private_ip_error_does_not_expose_raw_url() -> None
 # _reject_ssrf_resolved_addresses
 # ---------------------------------------------------------------------------
 
-_DOMAIN_WEBHOOK_URL: str = "https://internal.example.com/hook"
-
-
 def test_validate_webhook_url_blocks_hostname_resolving_to_loopback() -> None:
     """_validate_webhook_url must block a hostname that resolves to 127.0.0.1."""
     with patch("phi_scan.notifier._resolve_hostname_addresses") as stub_resolve:
@@ -805,22 +802,22 @@ def test_validate_webhook_url_returns_none_when_private_allowed() -> None:
 
 def test_build_pinned_url_replaces_hostname_with_ip() -> None:
     """_build_pinned_url must substitute the hostname with the pinned IP."""
-    pinned = _build_pinned_url(_HOOKS_WEBHOOK_URL, _TEST_PINNED_IP)
+    pinned = _build_pinned_url(_DOMAIN_WEBHOOK_URL, _TEST_PINNED_IP)
     assert _TEST_PINNED_IP in pinned
     assert _DOMAIN_WEBHOOK_HOST not in pinned
 
 
 def test_build_pinned_request_arguments_sets_host_header() -> None:
     """_build_pinned_request_arguments must set Host header to the original hostname."""
-    request_args = _build_pinned_request_arguments(_HOOKS_WEBHOOK_URL, _TEST_PINNED_IP)
+    request_args = _build_pinned_request_arguments(_DOMAIN_WEBHOOK_URL, _TEST_PINNED_IP)
     assert request_args.headers.get("Host") == _DOMAIN_WEBHOOK_HOST
     assert _TEST_PINNED_IP in request_args.target_url
 
 
 def test_build_pinned_request_arguments_returns_original_url_when_no_pin() -> None:
     """_build_pinned_request_arguments must return original URL unchanged when pinned_ip is None."""
-    request_args = _build_pinned_request_arguments(_HOOKS_WEBHOOK_URL, None)
-    assert request_args.target_url == _HOOKS_WEBHOOK_URL
+    request_args = _build_pinned_request_arguments(_DOMAIN_WEBHOOK_URL, None)
+    assert request_args.target_url == _DOMAIN_WEBHOOK_URL
     assert "Host" not in request_args.headers
 
 
@@ -836,7 +833,7 @@ def test_post_with_retry_pins_connection_to_resolved_ip() -> None:
 
     with patch("phi_scan.notifier.httpx.post", side_effect=stub_post):
         _post_with_retry(
-            _HOOKS_WEBHOOK_URL,
+            _DOMAIN_WEBHOOK_URL,
             payload={"text": "test"},
             retry_count=1,
             pinned_ip=_TEST_PINNED_IP,
@@ -846,6 +843,25 @@ def test_post_with_retry_pins_connection_to_resolved_ip() -> None:
     assert _TEST_PINNED_IP in str(captured_calls[0]["url"])
     assert _DOMAIN_WEBHOOK_HOST not in str(captured_calls[0]["url"])
     assert captured_calls[0]["headers"].get("Host") == _DOMAIN_WEBHOOK_HOST
+
+
+def test_build_pinned_url_raises_when_hostname_is_missing() -> None:
+    """_build_pinned_url must raise NotificationError for a URL with no parseable hostname."""
+    with pytest.raises(NotificationError):
+        _build_pinned_url("file:///local/path", _TEST_PINNED_IP)
+
+
+_TEST_IPV6_HOST: str = "2001:db8::1"
+_TEST_IPV6_WEBHOOK_URL: str = f"https://[{_TEST_IPV6_HOST}]:8443/notify"
+_TEST_IPV4_PINNED_IP: str = "93.184.216.34"
+
+
+def test_build_pinned_url_handles_ipv6_url() -> None:
+    """_build_pinned_url must produce a valid URL when pinning an IPv6 address."""
+    pinned = _build_pinned_url(_TEST_IPV6_WEBHOOK_URL, _TEST_IPV4_PINNED_IP)
+    assert _TEST_IPV4_PINNED_IP in pinned
+    assert _TEST_IPV6_HOST not in pinned
+    assert ":8443" in pinned
 
 
 def test_resolve_hostname_addresses_raises_on_gaierror() -> None:


### PR DESCRIPTION
## Summary
- **hashing.py**: `StructuredFindingRequest.__post_init__` now validates `value_hash` against `string.hexdigits.lower()` — rejects uppercase hex that would previously pass. SHA-256 `hexdigest()` always produces lowercase so this enforces the documented contract.
- **notifier.py**: `_validate_webhook_url` now returns the first resolved IP. `_post_with_retry` accepts a `pinned_ip` parameter and rewrites the request URL to connect directly to that IP with the original hostname in the `Host` header, eliminating the TOCTOU window between DNS validation and HTTP delivery.
- **tests/test_notifier.py**: three new tests covering the pinned IP return value, None return when `is_private_webhook_url_allowed=True`, and the URL/Host rewrite behaviour in `_post_with_retry`.

## Test plan
- [ ] `uv run pytest tests/test_notifier.py tests/test_fhir_recognizer.py` — 90 passed
- [ ] `uv run ruff check phi_scan/hashing.py phi_scan/notifier.py` — clean
- [ ] `uv run mypy phi_scan/hashing.py phi_scan/notifier.py` — clean