### PR TITLE
[8F-ext.1] Add --workers flag for parallel file scanning

### DIFF
--- a/phi_scan/cli.py
+++ b/phi_scan/cli.py
@@ -377,7 +377,7 @@ _PROGRESS_FILENAME_ELLIPSIS: str = "…"
 # Label shown in the progress bar description column when parallel scanning is active.
 # Replaces the per-file name shown in sequential mode (multiple files run simultaneously
 # so a single filename would be misleading).
-_PARALLEL_SCAN_PROGRESS_LABEL: str = "scanning..."
+_PARALLEL_SCAN_PROGRESS_LABEL: str = f"scanning{_PROGRESS_FILENAME_ELLIPSIS}"
 # Default worker count accepted by the --workers option.
 _DEFAULT_WORKER_COUNT: int = MIN_WORKER_COUNT
 # Error messages for out-of-range --workers values.
@@ -600,7 +600,7 @@ class _ScanExecutionOptions:
 
 @dataclass(frozen=True)
 class _ProgressScanContext:
-    """Arguments for _scan_files_with_progress and its sequential/parallel sub-helpers.
+    """Arguments for _run_scan_with_progress and its sequential/parallel sub-helpers.
 
     Bundles all five inputs required by the progress-bar scan path into a single
     object so each helper stays within the three-argument limit.
@@ -718,7 +718,7 @@ def _validate_worker_count(worker_count: int) -> None:
         raise typer.BadParameter(_WORKERS_ABOVE_MAXIMUM_ERROR)
 
 
-def _scan_files_sequential_with_progress(
+def _run_sequential_scan_with_progress(
     scan: _ProgressScanContext,
 ) -> list[ScanFinding]:
     """Scan files one at a time, advancing the progress bar after each file.
@@ -738,14 +738,16 @@ def _scan_files_sequential_with_progress(
     return all_findings
 
 
-def _scan_files_parallel_with_progress(
+def _run_parallel_scan_with_progress(
     scan: _ProgressScanContext,
 ) -> list[ScanFinding]:
     """Scan files concurrently, advancing the progress bar as each file completes.
 
     Uses as_completed() so the progress bar fires on actual completion rather than
     submission order. Results are re-sorted by original scan_targets index before
-    returning to ensure deterministic output ordering.
+    returning to ensure deterministic output ordering. Worker-thread exceptions
+    are re-raised by Future.result() and propagate to the caller — matching the
+    re-raise-on-iteration behaviour of executor.map() in scanner._run_parallel_scan.
 
     Args:
         scan: Bundled scan targets, config, worker count, and progress bar state.
@@ -773,7 +775,7 @@ def _scan_files_parallel_with_progress(
     return [finding for file_findings in ordered_per_file for finding in file_findings]
 
 
-def _scan_files_with_progress(
+def _run_scan_with_progress(
     scan: _ProgressScanContext,
 ) -> list[ScanFinding]:
     """Dispatch to sequential or parallel progress scanning based on worker_count.
@@ -785,8 +787,8 @@ def _scan_files_with_progress(
         All findings in scan_targets order.
     """
     if scan.worker_count > MIN_WORKER_COUNT:
-        return _scan_files_parallel_with_progress(scan)
-    return _scan_files_sequential_with_progress(scan)
+        return _run_parallel_scan_with_progress(scan)
+    return _run_sequential_scan_with_progress(scan)
 
 
 def _execute_scan_with_progress(
@@ -818,7 +820,7 @@ def _execute_scan_with_progress(
             progress=progress,
             task_id=task_id,
         )
-        all_findings = _scan_files_with_progress(progress_scan_context)
+        all_findings = _run_scan_with_progress(progress_scan_context)
     scan_duration = time.monotonic() - scan_start
     return build_scan_result(tuple(all_findings), len(scan_targets), scan_duration)
 

--- a/phi_scan/cli.py
+++ b/phi_scan/cli.py
@@ -7,7 +7,6 @@ import json
 import logging
 import time
 from collections import deque
-from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -129,9 +128,9 @@ from phi_scan.output import (
 )
 from phi_scan.report import generate_html_report, generate_pdf_report
 from phi_scan.scanner import (
-    _PARALLEL_THREAD_NAME_PREFIX,  # noqa: PLC2701
     MAX_WORKER_COUNT,
     MIN_WORKER_COUNT,
+    _run_parallel_scan,  # noqa: PLC2701
     build_scan_result,
     collect_scan_targets,
     execute_scan,
@@ -743,11 +742,10 @@ def _run_parallel_scan_with_progress(
 ) -> list[ScanFinding]:
     """Scan files concurrently, advancing the progress bar as each file completes.
 
-    Uses as_completed() so the progress bar fires on actual completion rather than
-    submission order. Results are re-sorted by original scan_targets index before
-    returning to ensure deterministic output ordering. Worker-thread exceptions
-    are re-raised by Future.result() and propagate to the caller — matching the
-    re-raise-on-iteration behaviour of executor.map() in scanner._run_parallel_scan.
+    Delegates the thread pool and ordering logic to ``scanner._run_parallel_scan``
+    and supplies a per-file completion callback that ticks the Rich progress
+    bar. Keeping a single parallel executor implementation prevents the CLI and
+    scanner paths from diverging in thread safety, error handling, or ordering.
 
     Args:
         scan: Bundled scan targets, config, worker count, and progress bar state.
@@ -755,24 +753,20 @@ def _run_parallel_scan_with_progress(
     Returns:
         All findings in scan_targets order.
     """
-    indexed_results: dict[int, list[ScanFinding]] = {}
-    future_to_index: dict[Future[list[ScanFinding]], int] = {}
-    with ThreadPoolExecutor(
-        max_workers=scan.worker_count,
-        thread_name_prefix=_PARALLEL_THREAD_NAME_PREFIX,
-    ) as executor:
-        for index, file_path in enumerate(scan.scan_targets):
-            future_to_index[executor.submit(scan_file, file_path, scan.config)] = index
-        for completed_future in as_completed(future_to_index):
-            original_index = future_to_index[completed_future]
-            indexed_results[original_index] = completed_future.result()
-            scan.progress.update(
-                scan.task_id,
-                description=_PARALLEL_SCAN_PROGRESS_LABEL,
-                advance=1,
-            )
-    ordered_per_file = [indexed_results[i] for i in range(len(scan.scan_targets))]
-    return [finding for file_findings in ordered_per_file for finding in file_findings]
+
+    def _advance_progress_bar(_: Path) -> None:
+        scan.progress.update(
+            scan.task_id,
+            description=_PARALLEL_SCAN_PROGRESS_LABEL,
+            advance=1,
+        )
+
+    return _run_parallel_scan(
+        scan.scan_targets,
+        scan.config,
+        scan.worker_count,
+        on_file_complete=_advance_progress_bar,
+    )
 
 
 def _run_scan_with_progress(

--- a/phi_scan/cli.py
+++ b/phi_scan/cli.py
@@ -129,9 +129,9 @@ from phi_scan.output import (
 )
 from phi_scan.report import generate_html_report, generate_pdf_report
 from phi_scan.scanner import (
-    _MIN_WORKER_COUNT,  # noqa: PLC2701
     _PARALLEL_THREAD_NAME_PREFIX,  # noqa: PLC2701
     MAX_WORKER_COUNT,
+    MIN_WORKER_COUNT,
     build_scan_result,
     collect_scan_targets,
     execute_scan,
@@ -379,9 +379,9 @@ _PROGRESS_FILENAME_ELLIPSIS: str = "…"
 # so a single filename would be misleading).
 _PARALLEL_SCAN_PROGRESS_LABEL: str = "scanning..."
 # Default worker count accepted by the --workers option.
-_DEFAULT_WORKER_COUNT: int = _MIN_WORKER_COUNT
+_DEFAULT_WORKER_COUNT: int = MIN_WORKER_COUNT
 # Error messages for out-of-range --workers values.
-_WORKERS_BELOW_MINIMUM_ERROR: str = f"--workers must be at least {_MIN_WORKER_COUNT}"
+_WORKERS_BELOW_MINIMUM_ERROR: str = f"--workers must be at least {MIN_WORKER_COUNT}"
 _WORKERS_ABOVE_MAXIMUM_ERROR: str = f"--workers must not exceed {MAX_WORKER_COUNT}"
 
 # ---------------------------------------------------------------------------
@@ -598,7 +598,7 @@ class _ScanExecutionOptions:
     should_show_progress: bool = False
 
 
-@dataclass
+@dataclass(frozen=True)
 class _ProgressScanContext:
     """Arguments for _scan_files_with_progress and its sequential/parallel sub-helpers.
 
@@ -710,9 +710,9 @@ def _validate_worker_count(worker_count: int) -> None:
         worker_count: Value supplied by the --workers CLI option.
 
     Raises:
-        typer.BadParameter: If worker_count < _MIN_WORKER_COUNT or > MAX_WORKER_COUNT.
+        typer.BadParameter: If worker_count < MIN_WORKER_COUNT or > MAX_WORKER_COUNT.
     """
-    if worker_count < _MIN_WORKER_COUNT:
+    if worker_count < MIN_WORKER_COUNT:
         raise typer.BadParameter(_WORKERS_BELOW_MINIMUM_ERROR)
     if worker_count > MAX_WORKER_COUNT:
         raise typer.BadParameter(_WORKERS_ABOVE_MAXIMUM_ERROR)
@@ -732,8 +732,9 @@ def _scan_files_sequential_with_progress(
     all_findings: list[ScanFinding] = []
     for file_path in scan.scan_targets:
         progress_label = _truncate_filename_for_progress(file_path)
-        scan.progress.update(scan.task_id, description=progress_label, advance=1)
+        scan.progress.update(scan.task_id, description=progress_label)
         all_findings.extend(scan_file(file_path, scan.config))
+        scan.progress.update(scan.task_id, advance=1)
     return all_findings
 
 
@@ -783,7 +784,7 @@ def _scan_files_with_progress(
     Returns:
         All findings in scan_targets order.
     """
-    if scan.worker_count > _MIN_WORKER_COUNT:
+    if scan.worker_count > MIN_WORKER_COUNT:
         return _scan_files_parallel_with_progress(scan)
     return _scan_files_sequential_with_progress(scan)
 

--- a/phi_scan/cli.py
+++ b/phi_scan/cli.py
@@ -7,6 +7,7 @@ import json
 import logging
 import time
 from collections import deque
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -15,6 +16,7 @@ from typing import TYPE_CHECKING, Annotated, Any, NoReturn
 import pathspec
 import typer
 from rich.live import Live
+from rich.progress import Progress, TaskID
 from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer
 
@@ -127,6 +129,7 @@ from phi_scan.output import (
 )
 from phi_scan.report import generate_html_report, generate_pdf_report
 from phi_scan.scanner import (
+    MAX_WORKER_COUNT,
     build_scan_result,
     collect_scan_targets,
     execute_scan,
@@ -359,11 +362,28 @@ _SCAN_UPLOAD_SARIF_HELP: str = (
     "Requires --output sarif and GITHUB_TOKEN. "
     "Each finding appears as an inline annotation on the exact line in the PR diff."
 )
+_SCAN_WORKERS_HELP: str = (
+    f"Number of worker threads for parallel file scanning. Default 1 (sequential). "
+    f"Values above 1 enable concurrent scanning up to {MAX_WORKER_COUNT}. "
+    "Output ordering is deterministic regardless of thread completion order."
+)
 
 # Maximum characters of a file path shown in the progress bar description column.
 # Longer paths are truncated with a leading ellipsis so the bar layout stays stable.
 _PROGRESS_FILENAME_MAX_CHARS: int = 38
 _PROGRESS_FILENAME_ELLIPSIS: str = "…"
+# Label shown in the progress bar description column when parallel scanning is active.
+# Replaces the per-file name shown in sequential mode (multiple files run simultaneously
+# so a single filename would be misleading).
+_PARALLEL_SCAN_PROGRESS_LABEL: str = "scanning..."
+# Thread name prefix used by the CLI-side ThreadPoolExecutor (progress bar path).
+_CLI_PARALLEL_THREAD_NAME_PREFIX: str = "phi-scan-worker"
+# Default and minimum worker count accepted by the --workers option.
+_DEFAULT_WORKER_COUNT: int = 1
+_MIN_WORKER_COUNT: int = 1
+# Error messages for out-of-range --workers values.
+_WORKERS_BELOW_MINIMUM_ERROR: str = f"--workers must be at least {_MIN_WORKER_COUNT}"
+_WORKERS_ABOVE_MAXIMUM_ERROR: str = f"--workers must not exceed {MAX_WORKER_COUNT}"
 
 # ---------------------------------------------------------------------------
 # Error and warning messages
@@ -567,6 +587,33 @@ class _ScanPhaseOptions:
     should_use_baseline: bool = False
 
 
+@dataclass(frozen=True)
+class _ScanExecutionOptions:
+    """Execution parameters threaded from the scan command into the scan loop.
+
+    Bundles worker_count and should_show_progress so _execute_scan_with_progress
+    stays within the three-argument limit required by CLAUDE.md.
+    """
+
+    worker_count: int = _DEFAULT_WORKER_COUNT
+    should_show_progress: bool = False
+
+
+@dataclass
+class _ParallelProgressScan:
+    """Arguments for _scan_files_with_progress and its sequential/parallel sub-helpers.
+
+    Bundles all five inputs required by the progress-bar scan path into a single
+    object so each helper stays within the three-argument limit.
+    """
+
+    scan_targets: list[Path]
+    config: ScanConfig
+    worker_count: int
+    progress: Progress
+    task_id: TaskID
+
+
 def _configure_logging(log_level: str, log_file: Path | None, is_quiet: bool) -> None:
     """Apply logging configuration from CLI flags.
 
@@ -657,10 +704,91 @@ def _truncate_filename_for_progress(file_path: Path) -> str:
     return _PROGRESS_FILENAME_ELLIPSIS + path_string[-_PROGRESS_FILENAME_MAX_CHARS:]
 
 
+def _validate_worker_count(worker_count: int) -> None:
+    """Raise typer.BadParameter if worker_count is outside the permitted range.
+
+    Args:
+        worker_count: Value supplied by the --workers CLI option.
+
+    Raises:
+        typer.BadParameter: If worker_count < _MIN_WORKER_COUNT or > MAX_WORKER_COUNT.
+    """
+    if worker_count < _MIN_WORKER_COUNT:
+        raise typer.BadParameter(_WORKERS_BELOW_MINIMUM_ERROR)
+    if worker_count > MAX_WORKER_COUNT:
+        raise typer.BadParameter(_WORKERS_ABOVE_MAXIMUM_ERROR)
+
+
+def _scan_files_sequential_with_progress(
+    scan: _ParallelProgressScan,
+) -> list[ScanFinding]:
+    """Scan files one at a time, advancing the progress bar after each file.
+
+    Args:
+        scan: Bundled scan targets, config, and progress bar state.
+
+    Returns:
+        All findings in scan_targets order.
+    """
+    all_findings: list[ScanFinding] = []
+    for file_path in scan.scan_targets:
+        progress_label = _truncate_filename_for_progress(file_path)
+        scan.progress.update(scan.task_id, description=progress_label, advance=1)
+        all_findings.extend(scan_file(file_path, scan.config))
+    return all_findings
+
+
+def _scan_files_parallel_with_progress(
+    scan: _ParallelProgressScan,
+) -> list[ScanFinding]:
+    """Scan files concurrently, advancing the progress bar as each file completes.
+
+    Uses as_completed() so the progress bar fires on actual completion rather than
+    submission order. Results are re-sorted by original scan_targets index before
+    returning to ensure deterministic output ordering.
+
+    Args:
+        scan: Bundled scan targets, config, worker count, and progress bar state.
+
+    Returns:
+        All findings in scan_targets order.
+    """
+    indexed_results: dict[int, list[ScanFinding]] = {}
+    future_to_index: dict[Future[list[ScanFinding]], int] = {}
+    with ThreadPoolExecutor(
+        max_workers=scan.worker_count,
+        thread_name_prefix=_CLI_PARALLEL_THREAD_NAME_PREFIX,
+    ) as executor:
+        for index, file_path in enumerate(scan.scan_targets):
+            future_to_index[executor.submit(scan_file, file_path, scan.config)] = index
+        for completed_future in as_completed(future_to_index):
+            original_index = future_to_index[completed_future]
+            indexed_results[original_index] = completed_future.result()
+            scan.progress.update(scan.task_id, description=_PARALLEL_SCAN_PROGRESS_LABEL, advance=1)
+    ordered_per_file = [indexed_results[i] for i in range(len(scan.scan_targets))]
+    return [finding for file_findings in ordered_per_file for finding in file_findings]
+
+
+def _scan_files_with_progress(
+    scan: _ParallelProgressScan,
+) -> list[ScanFinding]:
+    """Dispatch to sequential or parallel progress scanning based on worker_count.
+
+    Args:
+        scan: Bundled scan targets, config, worker count, and progress bar state.
+
+    Returns:
+        All findings in scan_targets order.
+    """
+    if scan.worker_count > _MIN_WORKER_COUNT:
+        return _scan_files_parallel_with_progress(scan)
+    return _scan_files_sequential_with_progress(scan)
+
+
 def _execute_scan_with_progress(
     scan_targets: list[Path],
     config: ScanConfig,
-    should_show_progress: bool,
+    execution_options: _ScanExecutionOptions,
 ) -> ScanResult:
     """Run the scan loop, showing a Rich progress bar when should_show_progress is True.
 
@@ -670,20 +798,23 @@ def _execute_scan_with_progress(
     Args:
         scan_targets: Files to scan, as returned by _resolve_scan_targets.
         config: Active scan configuration.
-        should_show_progress: Show the Rich progress bar when True.
+        execution_options: Worker count and progress bar visibility settings.
 
     Returns:
         Aggregated ScanResult for all scanned files.
     """
-    if not should_show_progress:
-        return execute_scan(scan_targets, config)
-    all_findings: list[ScanFinding] = []
+    if not execution_options.should_show_progress:
+        return execute_scan(scan_targets, config, execution_options.worker_count)
     scan_start = time.monotonic()
     with create_scan_progress(total_files=len(scan_targets)) as (progress, task_id):
-        for file_path in scan_targets:
-            progress_label = _truncate_filename_for_progress(file_path)
-            progress.update(task_id, description=progress_label, advance=1)
-            all_findings.extend(scan_file(file_path, config))
+        parallel_scan = _ParallelProgressScan(
+            scan_targets=scan_targets,
+            config=config,
+            worker_count=execution_options.worker_count,
+            progress=progress,
+            task_id=task_id,
+        )
+        all_findings = _scan_files_with_progress(parallel_scan)
     scan_duration = time.monotonic() - scan_start
     return build_scan_result(tuple(all_findings), len(scan_targets), scan_duration)
 
@@ -1544,6 +1675,9 @@ def scan(
     should_upload_sarif: Annotated[
         bool, typer.Option("--upload-sarif", help=_SCAN_UPLOAD_SARIF_HELP)
     ] = False,
+    worker_count: Annotated[
+        int, typer.Option("--workers", help=_SCAN_WORKERS_HELP)
+    ] = _DEFAULT_WORKER_COUNT,
 ) -> None:
     """Scan a directory or file for PHI/PII.
 
@@ -1554,6 +1688,7 @@ def scan(
     table) is suppressed for serialised formats (json/csv/sarif) to keep stdout
     clean for pipe and file consumption.
     """
+    _validate_worker_count(worker_count)
     effective_log_level = _LOG_LEVEL_DEBUG if is_verbose else log_level
     _configure_logging(effective_log_level, log_file, is_quiet)
     output_format_enum = _resolve_output_format(output_format)
@@ -1572,7 +1707,11 @@ def scan(
     # framework_annotations depend on scan_result.findings. Any error raised by
     # _execute_scan_with_progress will propagate before output_options is configured,
     # which is acceptable — output_options has no effect until _emit_scan_output is called.
-    scan_result = _execute_scan_with_progress(scan_targets, scan_config, is_rich_mode)
+    execution_options = _ScanExecutionOptions(
+        worker_count=worker_count,
+        should_show_progress=is_rich_mode,
+    )
+    scan_result = _execute_scan_with_progress(scan_targets, scan_config, execution_options)
     framework_annotations = (
         annotate_findings(scan_result.findings, enabled_frameworks) if enabled_frameworks else None
     )

--- a/phi_scan/cli.py
+++ b/phi_scan/cli.py
@@ -130,12 +130,12 @@ from phi_scan.report import generate_html_report, generate_pdf_report
 from phi_scan.scanner import (
     MAX_WORKER_COUNT,
     MIN_WORKER_COUNT,
-    _run_parallel_scan,  # noqa: PLC2701
     build_scan_result,
     collect_scan_targets,
     execute_scan,
     is_path_excluded,
     load_ignore_patterns,
+    run_parallel_scan,
     scan_file,
 )
 
@@ -602,10 +602,13 @@ class _ProgressScanContext:
     """Arguments for _run_scan_with_progress and its sequential/parallel sub-helpers.
 
     Bundles all five inputs required by the progress-bar scan path into a single
-    object so each helper stays within the three-argument limit.
+    object so each helper stays within the three-argument limit. ``scan_targets``
+    is stored as a tuple so the frozen=True guarantee extends to the ordered
+    collection itself — preventing in-place mutation of the scan target list
+    after the context has been constructed.
     """
 
-    scan_targets: list[Path]
+    scan_targets: tuple[Path, ...]
     config: ScanConfig
     worker_count: int
     progress: Progress
@@ -742,7 +745,7 @@ def _run_parallel_scan_with_progress(
 ) -> list[ScanFinding]:
     """Scan files concurrently, advancing the progress bar as each file completes.
 
-    Delegates the thread pool and ordering logic to ``scanner._run_parallel_scan``
+    Delegates the thread pool and ordering logic to ``scanner.run_parallel_scan``
     and supplies a per-file completion callback that ticks the Rich progress
     bar. Keeping a single parallel executor implementation prevents the CLI and
     scanner paths from diverging in thread safety, error handling, or ordering.
@@ -761,8 +764,8 @@ def _run_parallel_scan_with_progress(
             advance=1,
         )
 
-    return _run_parallel_scan(
-        scan.scan_targets,
+    return run_parallel_scan(
+        list(scan.scan_targets),
         scan.config,
         scan.worker_count,
         on_file_complete=_advance_progress_bar,
@@ -808,7 +811,7 @@ def _execute_scan_with_progress(
     scan_start = time.monotonic()
     with create_scan_progress(total_files=len(scan_targets)) as (progress, task_id):
         progress_scan_context = _ProgressScanContext(
-            scan_targets=scan_targets,
+            scan_targets=tuple(scan_targets),
             config=config,
             worker_count=execution_options.worker_count,
             progress=progress,

--- a/phi_scan/cli.py
+++ b/phi_scan/cli.py
@@ -757,7 +757,12 @@ def _run_parallel_scan_with_progress(
         All findings in scan_targets order.
     """
 
-    def _advance_progress_bar(_: Path) -> None:
+    def _advance_progress_bar(completed_file_path: Path) -> None:
+        # completed_file_path is supplied by the run_parallel_scan callback
+        # contract but deliberately not displayed: the parallel progress
+        # label is a fixed string, because completion order is
+        # nondeterministic and showing file names mid-scan would cause the
+        # label to jitter across threads.
         scan.progress.update(
             scan.task_id,
             description=_PARALLEL_SCAN_PROGRESS_LABEL,

--- a/phi_scan/cli.py
+++ b/phi_scan/cli.py
@@ -129,6 +129,8 @@ from phi_scan.output import (
 )
 from phi_scan.report import generate_html_report, generate_pdf_report
 from phi_scan.scanner import (
+    _MIN_WORKER_COUNT,  # noqa: PLC2701
+    _PARALLEL_THREAD_NAME_PREFIX,  # noqa: PLC2701
     MAX_WORKER_COUNT,
     build_scan_result,
     collect_scan_targets,
@@ -376,11 +378,8 @@ _PROGRESS_FILENAME_ELLIPSIS: str = "…"
 # Replaces the per-file name shown in sequential mode (multiple files run simultaneously
 # so a single filename would be misleading).
 _PARALLEL_SCAN_PROGRESS_LABEL: str = "scanning..."
-# Thread name prefix used by the CLI-side ThreadPoolExecutor (progress bar path).
-_CLI_PARALLEL_THREAD_NAME_PREFIX: str = "phi-scan-worker"
-# Default and minimum worker count accepted by the --workers option.
-_DEFAULT_WORKER_COUNT: int = 1
-_MIN_WORKER_COUNT: int = 1
+# Default worker count accepted by the --workers option.
+_DEFAULT_WORKER_COUNT: int = _MIN_WORKER_COUNT
 # Error messages for out-of-range --workers values.
 _WORKERS_BELOW_MINIMUM_ERROR: str = f"--workers must be at least {_MIN_WORKER_COUNT}"
 _WORKERS_ABOVE_MAXIMUM_ERROR: str = f"--workers must not exceed {MAX_WORKER_COUNT}"
@@ -600,7 +599,7 @@ class _ScanExecutionOptions:
 
 
 @dataclass
-class _ParallelProgressScan:
+class _ProgressScanContext:
     """Arguments for _scan_files_with_progress and its sequential/parallel sub-helpers.
 
     Bundles all five inputs required by the progress-bar scan path into a single
@@ -720,7 +719,7 @@ def _validate_worker_count(worker_count: int) -> None:
 
 
 def _scan_files_sequential_with_progress(
-    scan: _ParallelProgressScan,
+    scan: _ProgressScanContext,
 ) -> list[ScanFinding]:
     """Scan files one at a time, advancing the progress bar after each file.
 
@@ -739,7 +738,7 @@ def _scan_files_sequential_with_progress(
 
 
 def _scan_files_parallel_with_progress(
-    scan: _ParallelProgressScan,
+    scan: _ProgressScanContext,
 ) -> list[ScanFinding]:
     """Scan files concurrently, advancing the progress bar as each file completes.
 
@@ -757,20 +756,24 @@ def _scan_files_parallel_with_progress(
     future_to_index: dict[Future[list[ScanFinding]], int] = {}
     with ThreadPoolExecutor(
         max_workers=scan.worker_count,
-        thread_name_prefix=_CLI_PARALLEL_THREAD_NAME_PREFIX,
+        thread_name_prefix=_PARALLEL_THREAD_NAME_PREFIX,
     ) as executor:
         for index, file_path in enumerate(scan.scan_targets):
             future_to_index[executor.submit(scan_file, file_path, scan.config)] = index
         for completed_future in as_completed(future_to_index):
             original_index = future_to_index[completed_future]
             indexed_results[original_index] = completed_future.result()
-            scan.progress.update(scan.task_id, description=_PARALLEL_SCAN_PROGRESS_LABEL, advance=1)
+            scan.progress.update(
+                scan.task_id,
+                description=_PARALLEL_SCAN_PROGRESS_LABEL,
+                advance=1,
+            )
     ordered_per_file = [indexed_results[i] for i in range(len(scan.scan_targets))]
     return [finding for file_findings in ordered_per_file for finding in file_findings]
 
 
 def _scan_files_with_progress(
-    scan: _ParallelProgressScan,
+    scan: _ProgressScanContext,
 ) -> list[ScanFinding]:
     """Dispatch to sequential or parallel progress scanning based on worker_count.
 
@@ -807,14 +810,14 @@ def _execute_scan_with_progress(
         return execute_scan(scan_targets, config, execution_options.worker_count)
     scan_start = time.monotonic()
     with create_scan_progress(total_files=len(scan_targets)) as (progress, task_id):
-        parallel_scan = _ParallelProgressScan(
+        progress_scan_context = _ProgressScanContext(
             scan_targets=scan_targets,
             config=config,
             worker_count=execution_options.worker_count,
             progress=progress,
             task_id=task_id,
         )
-        all_findings = _scan_files_with_progress(parallel_scan)
+        all_findings = _scan_files_with_progress(progress_scan_context)
     scan_duration = time.monotonic() - scan_start
     return build_scan_result(tuple(all_findings), len(scan_targets), scan_duration)
 

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -10,6 +10,7 @@ import zipfile
 import zlib
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
+from itertools import repeat
 from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -43,6 +44,7 @@ from phi_scan.suppression import is_finding_suppressed, load_suppressions
 
 __all__ = [
     "MAX_WORKER_COUNT",
+    "MIN_WORKER_COUNT",
     "collect_scan_targets",
     "execute_scan",
     "is_binary_file",
@@ -138,9 +140,9 @@ _NOTEBOOK_SECTION_SEPARATOR: str = "\n"
 # Maximum number of worker threads accepted by execute_scan and the CLI.
 # Values above this are rejected at the call site before reaching the executor.
 MAX_WORKER_COUNT: int = 32
-# Worker count threshold: values above this switch execute_scan to the parallel
-# code path. Values at or below run sequentially (default behaviour).
-_MIN_WORKER_COUNT: int = 1
+# Minimum worker count. Values at or below this run sequentially; values above
+# this switch execute_scan to the parallel code path.
+MIN_WORKER_COUNT: int = 1
 # Thread name prefix used by ThreadPoolExecutor for log and debugger visibility.
 _PARALLEL_THREAD_NAME_PREFIX: str = "phi-scan-worker"
 
@@ -342,7 +344,7 @@ def scan_file(file_path: Path, config: ScanConfig) -> list[ScanFinding]:
 def execute_scan(
     scan_targets: list[Path],
     config: ScanConfig,
-    worker_count: int = _MIN_WORKER_COUNT,
+    worker_count: int = MIN_WORKER_COUNT,
 ) -> ScanResult:
     """Scan every file in scan_targets and return the aggregated ScanResult.
 
@@ -365,13 +367,31 @@ def execute_scan(
     from phi_scan.ai_review import apply_ai_review_to_findings
 
     scan_start = time.monotonic()
-    if worker_count > _MIN_WORKER_COUNT:
-        all_findings = _scan_files_parallel(scan_targets, config, worker_count)
-    else:
-        all_findings = _scan_files_sequential(scan_targets, config)
+    all_findings = _collect_all_findings(scan_targets, config, worker_count)
     reviewed_findings, ai_usage = apply_ai_review_to_findings(all_findings, config.ai_review_config)
     scan_duration = time.monotonic() - scan_start
     return build_scan_result(tuple(reviewed_findings), len(scan_targets), scan_duration, ai_usage)
+
+
+def _collect_all_findings(
+    scan_targets: list[Path],
+    config: ScanConfig,
+    worker_count: int,
+) -> list[ScanFinding]:
+    """Dispatch scan_targets to the sequential or parallel scan path.
+
+    Args:
+        scan_targets: Ordered list of files to scan.
+        config: Scan configuration forwarded to each scan_file call.
+        worker_count: Number of worker threads. Values at or below
+            MIN_WORKER_COUNT run sequentially; higher values run in parallel.
+
+    Returns:
+        All findings from all files, in scan_targets order.
+    """
+    if worker_count > MIN_WORKER_COUNT:
+        return _scan_files_parallel(scan_targets, config, worker_count)
+    return _scan_files_sequential(scan_targets, config)
 
 
 def _scan_files_sequential(
@@ -400,26 +420,23 @@ def _scan_files_parallel(
 ) -> list[ScanFinding]:
     """Scan scan_targets concurrently using a bounded ThreadPoolExecutor.
 
-    Uses executor.map() to guarantee that results are returned in the same
-    order as scan_targets regardless of thread completion order.
+    Uses executor.map() with itertools.repeat() to broadcast config across all
+    calls without a closure. Results are returned in scan_targets order
+    regardless of thread completion order.
 
     Args:
         scan_targets: Ordered list of files to scan.
         config: Scan configuration forwarded to each scan_file call.
-        worker_count: Number of worker threads; must be > _MIN_WORKER_COUNT.
+        worker_count: Number of worker threads; must be > MIN_WORKER_COUNT.
 
     Returns:
         All findings from all files, in scan_targets order.
     """
-
-    def scan_one_file(file_path: Path) -> list[ScanFinding]:
-        return scan_file(file_path, config)
-
     with ThreadPoolExecutor(
         max_workers=worker_count,
         thread_name_prefix=_PARALLEL_THREAD_NAME_PREFIX,
     ) as executor:
-        per_file_results = list(executor.map(scan_one_file, scan_targets))
+        per_file_results = list(executor.map(scan_file, scan_targets, repeat(config)))
     return [finding for file_findings in per_file_results for finding in file_findings]
 
 

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -9,8 +9,7 @@ import time
 import zipfile
 import zlib
 from collections import Counter
-from concurrent.futures import ThreadPoolExecutor
-from itertools import repeat
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -18,6 +17,8 @@ from typing import TYPE_CHECKING
 import pathspec
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from phi_scan.ai_review import AIUsageSummary
 
 from phi_scan.cache import FileCacheKey, get_cached_result, store_cached_result
@@ -432,27 +433,46 @@ def _run_parallel_scan(
     scan_targets: list[Path],
     config: ScanConfig,
     worker_count: int,
+    on_file_complete: Callable[[Path], None] | None = None,
 ) -> list[ScanFinding]:
     """Scan scan_targets concurrently using a bounded ThreadPoolExecutor.
 
-    Uses executor.map() with itertools.repeat() to broadcast config across all
-    calls without a closure. Results are returned in scan_targets order
-    regardless of thread completion order.
+    Uses ``submit`` + ``as_completed`` so per-file results become available in
+    completion order, enabling callers to advance a progress UI as each file
+    finishes. Results are re-sorted by original scan_targets index before
+    flattening, so the returned findings list is deterministic regardless of
+    thread completion order. Worker-thread exceptions are re-raised by
+    ``Future.result()`` and propagate to the caller.
 
     Args:
         scan_targets: Ordered list of files to scan.
         config: Scan configuration forwarded to each scan_file call.
         worker_count: Number of worker threads; must be > MIN_WORKER_COUNT.
+        on_file_complete: Optional callback invoked on the orchestrating thread
+            once per file, immediately after its ``scan_file`` result is
+            collected. Receives the completed file path. Any exception raised
+            by the callback propagates to the caller.
 
     Returns:
         All findings from all files, in scan_targets order.
     """
+    if not scan_targets:
+        return []
+    indexed_results: dict[int, list[ScanFinding]] = {}
+    future_to_index: dict[Future[list[ScanFinding]], int] = {}
     with ThreadPoolExecutor(
         max_workers=worker_count,
         thread_name_prefix=_PARALLEL_THREAD_NAME_PREFIX,
     ) as executor:
-        per_file_results = list(executor.map(scan_file, scan_targets, repeat(config)))
-    return [finding for file_findings in per_file_results for finding in file_findings]
+        for index, file_path in enumerate(scan_targets):
+            future_to_index[executor.submit(scan_file, file_path, config)] = index
+        for completed_future in as_completed(future_to_index):
+            original_index = future_to_index[completed_future]
+            indexed_results[original_index] = completed_future.result()
+            if on_file_complete is not None:
+                on_file_complete(scan_targets[original_index])
+    ordered_per_file = [indexed_results[i] for i in range(len(scan_targets))]
+    return [finding for file_findings in ordered_per_file for finding in file_findings]
 
 
 # ---------------------------------------------------------------------------

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -61,6 +61,9 @@ _logger: logging.Logger = get_logger("scanner")
 
 _ROOT_PATH_NOT_FOUND_ERROR: str = "Scan root {path!r} does not exist"
 _ROOT_PATH_NOT_DIRECTORY_ERROR: str = "Scan root {path!r} is not a directory"
+_WORKER_COUNT_OUT_OF_RANGE_ERROR: str = (
+    "worker_count {worker_count} is out of range [{minimum}, {maximum}]"
+)
 _SYMLINK_SKIPPED_WARNING: str = "Skipping symlink {path!r} — symlink traversal is prohibited"
 _OVERSIZED_FILE_SKIPPED_WARNING: str = "Skipping {path!r} — size exceeds the {limit_mb} MB limit"
 _BINARY_FILE_SKIPPED_INFO: str = "Skipping {path!r} — detected as binary"
@@ -363,9 +366,21 @@ def execute_scan(
     Returns:
         A ScanResult aggregating all findings, file counts, timing, and
         risk classification.
+
+    Raises:
+        ValueError: If worker_count is outside
+            [MIN_WORKER_COUNT, MAX_WORKER_COUNT].
     """
     from phi_scan.ai_review import apply_ai_review_to_findings
 
+    if not MIN_WORKER_COUNT <= worker_count <= MAX_WORKER_COUNT:
+        raise ValueError(
+            _WORKER_COUNT_OUT_OF_RANGE_ERROR.format(
+                worker_count=worker_count,
+                minimum=MIN_WORKER_COUNT,
+                maximum=MAX_WORKER_COUNT,
+            ),
+        )
     scan_start = time.monotonic()
     all_findings = _collect_all_findings(scan_targets, config, worker_count)
     reviewed_findings, ai_usage = apply_ai_review_to_findings(all_findings, config.ai_review_config)
@@ -390,11 +405,11 @@ def _collect_all_findings(
         All findings from all files, in scan_targets order.
     """
     if worker_count > MIN_WORKER_COUNT:
-        return _scan_files_parallel(scan_targets, config, worker_count)
-    return _scan_files_sequential(scan_targets, config)
+        return _run_parallel_scan(scan_targets, config, worker_count)
+    return _run_sequential_scan(scan_targets, config)
 
 
-def _scan_files_sequential(
+def _run_sequential_scan(
     scan_targets: list[Path],
     config: ScanConfig,
 ) -> list[ScanFinding]:
@@ -413,7 +428,7 @@ def _scan_files_sequential(
     return all_findings
 
 
-def _scan_files_parallel(
+def _run_parallel_scan(
     scan_targets: list[Path],
     config: ScanConfig,
     worker_count: int,

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import hashlib
 import json
 import logging
@@ -9,6 +10,7 @@ import time
 import zipfile
 import zlib
 from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -41,6 +43,7 @@ from phi_scan.models import ScanConfig, ScanFinding, ScanResult
 from phi_scan.suppression import is_finding_suppressed, load_suppressions
 
 __all__ = [
+    "MAX_WORKER_COUNT",
     "collect_scan_targets",
     "execute_scan",
     "is_binary_file",
@@ -128,6 +131,19 @@ _NOTEBOOK_OUTPUT_TEXT_KEY: str = "text"
 # correct per the spec — joining with "\n" would insert double newlines.
 _NOTEBOOK_CELL_JOIN_SEPARATOR: str = ""
 _NOTEBOOK_SECTION_SEPARATOR: str = "\n"
+
+# ---------------------------------------------------------------------------
+# Parallel scan constants
+# ---------------------------------------------------------------------------
+
+# Maximum number of worker threads accepted by execute_scan and the CLI.
+# Values above this are rejected at the call site before reaching the executor.
+MAX_WORKER_COUNT: int = 32
+# Worker count threshold: values above this switch execute_scan to the parallel
+# code path. Values at or below run sequentially (default behaviour).
+_MIN_WORKER_COUNT: int = 1
+# Thread name prefix used by ThreadPoolExecutor for log and debugger visibility.
+_PARALLEL_THREAD_NAME_PREFIX: str = "phi-scan-worker"
 
 
 # ---------------------------------------------------------------------------
@@ -324,17 +340,24 @@ def scan_file(file_path: Path, config: ScanConfig) -> list[ScanFinding]:
     return _execute_scan_with_cache(file_content, content_hash, display_path, config)
 
 
-def execute_scan(scan_targets: list[Path], config: ScanConfig) -> ScanResult:
+def execute_scan(
+    scan_targets: list[Path],
+    config: ScanConfig,
+    worker_count: int = 1,
+) -> ScanResult:
     """Scan every file in scan_targets and return the aggregated ScanResult.
 
     Runs all local detection layers first, then applies the optional AI
     confidence review layer to medium-confidence findings before building
-    the final result.
+    the final result. When worker_count > 1, files are scanned concurrently
+    using a bounded ThreadPoolExecutor; output order matches scan_targets order.
 
     Args:
         scan_targets: Ordered list of files to scan, as returned by
             collect_scan_targets.
         config: Scan configuration controlling thresholds and output format.
+        worker_count: Number of worker threads. 1 (default) runs sequentially.
+            Values above 1 enable parallel scanning up to MAX_WORKER_COUNT.
 
     Returns:
         A ScanResult aggregating all findings, file counts, timing, and
@@ -343,13 +366,59 @@ def execute_scan(scan_targets: list[Path], config: ScanConfig) -> ScanResult:
     from phi_scan.ai_review import apply_ai_review_to_findings
 
     scan_start = time.monotonic()
-    all_findings: list[ScanFinding] = []
-    for file_path in scan_targets:
-        file_findings = scan_file(file_path, config)
-        all_findings.extend(file_findings)
+    if worker_count > _MIN_WORKER_COUNT:
+        all_findings = _scan_files_parallel(scan_targets, config, worker_count)
+    else:
+        all_findings = _scan_files_sequential(scan_targets, config)
     reviewed_findings, ai_usage = apply_ai_review_to_findings(all_findings, config.ai_review_config)
     scan_duration = time.monotonic() - scan_start
     return build_scan_result(tuple(reviewed_findings), len(scan_targets), scan_duration, ai_usage)
+
+
+def _scan_files_sequential(
+    scan_targets: list[Path],
+    config: ScanConfig,
+) -> list[ScanFinding]:
+    """Scan scan_targets one at a time and return all findings in input order.
+
+    Args:
+        scan_targets: Ordered list of files to scan.
+        config: Scan configuration forwarded to each scan_file call.
+
+    Returns:
+        All findings from all files, in scan_targets order.
+    """
+    all_findings: list[ScanFinding] = []
+    for file_path in scan_targets:
+        all_findings.extend(scan_file(file_path, config))
+    return all_findings
+
+
+def _scan_files_parallel(
+    scan_targets: list[Path],
+    config: ScanConfig,
+    worker_count: int,
+) -> list[ScanFinding]:
+    """Scan scan_targets concurrently using a bounded ThreadPoolExecutor.
+
+    Uses executor.map() to guarantee that results are returned in the same
+    order as scan_targets regardless of thread completion order.
+
+    Args:
+        scan_targets: Ordered list of files to scan.
+        config: Scan configuration forwarded to each scan_file call.
+        worker_count: Number of worker threads; must be > _MIN_WORKER_COUNT.
+
+    Returns:
+        All findings from all files, in scan_targets order.
+    """
+    scan_one = functools.partial(scan_file, config=config)
+    with ThreadPoolExecutor(
+        max_workers=worker_count,
+        thread_name_prefix=_PARALLEL_THREAD_NAME_PREFIX,
+    ) as executor:
+        per_file_results = list(executor.map(scan_one, scan_targets))
+    return [finding for file_findings in per_file_results for finding in file_findings]
 
 
 # ---------------------------------------------------------------------------

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import functools
 import hashlib
 import json
 import logging
@@ -412,12 +411,15 @@ def _scan_files_parallel(
     Returns:
         All findings from all files, in scan_targets order.
     """
-    scan_one = functools.partial(scan_file, config=config)
+
+    def scan_one_file(file_path: Path) -> list[ScanFinding]:
+        return scan_file(file_path, config)
+
     with ThreadPoolExecutor(
         max_workers=worker_count,
         thread_name_prefix=_PARALLEL_THREAD_NAME_PREFIX,
     ) as executor:
-        per_file_results = list(executor.map(scan_one, scan_targets))
+        per_file_results = list(executor.map(scan_one_file, scan_targets))
     return [finding for file_findings in per_file_results for finding in file_findings]
 
 

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -51,6 +51,7 @@ __all__ = [
     "is_binary_file",
     "is_path_excluded",
     "load_ignore_patterns",
+    "run_parallel_scan",
     "scan_file",
 ]
 
@@ -406,7 +407,7 @@ def _collect_all_findings(
         All findings from all files, in scan_targets order.
     """
     if worker_count > MIN_WORKER_COUNT:
-        return _run_parallel_scan(scan_targets, config, worker_count)
+        return run_parallel_scan(scan_targets, config, worker_count)
     return _run_sequential_scan(scan_targets, config)
 
 
@@ -429,7 +430,7 @@ def _run_sequential_scan(
     return all_findings
 
 
-def _run_parallel_scan(
+def run_parallel_scan(
     scan_targets: list[Path],
     config: ScanConfig,
     worker_count: int,
@@ -437,12 +438,18 @@ def _run_parallel_scan(
 ) -> list[ScanFinding]:
     """Scan scan_targets concurrently using a bounded ThreadPoolExecutor.
 
-    Uses ``submit`` + ``as_completed`` so per-file results become available in
-    completion order, enabling callers to advance a progress UI as each file
-    finishes. Results are re-sorted by original scan_targets index before
-    flattening, so the returned findings list is deterministic regardless of
-    thread completion order. Worker-thread exceptions are re-raised by
-    ``Future.result()`` and propagate to the caller.
+    This is the single parallel executor used by both ``execute_scan`` and the
+    CLI progress-bar scan path. Uses ``submit`` + ``as_completed`` so per-file
+    results become available in completion order, enabling callers to advance a
+    progress UI as each file finishes. Results are re-sorted by original
+    scan_targets index before flattening, so the returned findings list is
+    deterministic regardless of thread completion order. Worker-thread
+    exceptions are re-raised by ``Future.result()`` and propagate to the caller.
+
+    This function does not apply the AI confidence review layer — callers that
+    need a full ``ScanResult`` with AI review and timing should use
+    ``execute_scan`` instead. ``run_parallel_scan`` is the lower-level primitive
+    that returns raw findings from the local detection layers only.
 
     Args:
         scan_targets: Ordered list of files to scan.

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -343,7 +343,7 @@ def scan_file(file_path: Path, config: ScanConfig) -> list[ScanFinding]:
 def execute_scan(
     scan_targets: list[Path],
     config: ScanConfig,
-    worker_count: int = 1,
+    worker_count: int = _MIN_WORKER_COUNT,
 ) -> ScanResult:
     """Scan every file in scan_targets and return the aggregated ScanResult.
 

--- a/tests/fixtures/manifest.json
+++ b/tests/fixtures/manifest.json
@@ -121,6 +121,15 @@
       "notes": "Combination achieves ~87% unique identification (Sweeney 2000). Must be HIGH severity regardless of individual scores."
     },
     {
+      "path": "phi/parity.py",
+      "category": "phi",
+      "description": "Single synthetic SSN loaded verbatim by the sequential/parallel scan parity tests in test_scanner.py",
+      "expected_min_findings": 1,
+      "primary_entity_types": ["SSN"],
+      "hipaa_identifiers": ["SSN"],
+      "notes": "Area number 123 has never been assigned by the SSA — a well-known synthetic value. Keeps the raw literal out of test source files."
+    },
+    {
       "path": "clean/no_phi.py",
       "category": "clean",
       "description": "Pure algorithm code — math functions and named constants with no PHI",

--- a/tests/fixtures/phi/parity.py
+++ b/tests/fixtures/phi/parity.py
@@ -1,0 +1,10 @@
+# Synthetic PHI fixture: parity test content for sequential vs parallel scan.
+# Loaded as raw file text by tests/test_scanner.py to avoid embedding a raw
+# SSN literal inside a test source file. Covered by the tests/fixtures/ entry
+# in .phi-scanignore so self-scans do not flag it.
+#
+# 123-45-6789 uses area number 123, which the SSA has never assigned — it is
+# a well-known synthetic test value and is not a real individual's SSN.
+# Expected findings: minimum 1 (SSN entity type).
+
+patient_ssn = "123-45-6789"

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -26,7 +26,10 @@ from phi_scan.constants import (
 from phi_scan.exceptions import TraversalError
 from phi_scan.models import ScanConfig, ScanResult
 from phi_scan.scanner import (
+    MAX_WORKER_COUNT,
     _passes_decompression_bomb_guards,  # noqa: PLC2701
+    _scan_files_parallel,  # noqa: PLC2701
+    _scan_files_sequential,  # noqa: PLC2701
     collect_scan_targets,
     execute_scan,
     is_binary_file,
@@ -52,6 +55,14 @@ _OVERSIZED_FILE_SIZE_BYTES: int = MAX_FILE_SIZE_MB * BYTES_PER_MEGABYTE + 1
 _MULTI_FILE_SCAN_COUNT: int = 3
 # Minimum acceptable scan duration — time.monotonic() guarantees non-negative values.
 _MINIMUM_SCAN_DURATION: float = 0.0
+# Number of files used in parallel scan parity tests — large enough to exercise
+# the thread pool but small enough for fast test execution.
+_PARITY_FILE_COUNT: int = 6
+# Worker count used in parallel parity tests — must be > 1 to activate the parallel code path.
+_PARITY_WORKER_COUNT: int = 2
+# PHI content written to parity test files. Uses a structurally valid SSN (high
+# confidence regex match) so findings are consistently generated across both code paths.
+_PARITY_PHI_CONTENT: str = "patient_ssn = '123-45-6789'\n"
 # Number of non-blank, non-comment patterns written by
 # test_load_ignore_patterns_skips_blank_lines: _SAMPLE_IGNORE_PATTERN ("*.log") and "*.tmp".
 # Update this constant if that test's fixture content changes.
@@ -508,6 +519,138 @@ def test_execute_scan_category_counts_all_zero_for_clean_scan() -> None:
     scan_result = execute_scan([], _build_default_config())
 
     assert all(count == 0 for count in scan_result.category_counts.values())
+
+
+# ---------------------------------------------------------------------------
+# execute_scan — worker_count parameter
+# ---------------------------------------------------------------------------
+
+
+def test_execute_scan_worker_count_one_returns_scan_result(tmp_path: Path) -> None:
+    scan_result = execute_scan([], _build_default_config(), worker_count=1)
+
+    assert isinstance(scan_result, ScanResult)
+
+
+def test_execute_scan_worker_count_two_returns_scan_result(tmp_path: Path) -> None:
+    scan_result = execute_scan([], _build_default_config(), worker_count=2)
+
+    assert isinstance(scan_result, ScanResult)
+
+
+def test_execute_scan_parallel_files_scanned_matches_target_count(tmp_path: Path) -> None:
+    text_files = [tmp_path / f"file_{i}.py" for i in range(_MULTI_FILE_SCAN_COUNT)]
+    for text_file in text_files:
+        text_file.write_text(_SAMPLE_TEXT_CONTENT, encoding=DEFAULT_TEXT_ENCODING)
+
+    scan_result = execute_scan(
+        text_files, _build_default_config(), worker_count=_PARITY_WORKER_COUNT
+    )
+
+    assert scan_result.files_scanned == len(text_files)
+
+
+def test_execute_scan_parallel_is_clean_for_no_phi_content(tmp_path: Path) -> None:
+    text_files = [tmp_path / f"file_{i}.py" for i in range(_MULTI_FILE_SCAN_COUNT)]
+    for text_file in text_files:
+        text_file.write_text(_SAMPLE_TEXT_CONTENT, encoding=DEFAULT_TEXT_ENCODING)
+
+    scan_result = execute_scan(
+        text_files, _build_default_config(), worker_count=_PARITY_WORKER_COUNT
+    )
+
+    assert scan_result.is_clean is True
+
+
+# ---------------------------------------------------------------------------
+# Parallel scan parity — sequential and parallel produce identical results
+# ---------------------------------------------------------------------------
+
+
+def _build_parity_files(root: Path, file_count: int) -> list[Path]:
+    """Create file_count Python files with PHI content under root; return ordered list."""
+    files = [root / f"file_{index:03d}.py" for index in range(file_count)]
+    for phi_file in files:
+        phi_file.write_text(_PARITY_PHI_CONTENT, encoding=DEFAULT_TEXT_ENCODING)
+    return files
+
+
+def test_parallel_scan_finding_count_matches_sequential(tmp_path: Path) -> None:
+    phi_files = _build_parity_files(tmp_path, _PARITY_FILE_COUNT)
+    config = _build_default_config()
+
+    sequential_result = execute_scan(phi_files, config, worker_count=1)
+    parallel_result = execute_scan(phi_files, config, worker_count=_PARITY_WORKER_COUNT)
+
+    assert len(parallel_result.findings) == len(sequential_result.findings)
+
+
+def test_parallel_scan_file_paths_match_sequential(tmp_path: Path) -> None:
+    phi_files = _build_parity_files(tmp_path, _PARITY_FILE_COUNT)
+    config = _build_default_config()
+
+    sequential_result = execute_scan(phi_files, config, worker_count=1)
+    parallel_result = execute_scan(phi_files, config, worker_count=_PARITY_WORKER_COUNT)
+
+    sequential_paths = [f.file_path for f in sequential_result.findings]
+    parallel_paths = [f.file_path for f in parallel_result.findings]
+    assert parallel_paths == sequential_paths
+
+
+def test_parallel_scan_value_hashes_match_sequential(tmp_path: Path) -> None:
+    phi_files = _build_parity_files(tmp_path, _PARITY_FILE_COUNT)
+    config = _build_default_config()
+
+    sequential_result = execute_scan(phi_files, config, worker_count=1)
+    parallel_result = execute_scan(phi_files, config, worker_count=_PARITY_WORKER_COUNT)
+
+    sequential_hashes = [f.value_hash for f in sequential_result.findings]
+    parallel_hashes = [f.value_hash for f in parallel_result.findings]
+    assert parallel_hashes == sequential_hashes
+
+
+def test_parallel_scan_risk_level_matches_sequential(tmp_path: Path) -> None:
+    phi_files = _build_parity_files(tmp_path, _PARITY_FILE_COUNT)
+    config = _build_default_config()
+
+    sequential_result = execute_scan(phi_files, config, worker_count=1)
+    parallel_result = execute_scan(phi_files, config, worker_count=_PARITY_WORKER_COUNT)
+
+    assert parallel_result.risk_level == sequential_result.risk_level
+
+
+# ---------------------------------------------------------------------------
+# _scan_files_sequential and _scan_files_parallel — unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_scan_files_sequential_returns_empty_for_no_targets(tmp_path: Path) -> None:
+    findings = _scan_files_sequential([], _build_default_config())
+
+    assert findings == []
+
+
+def test_scan_files_parallel_returns_empty_for_no_targets(tmp_path: Path) -> None:
+    findings = _scan_files_parallel([], _build_default_config(), worker_count=_PARITY_WORKER_COUNT)
+
+    assert findings == []
+
+
+def test_scan_files_parallel_preserves_order(tmp_path: Path) -> None:
+    phi_files = _build_parity_files(tmp_path, _PARITY_FILE_COUNT)
+    config = _build_default_config()
+
+    sequential_findings = _scan_files_sequential(phi_files, config)
+    parallel_findings = _scan_files_parallel(phi_files, config, worker_count=_PARITY_WORKER_COUNT)
+
+    sequential_paths = [f.file_path for f in sequential_findings]
+    parallel_paths = [f.file_path for f in parallel_findings]
+    assert parallel_paths == sequential_paths
+
+
+def test_max_worker_count_is_positive_integer() -> None:
+    assert isinstance(MAX_WORKER_COUNT, int)
+    assert MAX_WORKER_COUNT >= 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -29,8 +29,8 @@ from phi_scan.scanner import (
     MAX_WORKER_COUNT,
     MIN_WORKER_COUNT,
     _passes_decompression_bomb_guards,  # noqa: PLC2701
-    _scan_files_parallel,  # noqa: PLC2701
-    _scan_files_sequential,  # noqa: PLC2701
+    _run_parallel_scan,  # noqa: PLC2701
+    _run_sequential_scan,  # noqa: PLC2701
     collect_scan_targets,
     execute_scan,
     is_binary_file,
@@ -61,6 +61,10 @@ _MINIMUM_SCAN_DURATION: float = 0.0
 _PARITY_FILE_COUNT: int = 6
 # Worker count used in parallel parity tests — must be > 1 to activate the parallel code path.
 _PARITY_WORKER_COUNT: int = 2
+# Out-of-range worker counts used by validation tests.
+_WORKER_COUNT_ZERO: int = 0
+_WORKER_COUNT_NEGATIVE: int = -1
+_WORKER_COUNT_ABOVE_MAX: int = MAX_WORKER_COUNT + 1
 # PHI content written to parity test files. Uses a structurally valid SSN pattern
 # (high confidence regex match) so findings are consistently generated across both code paths.
 # 123-45-6789 uses area number 123, which the SSA has never assigned — it is
@@ -541,6 +545,21 @@ def test_execute_scan_worker_count_two_returns_scan_result() -> None:
     assert isinstance(scan_result, ScanResult)
 
 
+def test_execute_scan_raises_value_error_when_worker_count_is_zero() -> None:
+    with pytest.raises(ValueError, match="out of range"):
+        execute_scan([], _build_default_config(), worker_count=_WORKER_COUNT_ZERO)
+
+
+def test_execute_scan_raises_value_error_when_worker_count_is_negative() -> None:
+    with pytest.raises(ValueError, match="out of range"):
+        execute_scan([], _build_default_config(), worker_count=_WORKER_COUNT_NEGATIVE)
+
+
+def test_execute_scan_raises_value_error_when_worker_count_exceeds_max() -> None:
+    with pytest.raises(ValueError, match="out of range"):
+        execute_scan([], _build_default_config(), worker_count=_WORKER_COUNT_ABOVE_MAX)
+
+
 def test_execute_scan_parallel_files_scanned_matches_target_count(tmp_path: Path) -> None:
     text_files = [tmp_path / f"file_{i}.py" for i in range(_MULTI_FILE_SCAN_COUNT)]
     for text_file in text_files:
@@ -623,28 +642,28 @@ def test_parallel_scan_risk_level_matches_sequential(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# _scan_files_sequential and _scan_files_parallel — unit tests
+# _run_sequential_scan and _run_parallel_scan — unit tests
 # ---------------------------------------------------------------------------
 
 
-def test_scan_files_sequential_returns_empty_for_no_targets() -> None:
-    findings = _scan_files_sequential([], _build_default_config())
+def test_run_sequential_scan_returns_empty_for_no_targets() -> None:
+    findings = _run_sequential_scan([], _build_default_config())
 
     assert findings == []
 
 
-def test_scan_files_parallel_returns_empty_for_no_targets() -> None:
-    findings = _scan_files_parallel([], _build_default_config(), worker_count=_PARITY_WORKER_COUNT)
+def test_run_parallel_scan_returns_empty_for_no_targets() -> None:
+    findings = _run_parallel_scan([], _build_default_config(), worker_count=_PARITY_WORKER_COUNT)
 
     assert findings == []
 
 
-def test_scan_files_parallel_preserves_order(tmp_path: Path) -> None:
+def test_run_parallel_scan_preserves_order(tmp_path: Path) -> None:
     phi_files = _build_parity_files(tmp_path, _PARITY_FILE_COUNT)
     config = _build_default_config()
 
-    sequential_findings = _scan_files_sequential(phi_files, config)
-    parallel_findings = _scan_files_parallel(phi_files, config, worker_count=_PARITY_WORKER_COUNT)
+    sequential_findings = _run_sequential_scan(phi_files, config)
+    parallel_findings = _run_parallel_scan(phi_files, config, worker_count=_PARITY_WORKER_COUNT)
 
     sequential_paths = [f.file_path for f in sequential_findings]
     parallel_paths = [f.file_path for f in parallel_findings]

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -65,11 +65,11 @@ _PARITY_WORKER_COUNT: int = 2
 _WORKER_COUNT_ZERO: int = 0
 _WORKER_COUNT_NEGATIVE: int = -1
 _WORKER_COUNT_ABOVE_MAX: int = MAX_WORKER_COUNT + 1
-# PHI content written to parity test files. Uses a structurally valid SSN pattern
-# (high confidence regex match) so findings are consistently generated across both code paths.
-# 123-45-6789 uses area number 123, which the SSA has never assigned — it is
-# a well-known synthetic test value and is not a real individual's SSN.
-_PARITY_PHI_CONTENT: str = "patient_ssn = '123-45-6789'\n"
+# Path to the parity PHI fixture. The raw SSN literal lives under
+# tests/fixtures/phi/, which is excluded by .phi-scanignore so the scanner
+# never flags its own test corpus. Keeping the literal out of this source
+# file preserves the "never store raw PHI values in code" invariant.
+_PARITY_PHI_FIXTURE_PATH: Path = Path(__file__).parent / "fixtures" / "phi" / "parity.py"
 # Number of non-blank, non-comment patterns written by
 # test_load_ignore_patterns_skips_blank_lines: _SAMPLE_IGNORE_PATTERN ("*.log") and "*.tmp".
 # Update this constant if that test's fixture content changes.
@@ -591,9 +591,10 @@ def test_execute_scan_parallel_is_clean_for_no_phi_content(tmp_path: Path) -> No
 
 def _build_parity_files(root: Path, file_count: int) -> list[Path]:
     """Create file_count Python files with PHI content under root; return ordered list."""
+    parity_content = _PARITY_PHI_FIXTURE_PATH.read_text(encoding=DEFAULT_TEXT_ENCODING)
     files = [root / f"file_{index:03d}.py" for index in range(file_count)]
     for phi_file in files:
-        phi_file.write_text(_PARITY_PHI_CONTENT, encoding=DEFAULT_TEXT_ENCODING)
+        phi_file.write_text(parity_content, encoding=DEFAULT_TEXT_ENCODING)
     return files
 
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -26,8 +26,8 @@ from phi_scan.constants import (
 from phi_scan.exceptions import TraversalError
 from phi_scan.models import ScanConfig, ScanResult
 from phi_scan.scanner import (
-    _MIN_WORKER_COUNT,  # noqa: PLC2701
     MAX_WORKER_COUNT,
+    MIN_WORKER_COUNT,
     _passes_decompression_bomb_guards,  # noqa: PLC2701
     _scan_files_parallel,  # noqa: PLC2701
     _scan_files_sequential,  # noqa: PLC2701
@@ -530,7 +530,7 @@ def test_execute_scan_category_counts_all_zero_for_clean_scan() -> None:
 
 
 def test_execute_scan_worker_count_one_returns_scan_result() -> None:
-    scan_result = execute_scan([], _build_default_config(), worker_count=_MIN_WORKER_COUNT)
+    scan_result = execute_scan([], _build_default_config(), worker_count=MIN_WORKER_COUNT)
 
     assert isinstance(scan_result, ScanResult)
 
@@ -582,7 +582,7 @@ def test_parallel_scan_finding_count_matches_sequential(tmp_path: Path) -> None:
     phi_files = _build_parity_files(tmp_path, _PARITY_FILE_COUNT)
     config = _build_default_config()
 
-    sequential_result = execute_scan(phi_files, config, worker_count=_MIN_WORKER_COUNT)
+    sequential_result = execute_scan(phi_files, config, worker_count=MIN_WORKER_COUNT)
     parallel_result = execute_scan(phi_files, config, worker_count=_PARITY_WORKER_COUNT)
 
     assert len(parallel_result.findings) == len(sequential_result.findings)
@@ -592,7 +592,7 @@ def test_parallel_scan_file_paths_match_sequential(tmp_path: Path) -> None:
     phi_files = _build_parity_files(tmp_path, _PARITY_FILE_COUNT)
     config = _build_default_config()
 
-    sequential_result = execute_scan(phi_files, config, worker_count=_MIN_WORKER_COUNT)
+    sequential_result = execute_scan(phi_files, config, worker_count=MIN_WORKER_COUNT)
     parallel_result = execute_scan(phi_files, config, worker_count=_PARITY_WORKER_COUNT)
 
     sequential_paths = [f.file_path for f in sequential_result.findings]
@@ -604,7 +604,7 @@ def test_parallel_scan_value_hashes_match_sequential(tmp_path: Path) -> None:
     phi_files = _build_parity_files(tmp_path, _PARITY_FILE_COUNT)
     config = _build_default_config()
 
-    sequential_result = execute_scan(phi_files, config, worker_count=_MIN_WORKER_COUNT)
+    sequential_result = execute_scan(phi_files, config, worker_count=MIN_WORKER_COUNT)
     parallel_result = execute_scan(phi_files, config, worker_count=_PARITY_WORKER_COUNT)
 
     sequential_hashes = [f.value_hash for f in sequential_result.findings]
@@ -616,7 +616,7 @@ def test_parallel_scan_risk_level_matches_sequential(tmp_path: Path) -> None:
     phi_files = _build_parity_files(tmp_path, _PARITY_FILE_COUNT)
     config = _build_default_config()
 
-    sequential_result = execute_scan(phi_files, config, worker_count=_MIN_WORKER_COUNT)
+    sequential_result = execute_scan(phi_files, config, worker_count=MIN_WORKER_COUNT)
     parallel_result = execute_scan(phi_files, config, worker_count=_PARITY_WORKER_COUNT)
 
     assert parallel_result.risk_level == sequential_result.risk_level
@@ -627,13 +627,13 @@ def test_parallel_scan_risk_level_matches_sequential(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_scan_files_sequential_returns_empty_for_no_targets(tmp_path: Path) -> None:
+def test_scan_files_sequential_returns_empty_for_no_targets() -> None:
     findings = _scan_files_sequential([], _build_default_config())
 
     assert findings == []
 
 
-def test_scan_files_parallel_returns_empty_for_no_targets(tmp_path: Path) -> None:
+def test_scan_files_parallel_returns_empty_for_no_targets() -> None:
     findings = _scan_files_parallel([], _build_default_config(), worker_count=_PARITY_WORKER_COUNT)
 
     assert findings == []

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -26,6 +26,7 @@ from phi_scan.constants import (
 from phi_scan.exceptions import TraversalError
 from phi_scan.models import ScanConfig, ScanResult
 from phi_scan.scanner import (
+    _MIN_WORKER_COUNT,  # noqa: PLC2701
     MAX_WORKER_COUNT,
     _passes_decompression_bomb_guards,  # noqa: PLC2701
     _scan_files_parallel,  # noqa: PLC2701
@@ -60,8 +61,10 @@ _MINIMUM_SCAN_DURATION: float = 0.0
 _PARITY_FILE_COUNT: int = 6
 # Worker count used in parallel parity tests — must be > 1 to activate the parallel code path.
 _PARITY_WORKER_COUNT: int = 2
-# PHI content written to parity test files. Uses a structurally valid SSN (high
-# confidence regex match) so findings are consistently generated across both code paths.
+# PHI content written to parity test files. Uses a structurally valid SSN pattern
+# (high confidence regex match) so findings are consistently generated across both code paths.
+# 123-45-6789 uses area number 123, which the SSA has never assigned — it is
+# a well-known synthetic test value and is not a real individual's SSN.
 _PARITY_PHI_CONTENT: str = "patient_ssn = '123-45-6789'\n"
 # Number of non-blank, non-comment patterns written by
 # test_load_ignore_patterns_skips_blank_lines: _SAMPLE_IGNORE_PATTERN ("*.log") and "*.tmp".
@@ -526,14 +529,14 @@ def test_execute_scan_category_counts_all_zero_for_clean_scan() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_execute_scan_worker_count_one_returns_scan_result(tmp_path: Path) -> None:
-    scan_result = execute_scan([], _build_default_config(), worker_count=1)
+def test_execute_scan_worker_count_one_returns_scan_result() -> None:
+    scan_result = execute_scan([], _build_default_config(), worker_count=_MIN_WORKER_COUNT)
 
     assert isinstance(scan_result, ScanResult)
 
 
-def test_execute_scan_worker_count_two_returns_scan_result(tmp_path: Path) -> None:
-    scan_result = execute_scan([], _build_default_config(), worker_count=2)
+def test_execute_scan_worker_count_two_returns_scan_result() -> None:
+    scan_result = execute_scan([], _build_default_config(), worker_count=_PARITY_WORKER_COUNT)
 
     assert isinstance(scan_result, ScanResult)
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -589,17 +589,21 @@ def test_execute_scan_parallel_is_clean_for_no_phi_content(tmp_path: Path) -> No
 # ---------------------------------------------------------------------------
 
 
-def _build_parity_files(root: Path, file_count: int) -> list[Path]:
-    """Create file_count Python files with PHI content under root; return ordered list."""
-    parity_content = _PARITY_PHI_FIXTURE_PATH.read_text(encoding=DEFAULT_TEXT_ENCODING)
-    files = [root / f"file_{index:03d}.py" for index in range(file_count)]
-    for phi_file in files:
-        phi_file.write_text(parity_content, encoding=DEFAULT_TEXT_ENCODING)
-    return files
+def _collect_parity_file_paths(root: Path, file_count: int) -> list[Path]:
+    """Return the ordered synthesised paths for file_count parity PHI files under root."""
+    return [root / f"file_{index:03d}.py" for index in range(file_count)]
+
+
+def _write_parity_file_contents(parity_files: list[Path]) -> None:
+    """Write the synthetic PHI fixture content into each path in parity_files."""
+    phi_file_content = _PARITY_PHI_FIXTURE_PATH.read_text(encoding=DEFAULT_TEXT_ENCODING)
+    for phi_file in parity_files:
+        phi_file.write_text(phi_file_content, encoding=DEFAULT_TEXT_ENCODING)
 
 
 def test_parallel_scan_finding_count_matches_sequential(tmp_path: Path) -> None:
-    phi_files = _build_parity_files(tmp_path, _PARITY_FILE_COUNT)
+    phi_files = _collect_parity_file_paths(tmp_path, _PARITY_FILE_COUNT)
+    _write_parity_file_contents(phi_files)
     config = _build_default_config()
 
     sequential_result = execute_scan(phi_files, config, worker_count=MIN_WORKER_COUNT)
@@ -609,7 +613,8 @@ def test_parallel_scan_finding_count_matches_sequential(tmp_path: Path) -> None:
 
 
 def test_parallel_scan_file_paths_match_sequential(tmp_path: Path) -> None:
-    phi_files = _build_parity_files(tmp_path, _PARITY_FILE_COUNT)
+    phi_files = _collect_parity_file_paths(tmp_path, _PARITY_FILE_COUNT)
+    _write_parity_file_contents(phi_files)
     config = _build_default_config()
 
     sequential_result = execute_scan(phi_files, config, worker_count=MIN_WORKER_COUNT)
@@ -621,7 +626,8 @@ def test_parallel_scan_file_paths_match_sequential(tmp_path: Path) -> None:
 
 
 def test_parallel_scan_value_hashes_match_sequential(tmp_path: Path) -> None:
-    phi_files = _build_parity_files(tmp_path, _PARITY_FILE_COUNT)
+    phi_files = _collect_parity_file_paths(tmp_path, _PARITY_FILE_COUNT)
+    _write_parity_file_contents(phi_files)
     config = _build_default_config()
 
     sequential_result = execute_scan(phi_files, config, worker_count=MIN_WORKER_COUNT)
@@ -633,7 +639,8 @@ def test_parallel_scan_value_hashes_match_sequential(tmp_path: Path) -> None:
 
 
 def test_parallel_scan_risk_level_matches_sequential(tmp_path: Path) -> None:
-    phi_files = _build_parity_files(tmp_path, _PARITY_FILE_COUNT)
+    phi_files = _collect_parity_file_paths(tmp_path, _PARITY_FILE_COUNT)
+    _write_parity_file_contents(phi_files)
     config = _build_default_config()
 
     sequential_result = execute_scan(phi_files, config, worker_count=MIN_WORKER_COUNT)
@@ -660,7 +667,8 @@ def test_run_parallel_scan_returns_empty_for_no_targets() -> None:
 
 
 def test_run_parallel_scan_preserves_order(tmp_path: Path) -> None:
-    phi_files = _build_parity_files(tmp_path, _PARITY_FILE_COUNT)
+    phi_files = _collect_parity_file_paths(tmp_path, _PARITY_FILE_COUNT)
+    _write_parity_file_contents(phi_files)
     config = _build_default_config()
 
     sequential_findings = _run_sequential_scan(phi_files, config)

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -29,13 +29,13 @@ from phi_scan.scanner import (
     MAX_WORKER_COUNT,
     MIN_WORKER_COUNT,
     _passes_decompression_bomb_guards,  # noqa: PLC2701
-    _run_parallel_scan,  # noqa: PLC2701
     _run_sequential_scan,  # noqa: PLC2701
     collect_scan_targets,
     execute_scan,
     is_binary_file,
     is_path_excluded,
     load_ignore_patterns,
+    run_parallel_scan,
     scan_file,
 )
 
@@ -643,7 +643,7 @@ def test_parallel_scan_risk_level_matches_sequential(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# _run_sequential_scan and _run_parallel_scan — unit tests
+# _run_sequential_scan and run_parallel_scan — unit tests
 # ---------------------------------------------------------------------------
 
 
@@ -654,7 +654,7 @@ def test_run_sequential_scan_returns_empty_for_no_targets() -> None:
 
 
 def test_run_parallel_scan_returns_empty_for_no_targets() -> None:
-    findings = _run_parallel_scan([], _build_default_config(), worker_count=_PARITY_WORKER_COUNT)
+    findings = run_parallel_scan([], _build_default_config(), worker_count=_PARITY_WORKER_COUNT)
 
     assert findings == []
 
@@ -664,7 +664,7 @@ def test_run_parallel_scan_preserves_order(tmp_path: Path) -> None:
     config = _build_default_config()
 
     sequential_findings = _run_sequential_scan(phi_files, config)
-    parallel_findings = _run_parallel_scan(phi_files, config, worker_count=_PARITY_WORKER_COUNT)
+    parallel_findings = run_parallel_scan(phi_files, config, worker_count=_PARITY_WORKER_COUNT)
 
     sequential_paths = [f.file_path for f in sequential_findings]
     parallel_paths = [f.file_path for f in parallel_findings]

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -582,7 +582,7 @@ def test_parallel_scan_finding_count_matches_sequential(tmp_path: Path) -> None:
     phi_files = _build_parity_files(tmp_path, _PARITY_FILE_COUNT)
     config = _build_default_config()
 
-    sequential_result = execute_scan(phi_files, config, worker_count=1)
+    sequential_result = execute_scan(phi_files, config, worker_count=_MIN_WORKER_COUNT)
     parallel_result = execute_scan(phi_files, config, worker_count=_PARITY_WORKER_COUNT)
 
     assert len(parallel_result.findings) == len(sequential_result.findings)
@@ -592,7 +592,7 @@ def test_parallel_scan_file_paths_match_sequential(tmp_path: Path) -> None:
     phi_files = _build_parity_files(tmp_path, _PARITY_FILE_COUNT)
     config = _build_default_config()
 
-    sequential_result = execute_scan(phi_files, config, worker_count=1)
+    sequential_result = execute_scan(phi_files, config, worker_count=_MIN_WORKER_COUNT)
     parallel_result = execute_scan(phi_files, config, worker_count=_PARITY_WORKER_COUNT)
 
     sequential_paths = [f.file_path for f in sequential_result.findings]
@@ -604,7 +604,7 @@ def test_parallel_scan_value_hashes_match_sequential(tmp_path: Path) -> None:
     phi_files = _build_parity_files(tmp_path, _PARITY_FILE_COUNT)
     config = _build_default_config()
 
-    sequential_result = execute_scan(phi_files, config, worker_count=1)
+    sequential_result = execute_scan(phi_files, config, worker_count=_MIN_WORKER_COUNT)
     parallel_result = execute_scan(phi_files, config, worker_count=_PARITY_WORKER_COUNT)
 
     sequential_hashes = [f.value_hash for f in sequential_result.findings]
@@ -616,7 +616,7 @@ def test_parallel_scan_risk_level_matches_sequential(tmp_path: Path) -> None:
     phi_files = _build_parity_files(tmp_path, _PARITY_FILE_COUNT)
     config = _build_default_config()
 
-    sequential_result = execute_scan(phi_files, config, worker_count=1)
+    sequential_result = execute_scan(phi_files, config, worker_count=_MIN_WORKER_COUNT)
     parallel_result = execute_scan(phi_files, config, worker_count=_PARITY_WORKER_COUNT)
 
     assert parallel_result.risk_level == sequential_result.risk_level


### PR DESCRIPTION
### Problem Statement
File scanning was strictly sequential. Large codebases with thousands of files had no way to leverage multiple CPU cores, creating a performance ceiling for CI scans.

### Scope
- In Scope: `--workers N` CLI flag, `ThreadPoolExecutor`-based parallel file scan, determinism guarantee (identical output to sequential mode), parity tests.
- Out of Scope: config-file support for `workers` (deferred), multiprocessing, watch-mode parallelism.

### What Changed
**`phi_scan/scanner.py`**
- `MAX_WORKER_COUNT = 32` — public constant; CLI imports for validation.
- `_scan_files_sequential` / `_scan_files_parallel` — private helpers extracted from the scan loop.
- `execute_scan` gains `worker_count: int = 1`; dispatches to parallel path when > 1. `executor.map()` preserves scan_targets order regardless of thread completion order — sequential and parallel output is bit-for-bit identical.

**`phi_scan/cli.py`**
- `--workers` option added to `scan` command (default 1, validated ≥ 1 and ≤ 32).
- `_ScanExecutionOptions` dataclass bundles `worker_count` + `should_show_progress` so `_execute_scan_with_progress` stays within the 3-argument rule.
- `_ParallelProgressScan` dataclass bundles progress-bar state.
- `_scan_files_parallel_with_progress` uses `as_completed()` for a responsive progress bar; results are re-sorted by original index before returning.
- Default `worker_count=1` preserves all existing sequential behaviour exactly.

**`tests/test_scanner.py`**
- Parity tests: sequential vs `workers=2` produce identical finding count, file_path order, value_hash sequence, and risk_level.
- Unit tests for `_scan_files_sequential`, `_scan_files_parallel`, and `execute_scan(worker_count=...)`.

### Files Changed
- `phi_scan/scanner.py` — parallel engine
- `phi_scan/cli.py` — `--workers` flag + progress-bar parallel path
- `tests/test_scanner.py` — parity and unit tests

### Validation / Testing
- `uv run pytest -x -q --no-cov` → 1749 passed, 0 failures
- `uv run ruff check` → clean
- `uv run ruff format --check` → clean
- `uv run mypy phi_scan/scanner.py phi_scan/cli.py` → no issues (pre-existing errors in nlp_detector.py and hl7_scanner.py are unrelated to this PR)

### Security Impact
- Risk introduced: none. Workers scan local files only; no network activity.
- Cache (SQLite) uses per-call connections — thread-safe under concurrent access. Worst case is idempotent UPSERT contention, which is harmless.
- Residual risk: none.

### Backward Compatibility Impact
- User-facing changes: new `--workers` flag; default value 1 preserves existing behaviour exactly.
- Migration required: no.

### Documentation Updates
`docs/PROGRAM_SCORECARD.md` checks T4, T5, and A7 will be updated to PASS after this merges.

### Rollback Plan
Revert the three-file commit. No schema changes; no data migration required.

### Checklist
- [x] Tests updated (parity + unit tests added)
- [x] Security reviewed (no new risk)
- [x] Compatibility reviewed (default worker_count=1 preserves existing behaviour)
- [x] No AI/bot references