### PR TITLE
feat: plugin API v1 — BaseRecognizer, loader, registry (A1/A2/A3)

### DIFF
--- a/phi_scan/__init__.py
+++ b/phi_scan/__init__.py
@@ -1,4 +1,20 @@
 """PhiScan — HIPAA & FHIR compliant PHI/PII scanner for CI/CD pipelines."""
 
+from phi_scan.plugin_api import (
+    PLUGIN_API_VERSION,
+    BaseRecognizer,
+    ScanContext,
+    ScanFinding,
+)
+
 __version__ = "0.5.0"
 __app_name__ = "phi-scan"
+
+__all__ = [
+    "BaseRecognizer",
+    "PLUGIN_API_VERSION",
+    "ScanContext",
+    "ScanFinding",
+    "__app_name__",
+    "__version__",
+]

--- a/phi_scan/exceptions.py
+++ b/phi_scan/exceptions.py
@@ -171,10 +171,13 @@ class PluginValidationError(PhiScanError):
     """Raised internally by the plugin loader when a discovered recognizer
     fails Plugin API v1 validation.
 
-    This exception is never surfaced to callers. The loader catches it,
+    The loader catches every instance before it can reach a scan caller,
     logs the reason at WARNING level, and records the plugin in the
     skipped list of the returned ``PluginRegistry`` so PR-2's
-    ``phi-scan plugins list`` command can display the reason.
+    ``phi-scan plugins list`` command can display the reason. It is
+    exported from ``phi_scan.exceptions`` so the loader and its test
+    suite can reference it as a normal member of the domain-error
+    hierarchy, but scan callers should never see it raised.
 
     Args:
         message: Description of the validation failure including the

--- a/phi_scan/exceptions.py
+++ b/phi_scan/exceptions.py
@@ -21,6 +21,7 @@ __all__ = [
     "PhiDetectionError",
     "PhiScanError",
     "PhiScanLoggingError",
+    "PluginValidationError",
     "SchemaMigrationError",
     "TraversalError",
 ]
@@ -163,6 +164,21 @@ class SchemaMigrationError(PhiScanError):
     Args:
         message: Description of the migration failure including the source
             version, the target version, and the reason it could not complete.
+    """
+
+
+class PluginValidationError(PhiScanError):
+    """Raised internally by the plugin loader when a discovered recognizer
+    fails Plugin API v1 validation.
+
+    This exception is never surfaced to callers. The loader catches it,
+    logs the reason at WARNING level, and records the plugin in the
+    skipped list of the returned ``PluginRegistry`` so PR-2's
+    ``phi-scan plugins list`` command can display the reason.
+
+    Args:
+        message: Description of the validation failure including the
+            offending attribute or value and what was expected.
     """
 
 

--- a/phi_scan/plugin_api.py
+++ b/phi_scan/plugin_api.py
@@ -144,7 +144,8 @@ class ScanFinding:
 
     def __post_init__(self) -> None:
         self._reject_invalid_entity_type()
-        self._reject_invalid_offsets()
+        self._reject_negative_start_offset()
+        self._reject_non_increasing_end_offset()
         self._reject_invalid_confidence()
 
     def _reject_invalid_entity_type(self) -> None:
@@ -157,21 +158,25 @@ class ScanFinding:
             )
         )
 
-    def _reject_invalid_offsets(self) -> None:
-        if self.start_offset < MIN_START_OFFSET:
-            raise ValueError(
-                _INVALID_START_OFFSET_ERROR.format(
-                    minimum=MIN_START_OFFSET,
-                    start_offset=self.start_offset,
-                )
+    def _reject_negative_start_offset(self) -> None:
+        if self.start_offset >= MIN_START_OFFSET:
+            return
+        raise ValueError(
+            _INVALID_START_OFFSET_ERROR.format(
+                minimum=MIN_START_OFFSET,
+                start_offset=self.start_offset,
             )
-        if self.end_offset <= self.start_offset:
-            raise ValueError(
-                _INVALID_END_OFFSET_ERROR.format(
-                    end_offset=self.end_offset,
-                    start_offset=self.start_offset,
-                )
+        )
+
+    def _reject_non_increasing_end_offset(self) -> None:
+        if self.end_offset > self.start_offset:
+            return
+        raise ValueError(
+            _INVALID_END_OFFSET_ERROR.format(
+                end_offset=self.end_offset,
+                start_offset=self.start_offset,
             )
+        )
 
     def _reject_invalid_confidence(self) -> None:
         if MIN_CONFIDENCE_SCORE <= self.confidence <= MAX_CONFIDENCE_SCORE:

--- a/phi_scan/plugin_api.py
+++ b/phi_scan/plugin_api.py
@@ -144,51 +144,35 @@ class ScanFinding:
     confidence: float
 
     def __post_init__(self) -> None:
-        self._reject_invalid_entity_type()
-        self._reject_negative_start_offset()
-        self._reject_non_increasing_end_offset()
-        self._reject_invalid_confidence()
-
-    def _reject_invalid_entity_type(self) -> None:
-        if ENTITY_TYPE_PATTERN.match(self.entity_type):
-            return
-        raise ValueError(
-            _INVALID_ENTITY_TYPE_ERROR.format(
-                entity_type=self.entity_type,
-                pattern=ENTITY_TYPE_PATTERN.pattern,
+        if not ENTITY_TYPE_PATTERN.match(self.entity_type):
+            raise ValueError(
+                _INVALID_ENTITY_TYPE_ERROR.format(
+                    entity_type=self.entity_type,
+                    pattern=ENTITY_TYPE_PATTERN.pattern,
+                )
             )
-        )
-
-    def _reject_negative_start_offset(self) -> None:
-        if self.start_offset >= MIN_START_OFFSET:
-            return
-        raise ValueError(
-            _INVALID_START_OFFSET_ERROR.format(
-                minimum=MIN_START_OFFSET,
-                start_offset=self.start_offset,
+        if self.start_offset < MIN_START_OFFSET:
+            raise ValueError(
+                _INVALID_START_OFFSET_ERROR.format(
+                    minimum=MIN_START_OFFSET,
+                    start_offset=self.start_offset,
+                )
             )
-        )
-
-    def _reject_non_increasing_end_offset(self) -> None:
-        if self.end_offset > self.start_offset:
-            return
-        raise ValueError(
-            _INVALID_END_OFFSET_ERROR.format(
-                end_offset=self.end_offset,
-                start_offset=self.start_offset,
+        if self.end_offset <= self.start_offset:
+            raise ValueError(
+                _INVALID_END_OFFSET_ERROR.format(
+                    end_offset=self.end_offset,
+                    start_offset=self.start_offset,
+                )
             )
-        )
-
-    def _reject_invalid_confidence(self) -> None:
-        if MIN_CONFIDENCE_SCORE <= self.confidence <= MAX_CONFIDENCE_SCORE:
-            return
-        raise ValueError(
-            _INVALID_CONFIDENCE_ERROR.format(
-                minimum=MIN_CONFIDENCE_SCORE,
-                maximum=MAX_CONFIDENCE_SCORE,
-                confidence=self.confidence,
+        if not MIN_CONFIDENCE_SCORE <= self.confidence <= MAX_CONFIDENCE_SCORE:
+            raise ValueError(
+                _INVALID_CONFIDENCE_ERROR.format(
+                    minimum=MIN_CONFIDENCE_SCORE,
+                    maximum=MAX_CONFIDENCE_SCORE,
+                    confidence=self.confidence,
+                )
             )
-        )
 
 
 class BaseRecognizer(ABC):

--- a/phi_scan/plugin_api.py
+++ b/phi_scan/plugin_api.py
@@ -42,13 +42,7 @@ from pathlib import Path
 
 __all__ = [
     "BaseRecognizer",
-    "ENTITY_TYPE_PATTERN",
-    "MAX_CONFIDENCE_SCORE",
-    "MIN_CONFIDENCE_SCORE",
-    "MIN_LINE_NUMBER",
-    "MIN_START_OFFSET",
     "PLUGIN_API_VERSION",
-    "RECOGNIZER_NAME_PATTERN",
     "ScanContext",
     "ScanFinding",
 ]

--- a/phi_scan/plugin_api.py
+++ b/phi_scan/plugin_api.py
@@ -1,1 +1,258 @@
-"""Plugin system base classes and entry point discovery (Phase 8)."""
+"""Plugin API v1 — stable public surface for third-party PhiScan recognizers.
+
+This module defines the contract that third-party packages register
+against the ``phi_scan.plugins`` entry-point group. The public surface
+is intentionally minimal: a base class, two frozen dataclasses, and a
+version constant. Internal PhiScan models are NOT exposed here so that
+future refactors cannot break installed plugins.
+
+Version-compatibility policy for v1:
+
+    * The host declares ``PLUGIN_API_VERSION`` (currently ``"1.0"``).
+    * A plugin must declare the same string on
+      ``BaseRecognizer.plugin_api_version`` for the loader to accept
+      it. Any other value results in the plugin being skipped with a
+      WARNING.
+    * The exact-match rule is deliberate — v1 rollout prioritises a
+      clear compatibility boundary. Semver-range support may be added
+      in a future API version once the deprecation process is in
+      place; see ``docs/plugin-api-v1.md`` for the full policy.
+
+Canonical imports::
+
+    from phi_scan.plugin_api import (
+        BaseRecognizer,
+        PLUGIN_API_VERSION,
+        ScanContext,
+        ScanFinding,
+    )
+
+The same four names are re-exported at the ``phi_scan`` package root
+for convenience; both import paths are supported and stable across
+the 1.x line.
+"""
+
+from __future__ import annotations
+
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "BaseRecognizer",
+    "ENTITY_TYPE_PATTERN",
+    "MAX_CONFIDENCE_SCORE",
+    "MIN_CONFIDENCE_SCORE",
+    "MIN_LINE_NUMBER",
+    "MIN_START_OFFSET",
+    "PLUGIN_API_VERSION",
+    "RECOGNIZER_NAME_PATTERN",
+    "ScanContext",
+    "ScanFinding",
+]
+
+PLUGIN_API_VERSION: str = "1.0"
+
+RECOGNIZER_NAME_PATTERN: re.Pattern[str] = re.compile(r"^[a-z][a-z0-9_]*$")
+ENTITY_TYPE_PATTERN: re.Pattern[str] = re.compile(r"^[A-Z][A-Z0-9_]*$")
+
+MIN_CONFIDENCE_SCORE: float = 0.0
+MAX_CONFIDENCE_SCORE: float = 1.0
+MIN_START_OFFSET: int = 0
+MIN_LINE_NUMBER: int = 1
+
+_DEFAULT_PLUGIN_VERSION: str = "0.0.0"
+_DEFAULT_PLUGIN_DESCRIPTION: str = ""
+
+_INVALID_START_OFFSET_ERROR: str = (
+    "ScanFinding.start_offset must be >= {minimum}, got {start_offset}"
+)
+_INVALID_END_OFFSET_ERROR: str = (
+    "ScanFinding.end_offset ({end_offset}) must be strictly greater than "
+    "start_offset ({start_offset})"
+)
+_INVALID_CONFIDENCE_ERROR: str = (
+    "ScanFinding.confidence must be in [{minimum}, {maximum}], got {confidence}"
+)
+_INVALID_ENTITY_TYPE_ERROR: str = (
+    "ScanFinding.entity_type {entity_type!r} must match pattern {pattern!r} "
+    "(uppercase ASCII, starting with a letter)"
+)
+_INVALID_LINE_NUMBER_ERROR: str = "ScanContext.line_number must be >= {minimum}, got {line_number}"
+
+
+@dataclass(frozen=True)
+class ScanContext:
+    """Per-line context passed to ``BaseRecognizer.detect``.
+
+    Attributes:
+        file_path: Absolute path of the file currently being scanned.
+            Plugins must not open or stat this path; it is provided
+            for logging and language-gating only.
+        line_number: 1-indexed line number of the line being examined.
+        file_extension: File extension including the leading dot (e.g.
+            ``".py"``). Empty string when the file has no extension.
+            Plugins use this to skip files whose language they do not
+            handle.
+    """
+
+    file_path: Path
+    line_number: int
+    file_extension: str
+
+    def __post_init__(self) -> None:
+        if self.line_number < MIN_LINE_NUMBER:
+            raise ValueError(
+                _INVALID_LINE_NUMBER_ERROR.format(
+                    minimum=MIN_LINE_NUMBER, line_number=self.line_number
+                )
+            )
+
+
+@dataclass(frozen=True)
+class ScanFinding:
+    """A single detection emitted by a plugin recognizer.
+
+    The dataclass validates its arguments in ``__post_init__`` so
+    plugin authors see malformed findings at construction time. The
+    host applies additional defensive checks at runtime (see the
+    plugin-loader module for the execution-time validation rules).
+
+    Note:
+        ``end_offset`` is NOT bounds-checked against the line text
+        here because the line is not part of the dataclass. The host
+        validates ``end_offset <= len(line)`` at execution time and
+        drops any overrunning finding with a WARNING.
+
+    Attributes:
+        entity_type: One of the uppercase entity-type strings declared
+            on the recognizer's ``entity_types`` list. Must match
+            ``ENTITY_TYPE_PATTERN``.
+        start_offset: 0-indexed column where the match starts.
+        end_offset: Exclusive 0-indexed column where the match ends.
+            Must be strictly greater than ``start_offset``.
+        confidence: Match confidence in [0.0, 1.0]. Host-side severity
+            derivation combines this with a per-entity weight; plugins
+            must not pre-inflate confidence to raise severity.
+    """
+
+    entity_type: str
+    start_offset: int
+    end_offset: int
+    confidence: float
+
+    def __post_init__(self) -> None:
+        self._reject_invalid_entity_type()
+        self._reject_invalid_offsets()
+        self._reject_invalid_confidence()
+
+    def _reject_invalid_entity_type(self) -> None:
+        if ENTITY_TYPE_PATTERN.match(self.entity_type):
+            return
+        raise ValueError(
+            _INVALID_ENTITY_TYPE_ERROR.format(
+                entity_type=self.entity_type,
+                pattern=ENTITY_TYPE_PATTERN.pattern,
+            )
+        )
+
+    def _reject_invalid_offsets(self) -> None:
+        if self.start_offset < MIN_START_OFFSET:
+            raise ValueError(
+                _INVALID_START_OFFSET_ERROR.format(
+                    minimum=MIN_START_OFFSET,
+                    start_offset=self.start_offset,
+                )
+            )
+        if self.end_offset <= self.start_offset:
+            raise ValueError(
+                _INVALID_END_OFFSET_ERROR.format(
+                    end_offset=self.end_offset,
+                    start_offset=self.start_offset,
+                )
+            )
+
+    def _reject_invalid_confidence(self) -> None:
+        if MIN_CONFIDENCE_SCORE <= self.confidence <= MAX_CONFIDENCE_SCORE:
+            return
+        raise ValueError(
+            _INVALID_CONFIDENCE_ERROR.format(
+                minimum=MIN_CONFIDENCE_SCORE,
+                maximum=MAX_CONFIDENCE_SCORE,
+                confidence=self.confidence,
+            )
+        )
+
+
+class BaseRecognizer(ABC):
+    """Abstract base class for third-party recognizer plugins.
+
+    Subclasses declare class-level ``name``, ``entity_types``, and
+    (optionally) ``version`` and ``description``. The host instantiates
+    subclasses with no constructor arguments and calls ``detect`` once
+    per scanned line.
+
+    Class attribute contract:
+
+        * ``name`` — lowercase snake_case identifier matching
+          ``RECOGNIZER_NAME_PATTERN``. Used as the collision key for
+          deduplicating recognizers across installed distributions.
+        * ``entity_types`` — non-empty list of uppercase strings, each
+          matching ``ENTITY_TYPE_PATTERN`` and unique within the list.
+          Every ``ScanFinding`` returned by this recognizer MUST
+          declare an ``entity_type`` that appears in this list.
+        * ``plugin_api_version`` — must equal the host's
+          ``PLUGIN_API_VERSION`` constant for the plugin to be loaded.
+          Defaults to ``"1.0"``.
+        * ``version`` — plugin's own semantic version, informational.
+          Defaults to ``"0.0.0"``.
+        * ``description`` — one-line human description, informational.
+          Defaults to ``""``.
+
+    Lifecycle:
+
+        1. The host discovers the class via the ``phi_scan.plugins``
+           entry-point group at startup.
+        2. The loader validates the class attributes and
+           ``plugin_api_version`` and rejects any plugin whose metadata
+           fails validation (logged at WARNING, never raised).
+        3. The loader calls ``RecognizerClass()`` — no arguments —
+           and stores the resulting instance in the plugin registry.
+        4. During a scan the host calls ``detect(line, context)`` once
+           per line; the recognizer returns zero or more
+           ``ScanFinding`` objects.
+
+    Plugin authors MUST NOT:
+
+        * Read, open, or mutate files at ``context.file_path`` — it
+          is supplied for language-gating and logging only.
+        * Include raw PHI values in any ``ScanFinding`` — the host
+          hashes the matched line slice to enforce value-hash
+          consistency and the plugin never sees the hash.
+        * Send any data to a remote service — PhiScan is an offline
+          scanner and plugins inherit that guarantee.
+    """
+
+    name: str
+    entity_types: list[str]
+    plugin_api_version: str = PLUGIN_API_VERSION
+    version: str = _DEFAULT_PLUGIN_VERSION
+    description: str = _DEFAULT_PLUGIN_DESCRIPTION
+
+    @abstractmethod
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        """Return ``ScanFinding`` objects for the given line.
+
+        Args:
+            line: The full text of the line, without its trailing
+                newline. May be empty.
+            context: Per-line metadata about where the line lives.
+
+        Returns:
+            Zero or more ``ScanFinding`` objects. An empty list means
+            the line contains nothing this recognizer cares about.
+            Raising from ``detect`` is allowed; the host catches the
+            exception and drops the batch for that line with a
+            WARNING-level log entry.
+        """

--- a/phi_scan/plugin_api.py
+++ b/phi_scan/plugin_api.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import re
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -203,10 +204,12 @@ class BaseRecognizer(ABC):
         * ``name`` — lowercase snake_case identifier matching
           ``RECOGNIZER_NAME_PATTERN``. Used as the collision key for
           deduplicating recognizers across installed distributions.
-        * ``entity_types`` — non-empty list of uppercase strings, each
-          matching ``ENTITY_TYPE_PATTERN`` and unique within the list.
+        * ``entity_types`` — non-empty sequence of uppercase strings
+          (``tuple`` preferred for immutability, ``list`` also accepted
+          for backwards compatibility). Each string must match
+          ``ENTITY_TYPE_PATTERN`` and be unique within the sequence.
           Every ``ScanFinding`` returned by this recognizer MUST
-          declare an ``entity_type`` that appears in this list.
+          declare an ``entity_type`` that appears in this sequence.
         * ``plugin_api_version`` — must equal the host's
           ``PLUGIN_API_VERSION`` constant for the plugin to be loaded.
           Defaults to ``"1.0"``.
@@ -240,7 +243,7 @@ class BaseRecognizer(ABC):
     """
 
     name: str
-    entity_types: list[str]
+    entity_types: Sequence[str]
     plugin_api_version: str = PLUGIN_API_VERSION
     version: str = _DEFAULT_PLUGIN_VERSION
     description: str = _DEFAULT_PLUGIN_DESCRIPTION

--- a/phi_scan/plugin_api.py
+++ b/phi_scan/plugin_api.py
@@ -258,7 +258,12 @@ class BaseRecognizer(ABC):
             context: Per-line metadata about where the line lives.
 
         Returns:
-            Zero or more ``ScanFinding`` objects. An empty list means
+            A freshly constructed list of zero or more ``ScanFinding``
+            objects. Plugins MUST return a new list on every call and
+            MUST NOT retain or reuse a shared mutable list across
+            invocations — the host may iterate, extend, or otherwise
+            consume the returned list, and aliasing would cause findings
+            from one line to bleed into another. An empty list means
             the line contains nothing this recognizer cares about.
             Raising from ``detect`` is allowed; the host catches the
             exception and drops the batch for that line with a

--- a/phi_scan/plugin_loader.py
+++ b/phi_scan/plugin_loader.py
@@ -21,7 +21,7 @@ returned here is the hand-off point for that later work.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from importlib.metadata import EntryPoint, entry_points
 
 from phi_scan.exceptions import PluginValidationError
@@ -61,8 +61,8 @@ _API_VERSION_MISMATCH_REASON: str = (
     "plugin_api_version {plugin_version!r} does not match host {host_version!r}"
 )
 _NAME_COLLISION_REASON: str = "name {name!r} already registered by a previous plugin"
-_IMPORT_FAILURE_REASON: str = "entry-point load failed: {error}"
-_INSTANTIATION_FAILURE_REASON: str = "recognizer constructor raised: {error}"
+_IMPORT_FAILURE_REASON: str = "entry-point load failed with {error_type}"
+_INSTANTIATION_FAILURE_REASON: str = "recognizer constructor raised {error_type}"
 
 _SKIPPED_PLUGIN_LOG_MESSAGE: str = "Skipping plugin %r from %s: %s"
 
@@ -116,8 +116,8 @@ class PluginRegistry:
             same deterministic order.
     """
 
-    loaded: tuple[LoadedPlugin, ...] = field(default_factory=tuple)
-    skipped: tuple[SkippedPlugin, ...] = field(default_factory=tuple)
+    loaded: tuple[LoadedPlugin, ...] = ()
+    skipped: tuple[SkippedPlugin, ...] = ()
 
 
 def load_plugin_registry() -> PluginRegistry:
@@ -207,7 +207,9 @@ def _load_entry_point_class(entry_point: EntryPoint) -> type[BaseRecognizer]:
     try:
         loaded_object = entry_point.load()
     except (ImportError, AttributeError) as load_error:
-        raise PluginValidationError(_IMPORT_FAILURE_REASON.format(error=load_error)) from load_error
+        raise PluginValidationError(
+            _IMPORT_FAILURE_REASON.format(error_type=type(load_error).__name__)
+        ) from load_error
     if not isinstance(loaded_object, type):
         raise PluginValidationError(_NOT_A_CLASS_REASON)
     if not issubclass(loaded_object, BaseRecognizer):
@@ -303,12 +305,16 @@ def _instantiate_recognizer(
     # plugin must never crash the scan or leak a raw traceback to the CLI. The
     # exception is re-raised as PluginValidationError so the loader records it
     # in the skipped list and continues. BaseException (SystemExit,
-    # KeyboardInterrupt) is deliberately not caught.
+    # KeyboardInterrupt) is deliberately not caught. Only the exception type
+    # name is embedded in the reason — the raw message is intentionally
+    # dropped because a plugin constructor may have read a value from the
+    # environment (env var, file, DB) that could incidentally contain PHI,
+    # and the reason string is logged at WARNING level.
     try:
         return recognizer_class()
     except Exception as init_error:  # noqa: BLE001 — see comment above
         raise PluginValidationError(
-            _INSTANTIATION_FAILURE_REASON.format(error=init_error)
+            _INSTANTIATION_FAILURE_REASON.format(error_type=type(init_error).__name__)
         ) from init_error
 
 

--- a/phi_scan/plugin_loader.py
+++ b/phi_scan/plugin_loader.py
@@ -59,7 +59,6 @@ _INVALID_ENTITY_TYPE_REASON: str = (
     "entity_types[{index}] {value!r} does not match pattern {pattern}"
 )
 _DUPLICATE_ENTITY_TYPE_REASON: str = "entity_types contains duplicate entry {value!r}"
-_MISSING_API_VERSION_REASON: str = "class does not declare 'plugin_api_version'"
 _API_VERSION_MISMATCH_REASON: str = (
     "plugin_api_version {plugin_version!r} does not match host {host_version!r}"
 )
@@ -134,21 +133,21 @@ def load_plugin_registry() -> PluginRegistry:
         entries and logged at WARNING level.
     """
     sorted_entry_points = _sort_entry_points_deterministically(_discover_entry_points())
-    loaded_plugins, skipped_plugins = _partition_entry_points_into_registry(sorted_entry_points)
+    loaded_plugins, skipped_plugins = _build_registry_lists(sorted_entry_points)
     return PluginRegistry(
         loaded=tuple(loaded_plugins),
         skipped=tuple(skipped_plugins),
     )
 
 
-def _partition_entry_points_into_registry(
+def _build_registry_lists(
     sorted_entry_points: tuple[EntryPoint, ...],
 ) -> tuple[list[LoadedPlugin], list[SkippedPlugin]]:
     loaded_plugins: list[LoadedPlugin] = []
     skipped_plugins: list[SkippedPlugin] = []
     reserved_names: set[str] = set()
     for entry_point in sorted_entry_points:
-        load_outcome = _resolve_plugin_from_entry_point(entry_point, reserved_names)
+        load_outcome = _load_or_skip_entry_point(entry_point, reserved_names)
         if isinstance(load_outcome, LoadedPlugin):
             loaded_plugins.append(load_outcome)
             reserved_names.add(load_outcome.recognizer.name)
@@ -183,7 +182,7 @@ def _resolve_distribution_name(entry_point: EntryPoint) -> str | None:
     return distribution.name
 
 
-def _resolve_plugin_from_entry_point(
+def _load_or_skip_entry_point(
     entry_point: EntryPoint,
     reserved_names: set[str],
 ) -> LoadedPlugin | SkippedPlugin:
@@ -242,9 +241,12 @@ def _validate_recognizer_class(recognizer_class: type[BaseRecognizer]) -> None:
 
 
 def _validate_api_version(recognizer_class: type[BaseRecognizer]) -> None:
-    declared_version = getattr(recognizer_class, "plugin_api_version", None)
-    if declared_version is None:
-        raise PluginValidationError(_MISSING_API_VERSION_REASON)
+    # BaseRecognizer declares ``plugin_api_version: str = PLUGIN_API_VERSION`` as
+    # a class attribute, so any subclass that passed the ``issubclass`` check in
+    # ``_load_entry_point_class`` inherits a value. A deliberate override to a
+    # non-matching value (including ``None``) falls through to the mismatch
+    # error below, which is the correct outcome.
+    declared_version = recognizer_class.plugin_api_version
     if declared_version != PLUGIN_API_VERSION:
         raise PluginValidationError(
             _API_VERSION_MISMATCH_REASON.format(

--- a/phi_scan/plugin_loader.py
+++ b/phi_scan/plugin_loader.py
@@ -134,6 +134,8 @@ def load_plugin_registry() -> PluginRegistry:
     """
     sorted_entry_points = _sort_entry_points_deterministically(_discover_entry_points())
     loaded_plugins, skipped_plugins = _build_registry_lists(sorted_entry_points)
+    for skipped_plugin in skipped_plugins:
+        _log_skipped_plugin(skipped_plugin)
     return PluginRegistry(
         loaded=tuple(loaded_plugins),
         skipped=tuple(skipped_plugins),
@@ -153,7 +155,6 @@ def _build_registry_lists(
             reserved_names.add(load_outcome.recognizer.name)
             continue
         skipped_plugins.append(load_outcome)
-        _log_skipped_plugin(load_outcome)
     return loaded_plugins, skipped_plugins
 
 

--- a/phi_scan/plugin_loader.py
+++ b/phi_scan/plugin_loader.py
@@ -1,0 +1,309 @@
+"""Plugin discovery and registration for PhiScan recognizer plugins.
+
+Loads third-party plugins that register under the
+``phi_scan.plugins`` entry-point group, validates each one against
+the Plugin API v1 contract defined in ``phi_scan.plugin_api``, and
+returns a ``PluginRegistry`` capturing both the recognizers that
+passed validation and the ones that were skipped with the reason.
+
+Load failures are fail-safe: a broken plugin is logged at WARNING
+level and added to the skipped list, but never raises. A scan with
+no installed plugins is indistinguishable from one where every
+installed plugin happened to be invalid — both produce an empty
+loaded list and the rest of the scan proceeds unchanged.
+
+PR-1 scope: discover → validate → instantiate → register. Nothing
+in this module wires plugins into the scan pipeline yet; that is
+done in a follow-up PR that adds ``phi-scan plugins list`` and
+plumbs execution through ``detection_coordinator``. The registry
+returned here is the hand-off point for that later work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from importlib.metadata import EntryPoint, entry_points
+
+from phi_scan.exceptions import PluginValidationError
+from phi_scan.logging_config import get_logger
+from phi_scan.plugin_api import (
+    ENTITY_TYPE_PATTERN,
+    PLUGIN_API_VERSION,
+    RECOGNIZER_NAME_PATTERN,
+    BaseRecognizer,
+)
+
+__all__ = [
+    "LoadedPlugin",
+    "PLUGIN_ENTRY_POINT_GROUP",
+    "PluginRegistry",
+    "SkippedPlugin",
+    "load_plugin_registry",
+]
+
+PLUGIN_ENTRY_POINT_GROUP: str = "phi_scan.plugins"
+
+_UNKNOWN_DISTRIBUTION_LABEL: str = "<unknown distribution>"
+
+_NOT_A_CLASS_REASON: str = "entry point did not resolve to a class"
+_NOT_A_RECOGNIZER_REASON: str = "class does not inherit from BaseRecognizer"
+_MISSING_NAME_REASON: str = "class does not declare a 'name' attribute"
+_INVALID_NAME_REASON: str = "name {name!r} does not match pattern {pattern}"
+_MISSING_ENTITY_TYPES_REASON: str = "class does not declare 'entity_types'"
+_ENTITY_TYPES_NOT_LIST_REASON: str = "entity_types must be a list, got {type_name}"
+_EMPTY_ENTITY_TYPES_REASON: str = "entity_types is empty — recognizer cannot emit any findings"
+_INVALID_ENTITY_TYPE_REASON: str = (
+    "entity_types[{index}] {value!r} does not match pattern {pattern}"
+)
+_DUPLICATE_ENTITY_TYPE_REASON: str = "entity_types contains duplicate entry {value!r}"
+_MISSING_API_VERSION_REASON: str = "class does not declare 'plugin_api_version'"
+_API_VERSION_MISMATCH_REASON: str = (
+    "plugin_api_version {plugin_version!r} does not match host {host_version!r}"
+)
+_NAME_COLLISION_REASON: str = "name {name!r} already registered by a previous plugin"
+_IMPORT_FAILURE_REASON: str = "entry-point load failed: {error}"
+_INSTANTIATION_FAILURE_REASON: str = "recognizer constructor raised: {error}"
+
+_SKIPPED_PLUGIN_LOG_MESSAGE: str = "Skipping plugin %r from %s: %s"
+
+
+@dataclass(frozen=True)
+class LoadedPlugin:
+    """A recognizer plugin that passed validation and was instantiated.
+
+    Attributes:
+        entry_point_name: The ``name`` field on the setuptools entry
+            point (left-hand side of the ``name = module:Class``
+            line in the publishing package's ``pyproject.toml``).
+        distribution_name: Name of the installed distribution that
+            provided the entry point, or ``None`` if the metadata
+            was unavailable.
+        recognizer: The instantiated recognizer, ready to be invoked
+            by ``detect(line, context)``.
+    """
+
+    entry_point_name: str
+    distribution_name: str | None
+    recognizer: BaseRecognizer
+
+
+@dataclass(frozen=True)
+class SkippedPlugin:
+    """A recognizer plugin that failed validation or instantiation.
+
+    Attributes:
+        entry_point_name: Same semantics as ``LoadedPlugin``.
+        distribution_name: Same semantics as ``LoadedPlugin``.
+        reason: Human-readable description of why the plugin was
+            rejected. Safe to display directly in
+            ``phi-scan plugins list`` output.
+    """
+
+    entry_point_name: str
+    distribution_name: str | None
+    reason: str
+
+
+@dataclass(frozen=True)
+class PluginRegistry:
+    """The result of one plugin-discovery pass over the entry-point group.
+
+    Attributes:
+        loaded: Tuple of recognizers that passed validation, in the
+            deterministic discovery order (sorted by distribution
+            name then entry-point name).
+        skipped: Tuple of recognizers that were rejected, in the
+            same deterministic order.
+    """
+
+    loaded: tuple[LoadedPlugin, ...] = field(default_factory=tuple)
+    skipped: tuple[SkippedPlugin, ...] = field(default_factory=tuple)
+
+
+def load_plugin_registry() -> PluginRegistry:
+    """Discover, validate, and instantiate every plugin under the entry-point group.
+
+    Returns:
+        A ``PluginRegistry`` with the successfully loaded recognizers
+        in ``loaded`` and the rejected ones in ``skipped``. Both
+        tuples preserve deterministic discovery order. Never raises;
+        all per-plugin failures are converted to ``SkippedPlugin``
+        entries and logged at WARNING level.
+    """
+    sorted_entry_points = _sort_entry_points_deterministically(_discover_entry_points())
+    loaded_plugins: list[LoadedPlugin] = []
+    skipped_plugins: list[SkippedPlugin] = []
+    reserved_names: set[str] = set()
+    for entry_point in sorted_entry_points:
+        load_outcome = _evaluate_entry_point(entry_point, reserved_names)
+        if isinstance(load_outcome, LoadedPlugin):
+            loaded_plugins.append(load_outcome)
+            reserved_names.add(load_outcome.recognizer.name)
+            continue
+        skipped_plugins.append(load_outcome)
+        _log_skipped_plugin(load_outcome)
+    return PluginRegistry(
+        loaded=tuple(loaded_plugins),
+        skipped=tuple(skipped_plugins),
+    )
+
+
+def _discover_entry_points() -> tuple[EntryPoint, ...]:
+    return tuple(entry_points(group=PLUGIN_ENTRY_POINT_GROUP))
+
+
+def _sort_entry_points_deterministically(
+    discovered_entry_points: tuple[EntryPoint, ...],
+) -> tuple[EntryPoint, ...]:
+    return tuple(
+        sorted(
+            discovered_entry_points,
+            key=lambda entry_point: (
+                _resolve_distribution_name(entry_point) or "",
+                entry_point.name,
+            ),
+        )
+    )
+
+
+def _resolve_distribution_name(entry_point: EntryPoint) -> str | None:
+    distribution = entry_point.dist
+    if distribution is None:
+        return None
+    return distribution.name
+
+
+def _evaluate_entry_point(
+    entry_point: EntryPoint,
+    reserved_names: set[str],
+) -> LoadedPlugin | SkippedPlugin:
+    distribution_name = _resolve_distribution_name(entry_point)
+    try:
+        recognizer_class = _load_entry_point_class(entry_point)
+        _validate_recognizer_class(recognizer_class)
+        _reject_reserved_name(recognizer_class.name, reserved_names)
+        recognizer_instance = _instantiate_recognizer(recognizer_class)
+    except PluginValidationError as validation_error:
+        return SkippedPlugin(
+            entry_point_name=entry_point.name,
+            distribution_name=distribution_name,
+            reason=str(validation_error),
+        )
+    return LoadedPlugin(
+        entry_point_name=entry_point.name,
+        distribution_name=distribution_name,
+        recognizer=recognizer_instance,
+    )
+
+
+def _load_entry_point_class(entry_point: EntryPoint) -> type[BaseRecognizer]:
+    try:
+        loaded_object = entry_point.load()
+    except (ImportError, AttributeError) as load_error:
+        raise PluginValidationError(_IMPORT_FAILURE_REASON.format(error=load_error)) from load_error
+    if not isinstance(loaded_object, type):
+        raise PluginValidationError(_NOT_A_CLASS_REASON)
+    if not issubclass(loaded_object, BaseRecognizer):
+        raise PluginValidationError(_NOT_A_RECOGNIZER_REASON)
+    return loaded_object
+
+
+def _validate_recognizer_class(recognizer_class: type[BaseRecognizer]) -> None:
+    _validate_api_version(recognizer_class)
+    _validate_recognizer_name(recognizer_class)
+    _validate_entity_types_list(recognizer_class)
+
+
+def _validate_api_version(recognizer_class: type[BaseRecognizer]) -> None:
+    declared_version = getattr(recognizer_class, "plugin_api_version", None)
+    if declared_version is None:
+        raise PluginValidationError(_MISSING_API_VERSION_REASON)
+    if declared_version != PLUGIN_API_VERSION:
+        raise PluginValidationError(
+            _API_VERSION_MISMATCH_REASON.format(
+                plugin_version=declared_version,
+                host_version=PLUGIN_API_VERSION,
+            )
+        )
+
+
+def _validate_recognizer_name(recognizer_class: type[BaseRecognizer]) -> None:
+    declared_name = getattr(recognizer_class, "name", None)
+    if declared_name is None:
+        raise PluginValidationError(_MISSING_NAME_REASON)
+    if not isinstance(declared_name, str) or not RECOGNIZER_NAME_PATTERN.match(declared_name):
+        raise PluginValidationError(
+            _INVALID_NAME_REASON.format(
+                name=declared_name,
+                pattern=RECOGNIZER_NAME_PATTERN.pattern,
+            )
+        )
+
+
+def _validate_entity_types_list(recognizer_class: type[BaseRecognizer]) -> None:
+    declared_types = getattr(recognizer_class, "entity_types", None)
+    if declared_types is None:
+        raise PluginValidationError(_MISSING_ENTITY_TYPES_REASON)
+    if not isinstance(declared_types, list):
+        raise PluginValidationError(
+            _ENTITY_TYPES_NOT_LIST_REASON.format(type_name=type(declared_types).__name__)
+        )
+    if not declared_types:
+        raise PluginValidationError(_EMPTY_ENTITY_TYPES_REASON)
+    _validate_entity_type_values(declared_types)
+
+
+def _validate_entity_type_values(declared_types: list[str]) -> None:
+    seen_entity_types: set[str] = set()
+    for type_index, entity_type_value in enumerate(declared_types):
+        _reject_malformed_entity_type(type_index, entity_type_value)
+        _reject_duplicate_entity_type(entity_type_value, seen_entity_types)
+        seen_entity_types.add(entity_type_value)
+
+
+def _reject_malformed_entity_type(type_index: int, entity_type_value: object) -> None:
+    if isinstance(entity_type_value, str) and ENTITY_TYPE_PATTERN.match(entity_type_value):
+        return
+    raise PluginValidationError(
+        _INVALID_ENTITY_TYPE_REASON.format(
+            index=type_index,
+            value=entity_type_value,
+            pattern=ENTITY_TYPE_PATTERN.pattern,
+        )
+    )
+
+
+def _reject_duplicate_entity_type(
+    entity_type_value: str,
+    seen_entity_types: set[str],
+) -> None:
+    if entity_type_value not in seen_entity_types:
+        return
+    raise PluginValidationError(_DUPLICATE_ENTITY_TYPE_REASON.format(value=entity_type_value))
+
+
+def _reject_reserved_name(recognizer_name: str, reserved_names: set[str]) -> None:
+    if recognizer_name not in reserved_names:
+        return
+    raise PluginValidationError(_NAME_COLLISION_REASON.format(name=recognizer_name))
+
+
+def _instantiate_recognizer(
+    recognizer_class: type[BaseRecognizer],
+) -> BaseRecognizer:
+    try:
+        return recognizer_class()
+    except Exception as init_error:
+        raise PluginValidationError(
+            _INSTANTIATION_FAILURE_REASON.format(error=init_error)
+        ) from init_error
+
+
+def _log_skipped_plugin(skipped_plugin: SkippedPlugin) -> None:
+    logger = get_logger("plugin_loader")
+    logger.warning(
+        _SKIPPED_PLUGIN_LOG_MESSAGE,
+        skipped_plugin.entry_point_name,
+        skipped_plugin.distribution_name or _UNKNOWN_DISTRIBUTION_LABEL,
+        skipped_plugin.reason,
+    )

--- a/phi_scan/plugin_loader.py
+++ b/phi_scan/plugin_loader.py
@@ -21,6 +21,7 @@ returned here is the hand-off point for that later work.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from importlib.metadata import EntryPoint, entry_points
 
@@ -50,7 +51,9 @@ _NOT_A_RECOGNIZER_REASON: str = "class does not inherit from BaseRecognizer"
 _MISSING_NAME_REASON: str = "class does not declare a 'name' attribute"
 _INVALID_NAME_REASON: str = "name {name!r} does not match pattern {pattern}"
 _MISSING_ENTITY_TYPES_REASON: str = "class does not declare 'entity_types'"
-_ENTITY_TYPES_NOT_LIST_REASON: str = "entity_types must be a list, got {type_name}"
+_ENTITY_TYPES_NOT_SEQUENCE_REASON: str = (
+    "entity_types must be a tuple or list of str, got {type_name}"
+)
 _EMPTY_ENTITY_TYPES_REASON: str = "entity_types is empty — recognizer cannot emit any findings"
 _INVALID_ENTITY_TYPE_REASON: str = (
     "entity_types[{index}] {value!r} does not match pattern {pattern}"
@@ -131,14 +134,14 @@ def load_plugin_registry() -> PluginRegistry:
         entries and logged at WARNING level.
     """
     sorted_entry_points = _sort_entry_points_deterministically(_discover_entry_points())
-    loaded_plugins, skipped_plugins = _collect_plugin_outcomes(sorted_entry_points)
+    loaded_plugins, skipped_plugins = _collect_plugin_registry_entries(sorted_entry_points)
     return PluginRegistry(
         loaded=tuple(loaded_plugins),
         skipped=tuple(skipped_plugins),
     )
 
 
-def _collect_plugin_outcomes(
+def _collect_plugin_registry_entries(
     sorted_entry_points: tuple[EntryPoint, ...],
 ) -> tuple[list[LoadedPlugin], list[SkippedPlugin]]:
     loaded_plugins: list[LoadedPlugin] = []
@@ -186,9 +189,7 @@ def _evaluate_entry_point(
 ) -> LoadedPlugin | SkippedPlugin:
     distribution_name = _resolve_distribution_name(entry_point)
     try:
-        recognizer_class = _load_entry_point_class(entry_point)
-        _validate_recognizer_class(recognizer_class)
-        _reject_reserved_name(recognizer_class.name, reserved_names)
+        recognizer_class = _resolve_and_validate_recognizer_class(entry_point, reserved_names)
         recognizer_instance = _instantiate_recognizer(recognizer_class)
     except PluginValidationError as validation_error:
         return SkippedPlugin(
@@ -201,6 +202,16 @@ def _evaluate_entry_point(
         distribution_name=distribution_name,
         recognizer=recognizer_instance,
     )
+
+
+def _resolve_and_validate_recognizer_class(
+    entry_point: EntryPoint,
+    reserved_names: set[str],
+) -> type[BaseRecognizer]:
+    recognizer_class = _load_entry_point_class(entry_point)
+    _validate_recognizer_class(recognizer_class)
+    _reject_reserved_name(recognizer_class.name, reserved_names)
+    return recognizer_class
 
 
 def _load_entry_point_class(entry_point: EntryPoint) -> type[BaseRecognizer]:
@@ -220,7 +231,7 @@ def _load_entry_point_class(entry_point: EntryPoint) -> type[BaseRecognizer]:
 def _validate_recognizer_class(recognizer_class: type[BaseRecognizer]) -> None:
     _validate_api_version(recognizer_class)
     _validate_recognizer_name(recognizer_class)
-    _validate_entity_types_list(recognizer_class)
+    _validate_entity_types_sequence(recognizer_class)
 
 
 def _validate_api_version(recognizer_class: type[BaseRecognizer]) -> None:
@@ -249,20 +260,20 @@ def _validate_recognizer_name(recognizer_class: type[BaseRecognizer]) -> None:
         )
 
 
-def _validate_entity_types_list(recognizer_class: type[BaseRecognizer]) -> None:
+def _validate_entity_types_sequence(recognizer_class: type[BaseRecognizer]) -> None:
     declared_types = getattr(recognizer_class, "entity_types", None)
     if declared_types is None:
         raise PluginValidationError(_MISSING_ENTITY_TYPES_REASON)
-    if not isinstance(declared_types, list):
+    if not isinstance(declared_types, (list, tuple)):
         raise PluginValidationError(
-            _ENTITY_TYPES_NOT_LIST_REASON.format(type_name=type(declared_types).__name__)
+            _ENTITY_TYPES_NOT_SEQUENCE_REASON.format(type_name=type(declared_types).__name__)
         )
     if not declared_types:
         raise PluginValidationError(_EMPTY_ENTITY_TYPES_REASON)
     _validate_entity_type_values(declared_types)
 
 
-def _validate_entity_type_values(declared_types: list[str]) -> None:
+def _validate_entity_type_values(declared_types: Sequence[str]) -> None:
     seen_entity_types: set[str] = set()
     for type_index, entity_type_value in enumerate(declared_types):
         _reject_malformed_entity_type(type_index, entity_type_value)

--- a/phi_scan/plugin_loader.py
+++ b/phi_scan/plugin_loader.py
@@ -134,21 +134,21 @@ def load_plugin_registry() -> PluginRegistry:
         entries and logged at WARNING level.
     """
     sorted_entry_points = _sort_entry_points_deterministically(_discover_entry_points())
-    loaded_plugins, skipped_plugins = _collect_plugin_registry_entries(sorted_entry_points)
+    loaded_plugins, skipped_plugins = _partition_entry_points_into_registry(sorted_entry_points)
     return PluginRegistry(
         loaded=tuple(loaded_plugins),
         skipped=tuple(skipped_plugins),
     )
 
 
-def _collect_plugin_registry_entries(
+def _partition_entry_points_into_registry(
     sorted_entry_points: tuple[EntryPoint, ...],
 ) -> tuple[list[LoadedPlugin], list[SkippedPlugin]]:
     loaded_plugins: list[LoadedPlugin] = []
     skipped_plugins: list[SkippedPlugin] = []
     reserved_names: set[str] = set()
     for entry_point in sorted_entry_points:
-        load_outcome = _evaluate_entry_point(entry_point, reserved_names)
+        load_outcome = _resolve_plugin_from_entry_point(entry_point, reserved_names)
         if isinstance(load_outcome, LoadedPlugin):
             loaded_plugins.append(load_outcome)
             reserved_names.add(load_outcome.recognizer.name)
@@ -183,7 +183,7 @@ def _resolve_distribution_name(entry_point: EntryPoint) -> str | None:
     return distribution.name
 
 
-def _evaluate_entry_point(
+def _resolve_plugin_from_entry_point(
     entry_point: EntryPoint,
     reserved_names: set[str],
 ) -> LoadedPlugin | SkippedPlugin:
@@ -215,6 +215,13 @@ def _resolve_and_validate_recognizer_class(
 
 
 def _load_entry_point_class(entry_point: EntryPoint) -> type[BaseRecognizer]:
+    # ``EntryPoint.load()`` imports the target module and then resolves the
+    # class attribute named in the ``module:Class`` spec. ImportError covers
+    # the import step (module missing, transitive import failure). AttributeError
+    # covers the attribute-resolution step — a publishing package that points
+    # the entry point at a class name that no longer exists in the module
+    # (typo, rename, partial refactor). Both are plugin-metadata problems that
+    # should skip the plugin with a WARNING, not crash the scan.
     try:
         loaded_object = entry_point.load()
     except (ImportError, AttributeError) as load_error:

--- a/phi_scan/plugin_loader.py
+++ b/phi_scan/plugin_loader.py
@@ -133,7 +133,7 @@ def load_plugin_registry() -> PluginRegistry:
         entries and logged at WARNING level.
     """
     sorted_entry_points = _sort_entry_points_deterministically(_discover_entry_points())
-    loaded_plugins, skipped_plugins = _build_registry_lists(sorted_entry_points)
+    loaded_plugins, skipped_plugins = _classify_entry_points(sorted_entry_points)
     for skipped_plugin in skipped_plugins:
         _log_skipped_plugin(skipped_plugin)
     return PluginRegistry(
@@ -142,7 +142,7 @@ def load_plugin_registry() -> PluginRegistry:
     )
 
 
-def _build_registry_lists(
+def _classify_entry_points(
     sorted_entry_points: tuple[EntryPoint, ...],
 ) -> tuple[list[LoadedPlugin], list[SkippedPlugin]]:
     loaded_plugins: list[LoadedPlugin] = []
@@ -208,13 +208,14 @@ def _resolve_and_validate_recognizer_class(
     entry_point: EntryPoint,
     reserved_names: set[str],
 ) -> type[BaseRecognizer]:
-    recognizer_class = _load_entry_point_class(entry_point)
+    entry_point_target = _import_entry_point_object(entry_point)
+    recognizer_class = _coerce_to_recognizer_class(entry_point_target)
     _validate_recognizer_class(recognizer_class)
     _reject_reserved_name(recognizer_class.name, reserved_names)
     return recognizer_class
 
 
-def _load_entry_point_class(entry_point: EntryPoint) -> type[BaseRecognizer]:
+def _import_entry_point_object(entry_point: EntryPoint) -> object:
     # ``EntryPoint.load()`` imports the target module and then resolves the
     # class attribute named in the ``module:Class`` spec. ImportError covers
     # the import step (module missing, transitive import failure). AttributeError
@@ -223,16 +224,19 @@ def _load_entry_point_class(entry_point: EntryPoint) -> type[BaseRecognizer]:
     # (typo, rename, partial refactor). Both are plugin-metadata problems that
     # should skip the plugin with a WARNING, not crash the scan.
     try:
-        loaded_object = entry_point.load()
+        return entry_point.load()
     except (ImportError, AttributeError) as load_error:
         raise PluginValidationError(
             _IMPORT_FAILURE_REASON.format(error_type=type(load_error).__name__)
         ) from load_error
-    if not isinstance(loaded_object, type):
+
+
+def _coerce_to_recognizer_class(entry_point_target: object) -> type[BaseRecognizer]:
+    if not isinstance(entry_point_target, type):
         raise PluginValidationError(_NOT_A_CLASS_REASON)
-    if not issubclass(loaded_object, BaseRecognizer):
+    if not issubclass(entry_point_target, BaseRecognizer):
         raise PluginValidationError(_NOT_A_RECOGNIZER_REASON)
-    return loaded_object
+    return entry_point_target
 
 
 def _validate_recognizer_class(recognizer_class: type[BaseRecognizer]) -> None:

--- a/phi_scan/plugin_loader.py
+++ b/phi_scan/plugin_loader.py
@@ -131,6 +131,16 @@ def load_plugin_registry() -> PluginRegistry:
         entries and logged at WARNING level.
     """
     sorted_entry_points = _sort_entry_points_deterministically(_discover_entry_points())
+    loaded_plugins, skipped_plugins = _collect_plugin_outcomes(sorted_entry_points)
+    return PluginRegistry(
+        loaded=tuple(loaded_plugins),
+        skipped=tuple(skipped_plugins),
+    )
+
+
+def _collect_plugin_outcomes(
+    sorted_entry_points: tuple[EntryPoint, ...],
+) -> tuple[list[LoadedPlugin], list[SkippedPlugin]]:
     loaded_plugins: list[LoadedPlugin] = []
     skipped_plugins: list[SkippedPlugin] = []
     reserved_names: set[str] = set()
@@ -142,10 +152,7 @@ def load_plugin_registry() -> PluginRegistry:
             continue
         skipped_plugins.append(load_outcome)
         _log_skipped_plugin(load_outcome)
-    return PluginRegistry(
-        loaded=tuple(loaded_plugins),
-        skipped=tuple(skipped_plugins),
-    )
+    return loaded_plugins, skipped_plugins
 
 
 def _discover_entry_points() -> tuple[EntryPoint, ...]:
@@ -291,9 +298,15 @@ def _reject_reserved_name(recognizer_name: str, reserved_names: set[str]) -> Non
 def _instantiate_recognizer(
     recognizer_class: type[BaseRecognizer],
 ) -> BaseRecognizer:
+    # Third-party plugin constructors may raise anything. Catching the full
+    # Exception hierarchy is the intentional trust-boundary behaviour: a broken
+    # plugin must never crash the scan or leak a raw traceback to the CLI. The
+    # exception is re-raised as PluginValidationError so the loader records it
+    # in the skipped list and continues. BaseException (SystemExit,
+    # KeyboardInterrupt) is deliberately not caught.
     try:
         return recognizer_class()
-    except Exception as init_error:
+    except Exception as init_error:  # noqa: BLE001 — see comment above
         raise PluginValidationError(
             _INSTANTIATION_FAILURE_REASON.format(error=init_error)
         ) from init_error

--- a/phi_scan/plugin_loader.py
+++ b/phi_scan/plugin_loader.py
@@ -189,7 +189,7 @@ def _load_or_skip_entry_point(
 ) -> LoadedPlugin | SkippedPlugin:
     distribution_name = _resolve_distribution_name(entry_point)
     try:
-        recognizer_class = _resolve_and_validate_recognizer_class(entry_point, reserved_names)
+        recognizer_class = _import_validated_recognizer_class(entry_point, reserved_names)
         recognizer_instance = _instantiate_recognizer(recognizer_class)
     except PluginValidationError as validation_error:
         return SkippedPlugin(
@@ -204,7 +204,7 @@ def _load_or_skip_entry_point(
     )
 
 
-def _resolve_and_validate_recognizer_class(
+def _import_validated_recognizer_class(
     entry_point: EntryPoint,
     reserved_names: set[str],
 ) -> type[BaseRecognizer]:
@@ -284,36 +284,36 @@ def _validate_entity_types_sequence(recognizer_class: type[BaseRecognizer]) -> N
         )
     if not declared_types:
         raise PluginValidationError(_EMPTY_ENTITY_TYPES_REASON)
-    _validate_entity_type_values(declared_types)
+    _validate_entity_type_candidates(declared_types)
 
 
-def _validate_entity_type_values(declared_types: Sequence[str]) -> None:
+def _validate_entity_type_candidates(declared_types: Sequence[str]) -> None:
     seen_entity_types: set[str] = set()
-    for type_index, entity_type_value in enumerate(declared_types):
-        _reject_malformed_entity_type(type_index, entity_type_value)
-        _reject_duplicate_entity_type(entity_type_value, seen_entity_types)
-        seen_entity_types.add(entity_type_value)
+    for type_index, entity_type_candidate in enumerate(declared_types):
+        _reject_malformed_entity_type(type_index, entity_type_candidate)
+        _reject_duplicate_entity_type(entity_type_candidate, seen_entity_types)
+        seen_entity_types.add(entity_type_candidate)
 
 
-def _reject_malformed_entity_type(type_index: int, entity_type_value: object) -> None:
-    if isinstance(entity_type_value, str) and ENTITY_TYPE_PATTERN.match(entity_type_value):
+def _reject_malformed_entity_type(type_index: int, entity_type_candidate: object) -> None:
+    if isinstance(entity_type_candidate, str) and ENTITY_TYPE_PATTERN.match(entity_type_candidate):
         return
     raise PluginValidationError(
         _INVALID_ENTITY_TYPE_REASON.format(
             index=type_index,
-            value=entity_type_value,
+            value=entity_type_candidate,
             pattern=ENTITY_TYPE_PATTERN.pattern,
         )
     )
 
 
 def _reject_duplicate_entity_type(
-    entity_type_value: str,
+    entity_type_candidate: str,
     seen_entity_types: set[str],
 ) -> None:
-    if entity_type_value not in seen_entity_types:
+    if entity_type_candidate not in seen_entity_types:
         return
-    raise PluginValidationError(_DUPLICATE_ENTITY_TYPE_REASON.format(value=entity_type_value))
+    raise PluginValidationError(_DUPLICATE_ENTITY_TYPE_REASON.format(value=entity_type_candidate))
 
 
 def _reject_reserved_name(recognizer_name: str, reserved_names: set[str]) -> None:

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -187,12 +187,15 @@ class _DuplicateEntityTypesRecognizer(BaseRecognizer):
         return []
 
 
+_CONSTRUCTOR_SENSITIVE_MESSAGE: str = "patient_name=Jane Doe MRN=12345"
+
+
 class _ConstructorRaisingRecognizer(BaseRecognizer):
     name = "constructor_raises"
     entity_types = ["BROKEN_TYPE"]
 
     def __init__(self) -> None:
-        raise RuntimeError("constructor intentionally raised in test")
+        raise RuntimeError(_CONSTRUCTOR_SENSITIVE_MESSAGE)
 
     def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
         del line, context
@@ -583,7 +586,23 @@ def test_recognizer_constructor_failure_is_skipped(
     )
     registry = load_plugin_registry()
     assert registry.loaded == ()
-    assert "constructor raised" in registry.skipped[0].reason
+    skipped_reason = registry.skipped[0].reason
+    assert "constructor raised" in skipped_reason
+    assert "RuntimeError" in skipped_reason
+
+
+def test_recognizer_constructor_error_message_is_not_leaked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(
+        monkeypatch,
+        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _ConstructorRaisingRecognizer)],
+    )
+    registry = load_plugin_registry()
+    skipped_reason = registry.skipped[0].reason
+    assert _CONSTRUCTOR_SENSITIVE_MESSAGE not in skipped_reason
+    assert "Jane Doe" not in skipped_reason
+    assert "12345" not in skipped_reason
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -8,6 +8,7 @@ pipeline without needing to build installable fixture packages.
 
 from __future__ import annotations
 
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -39,7 +40,8 @@ _BETA_ENTITY_TYPE: str = "BETA_IDENTIFIER"
 _ALPHA_ENTRY_POINT_NAME: str = "alpha_entry_point"
 _BETA_ENTRY_POINT_NAME: str = "beta_entry_point"
 
-_SAMPLE_FILE_PATH: Path = Path("/tmp/phi-scan-plugin-test-file.py")
+_SAMPLE_FILE_NAME: str = "phi-scan-plugin-test-file.py"
+_SAMPLE_FILE_PATH: Path = Path(tempfile.gettempdir()) / _SAMPLE_FILE_NAME
 _SAMPLE_FILE_EXTENSION: str = ".py"
 _SAMPLE_LINE_NUMBER: int = 10
 _SAMPLE_START_OFFSET: int = 2

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1,0 +1,637 @@
+"""Tests for phi_scan.plugin_api and phi_scan.plugin_loader (Plugin API v1).
+
+The loader tests install synthetic ``EntryPoint`` stand-ins by
+monkey-patching ``phi_scan.plugin_loader.entry_points`` so the suite
+exercises the full discover / validate / instantiate / register
+pipeline without needing to build installable fixture packages.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from phi_scan import (
+    PLUGIN_API_VERSION,
+    BaseRecognizer,
+    ScanContext,
+    ScanFinding,
+)
+from phi_scan.plugin_api import RECOGNIZER_NAME_PATTERN
+from phi_scan.plugin_loader import (
+    PLUGIN_ENTRY_POINT_GROUP,
+    LoadedPlugin,
+    SkippedPlugin,
+    load_plugin_registry,
+)
+
+_ENTRY_POINTS_PATCH_TARGET: str = "phi_scan.plugin_loader.entry_points"
+
+_FAKE_DISTRIBUTION_ALPHA: str = "phi-scan-ext-alpha"
+_FAKE_DISTRIBUTION_BETA: str = "phi-scan-ext-beta"
+
+_ALPHA_RECOGNIZER_NAME: str = "alpha_recognizer"
+_BETA_RECOGNIZER_NAME: str = "beta_recognizer"
+_ALPHA_ENTITY_TYPE: str = "ALPHA_IDENTIFIER"
+_BETA_ENTITY_TYPE: str = "BETA_IDENTIFIER"
+
+_ALPHA_ENTRY_POINT_NAME: str = "alpha_entry_point"
+_BETA_ENTRY_POINT_NAME: str = "beta_entry_point"
+
+_SAMPLE_FILE_PATH: Path = Path("/tmp/phi-scan-plugin-test-file.py")
+_SAMPLE_FILE_EXTENSION: str = ".py"
+_SAMPLE_LINE_NUMBER: int = 10
+_SAMPLE_START_OFFSET: int = 2
+_SAMPLE_END_OFFSET: int = 8
+_SAMPLE_CONFIDENCE_SCORE: float = 0.85
+
+_VERSION_TWO_POINT_ZERO: str = "2.0"
+_BAD_NAME_WITH_HYPHEN: str = "Invalid-Name"
+_BAD_ENTITY_TYPE_LOWERCASE: str = "lowercase_type"
+_DUPLICATED_ENTITY_TYPE: str = "DUPLICATED_TYPE"
+_MALFORMED_RECOGNIZER_NAME: str = "1_starts_with_digit"
+
+
+class _FakeDistribution:
+    """Minimal stand-in for ``importlib.metadata.Distribution``."""
+
+    def __init__(self, distribution_name: str) -> None:
+        self.name = distribution_name
+
+
+class _FakeEntryPoint:
+    """Minimal stand-in for ``importlib.metadata.EntryPoint``.
+
+    Only exposes the attributes the loader touches:
+    ``name``, ``dist``, and ``load()``.
+    """
+
+    def __init__(
+        self,
+        entry_point_name: str,
+        loaded_object: object,
+        distribution_name: str | None = None,
+        load_error: Exception | None = None,
+    ) -> None:
+        self.name = entry_point_name
+        self._loaded_object = loaded_object
+        self._distribution_name = distribution_name
+        self._load_error = load_error
+
+    def load(self) -> object:
+        if self._load_error is not None:
+            raise self._load_error
+        return self._loaded_object
+
+    @property
+    def dist(self) -> _FakeDistribution | None:
+        if self._distribution_name is None:
+            return None
+        return _FakeDistribution(self._distribution_name)
+
+
+def _install_fake_entry_points(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_entry_points: list[_FakeEntryPoint],
+) -> None:
+    def _entry_points_replacement(*, group: str) -> list[_FakeEntryPoint]:
+        if group != PLUGIN_ENTRY_POINT_GROUP:
+            return []
+        return list(fake_entry_points)
+
+    monkeypatch.setattr(_ENTRY_POINTS_PATCH_TARGET, _entry_points_replacement)
+
+
+class _ValidAlphaRecognizer(BaseRecognizer):
+    name = _ALPHA_RECOGNIZER_NAME
+    entity_types = [_ALPHA_ENTITY_TYPE]
+
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        del line, context
+        return []
+
+
+class _ValidBetaRecognizer(BaseRecognizer):
+    name = _BETA_RECOGNIZER_NAME
+    entity_types = [_BETA_ENTITY_TYPE]
+
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        del line, context
+        return []
+
+
+class _MismatchedVersionRecognizer(BaseRecognizer):
+    name = "mismatched_version"
+    entity_types = ["MISMATCHED_TYPE"]
+    plugin_api_version = _VERSION_TWO_POINT_ZERO
+
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        del line, context
+        return []
+
+
+class _HyphenNameRecognizer(BaseRecognizer):
+    name = _BAD_NAME_WITH_HYPHEN
+    entity_types = ["VALID_TYPE"]
+
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        del line, context
+        return []
+
+
+class _DigitStartNameRecognizer(BaseRecognizer):
+    name = _MALFORMED_RECOGNIZER_NAME
+    entity_types = ["VALID_TYPE"]
+
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        del line, context
+        return []
+
+
+class _EmptyEntityTypesRecognizer(BaseRecognizer):
+    name = "empty_entity_types"
+    entity_types: list[str] = []
+
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        del line, context
+        return []
+
+
+class _NonListEntityTypesRecognizer(BaseRecognizer):
+    name = "non_list_entity_types"
+    entity_types = "NOT_A_LIST"  # type: ignore[assignment]
+
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        del line, context
+        return []
+
+
+class _LowercaseEntityTypeRecognizer(BaseRecognizer):
+    name = "lowercase_entity_type"
+    entity_types = [_BAD_ENTITY_TYPE_LOWERCASE]
+
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        del line, context
+        return []
+
+
+class _DuplicateEntityTypesRecognizer(BaseRecognizer):
+    name = "duplicate_entity_types"
+    entity_types = [_DUPLICATED_ENTITY_TYPE, _DUPLICATED_ENTITY_TYPE]
+
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        del line, context
+        return []
+
+
+class _ConstructorRaisingRecognizer(BaseRecognizer):
+    name = "constructor_raises"
+    entity_types = ["BROKEN_TYPE"]
+
+    def __init__(self) -> None:
+        raise RuntimeError("constructor intentionally raised in test")
+
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        del line, context
+        return []
+
+
+class _MissingApiVersionRecognizer(BaseRecognizer):
+    name = "missing_api_version"
+    entity_types = ["VALID_TYPE"]
+    plugin_api_version = None  # type: ignore[assignment]
+
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        del line, context
+        return []
+
+
+class _MissingNameRecognizer(BaseRecognizer):
+    entity_types = ["VALID_TYPE"]
+
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        del line, context
+        return []
+
+
+class _MissingEntityTypesRecognizer(BaseRecognizer):
+    name = "missing_entity_types"
+
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        del line, context
+        return []
+
+
+class _NotARecognizerClass:
+    """Plain class that does not inherit from BaseRecognizer."""
+
+
+def _plain_function_not_a_class() -> None:
+    return None
+
+
+# ---------------------------------------------------------------------------
+# ScanFinding and ScanContext __post_init__ validation
+# ---------------------------------------------------------------------------
+
+
+def test_scan_finding_accepts_valid_arguments() -> None:
+    finding = ScanFinding(
+        entity_type=_ALPHA_ENTITY_TYPE,
+        start_offset=_SAMPLE_START_OFFSET,
+        end_offset=_SAMPLE_END_OFFSET,
+        confidence=_SAMPLE_CONFIDENCE_SCORE,
+    )
+    assert finding.entity_type == _ALPHA_ENTITY_TYPE
+    assert finding.start_offset == _SAMPLE_START_OFFSET
+    assert finding.end_offset == _SAMPLE_END_OFFSET
+    assert finding.confidence == pytest.approx(_SAMPLE_CONFIDENCE_SCORE)
+
+
+def test_scan_finding_rejects_lowercase_entity_type() -> None:
+    with pytest.raises(ValueError, match="entity_type"):
+        ScanFinding(
+            entity_type=_BAD_ENTITY_TYPE_LOWERCASE,
+            start_offset=_SAMPLE_START_OFFSET,
+            end_offset=_SAMPLE_END_OFFSET,
+            confidence=_SAMPLE_CONFIDENCE_SCORE,
+        )
+
+
+def test_scan_finding_rejects_negative_start_offset() -> None:
+    with pytest.raises(ValueError, match="start_offset"):
+        ScanFinding(
+            entity_type=_ALPHA_ENTITY_TYPE,
+            start_offset=-1,
+            end_offset=_SAMPLE_END_OFFSET,
+            confidence=_SAMPLE_CONFIDENCE_SCORE,
+        )
+
+
+def test_scan_finding_rejects_end_offset_not_after_start() -> None:
+    with pytest.raises(ValueError, match="strictly greater"):
+        ScanFinding(
+            entity_type=_ALPHA_ENTITY_TYPE,
+            start_offset=_SAMPLE_END_OFFSET,
+            end_offset=_SAMPLE_END_OFFSET,
+            confidence=_SAMPLE_CONFIDENCE_SCORE,
+        )
+
+
+def test_scan_finding_rejects_confidence_above_one() -> None:
+    with pytest.raises(ValueError, match="confidence"):
+        ScanFinding(
+            entity_type=_ALPHA_ENTITY_TYPE,
+            start_offset=_SAMPLE_START_OFFSET,
+            end_offset=_SAMPLE_END_OFFSET,
+            confidence=1.5,
+        )
+
+
+def test_scan_finding_rejects_confidence_below_zero() -> None:
+    with pytest.raises(ValueError, match="confidence"):
+        ScanFinding(
+            entity_type=_ALPHA_ENTITY_TYPE,
+            start_offset=_SAMPLE_START_OFFSET,
+            end_offset=_SAMPLE_END_OFFSET,
+            confidence=-0.1,
+        )
+
+
+def test_scan_context_rejects_zero_line_number() -> None:
+    with pytest.raises(ValueError, match="line_number"):
+        ScanContext(
+            file_path=_SAMPLE_FILE_PATH,
+            line_number=0,
+            file_extension=_SAMPLE_FILE_EXTENSION,
+        )
+
+
+def test_scan_context_accepts_valid_arguments() -> None:
+    context = ScanContext(
+        file_path=_SAMPLE_FILE_PATH,
+        line_number=_SAMPLE_LINE_NUMBER,
+        file_extension=_SAMPLE_FILE_EXTENSION,
+    )
+    assert context.file_path == _SAMPLE_FILE_PATH
+    assert context.line_number == _SAMPLE_LINE_NUMBER
+    assert context.file_extension == _SAMPLE_FILE_EXTENSION
+
+
+# ---------------------------------------------------------------------------
+# Happy-path discovery
+# ---------------------------------------------------------------------------
+
+
+def test_empty_entry_point_group_yields_empty_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(monkeypatch, [])
+    registry = load_plugin_registry()
+    assert registry.loaded == ()
+    assert registry.skipped == ()
+
+
+def test_single_valid_plugin_is_loaded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(
+        monkeypatch,
+        [
+            _FakeEntryPoint(
+                _ALPHA_ENTRY_POINT_NAME,
+                _ValidAlphaRecognizer,
+                _FAKE_DISTRIBUTION_ALPHA,
+            ),
+        ],
+    )
+    registry = load_plugin_registry()
+    assert len(registry.loaded) == 1
+    assert registry.skipped == ()
+    loaded_plugin = registry.loaded[0]
+    assert isinstance(loaded_plugin, LoadedPlugin)
+    assert loaded_plugin.entry_point_name == _ALPHA_ENTRY_POINT_NAME
+    assert loaded_plugin.distribution_name == _FAKE_DISTRIBUTION_ALPHA
+    assert isinstance(loaded_plugin.recognizer, _ValidAlphaRecognizer)
+    assert loaded_plugin.recognizer.name == _ALPHA_RECOGNIZER_NAME
+    assert loaded_plugin.recognizer.entity_types == [_ALPHA_ENTITY_TYPE]
+
+
+def test_multiple_valid_plugins_are_sorted_deterministically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(
+        monkeypatch,
+        [
+            _FakeEntryPoint(
+                _BETA_ENTRY_POINT_NAME,
+                _ValidBetaRecognizer,
+                _FAKE_DISTRIBUTION_BETA,
+            ),
+            _FakeEntryPoint(
+                _ALPHA_ENTRY_POINT_NAME,
+                _ValidAlphaRecognizer,
+                _FAKE_DISTRIBUTION_ALPHA,
+            ),
+        ],
+    )
+    registry = load_plugin_registry()
+    loaded_distribution_names = [
+        loaded_plugin.distribution_name for loaded_plugin in registry.loaded
+    ]
+    assert loaded_distribution_names == [_FAKE_DISTRIBUTION_ALPHA, _FAKE_DISTRIBUTION_BETA]
+
+
+def test_plugin_without_distribution_still_loads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(
+        monkeypatch,
+        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _ValidAlphaRecognizer)],
+    )
+    registry = load_plugin_registry()
+    assert len(registry.loaded) == 1
+    assert registry.loaded[0].distribution_name is None
+
+
+# ---------------------------------------------------------------------------
+# Validation failures — each produces a SkippedPlugin
+# ---------------------------------------------------------------------------
+
+
+def test_mismatched_api_version_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(
+        monkeypatch,
+        [
+            _FakeEntryPoint(
+                _ALPHA_ENTRY_POINT_NAME,
+                _MismatchedVersionRecognizer,
+                _FAKE_DISTRIBUTION_ALPHA,
+            ),
+        ],
+    )
+    registry = load_plugin_registry()
+    assert registry.loaded == ()
+    assert len(registry.skipped) == 1
+    skipped_plugin = registry.skipped[0]
+    assert isinstance(skipped_plugin, SkippedPlugin)
+    assert _VERSION_TWO_POINT_ZERO in skipped_plugin.reason
+    assert PLUGIN_API_VERSION in skipped_plugin.reason
+
+
+def test_name_with_hyphen_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(
+        monkeypatch,
+        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _HyphenNameRecognizer)],
+    )
+    registry = load_plugin_registry()
+    assert registry.loaded == ()
+    assert RECOGNIZER_NAME_PATTERN.pattern in registry.skipped[0].reason
+
+
+def test_name_starting_with_digit_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(
+        monkeypatch,
+        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _DigitStartNameRecognizer)],
+    )
+    registry = load_plugin_registry()
+    assert registry.loaded == ()
+    assert _MALFORMED_RECOGNIZER_NAME in registry.skipped[0].reason
+
+
+def test_empty_entity_types_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(
+        monkeypatch,
+        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _EmptyEntityTypesRecognizer)],
+    )
+    registry = load_plugin_registry()
+    assert registry.loaded == ()
+    assert "empty" in registry.skipped[0].reason
+
+
+def test_non_list_entity_types_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(
+        monkeypatch,
+        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _NonListEntityTypesRecognizer)],
+    )
+    registry = load_plugin_registry()
+    assert registry.loaded == ()
+    assert "must be a list" in registry.skipped[0].reason
+
+
+def test_lowercase_entity_type_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(
+        monkeypatch,
+        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _LowercaseEntityTypeRecognizer)],
+    )
+    registry = load_plugin_registry()
+    assert registry.loaded == ()
+    assert _BAD_ENTITY_TYPE_LOWERCASE in registry.skipped[0].reason
+
+
+def test_duplicate_entity_types_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(
+        monkeypatch,
+        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _DuplicateEntityTypesRecognizer)],
+    )
+    registry = load_plugin_registry()
+    assert registry.loaded == ()
+    assert "duplicate" in registry.skipped[0].reason
+
+
+def test_non_recognizer_class_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(
+        monkeypatch,
+        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _NotARecognizerClass)],
+    )
+    registry = load_plugin_registry()
+    assert registry.loaded == ()
+    assert "BaseRecognizer" in registry.skipped[0].reason
+
+
+def test_non_class_entry_point_target_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(
+        monkeypatch,
+        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _plain_function_not_a_class)],
+    )
+    registry = load_plugin_registry()
+    assert registry.loaded == ()
+    assert "did not resolve to a class" in registry.skipped[0].reason
+
+
+def test_entry_point_import_error_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(
+        monkeypatch,
+        [
+            _FakeEntryPoint(
+                _ALPHA_ENTRY_POINT_NAME,
+                loaded_object=None,
+                load_error=ImportError("module missing"),
+            ),
+        ],
+    )
+    registry = load_plugin_registry()
+    assert registry.loaded == ()
+    assert "load failed" in registry.skipped[0].reason
+
+
+def test_missing_api_version_attribute_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(
+        monkeypatch,
+        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _MissingApiVersionRecognizer)],
+    )
+    registry = load_plugin_registry()
+    assert registry.loaded == ()
+    assert "plugin_api_version" in registry.skipped[0].reason
+
+
+def test_missing_name_attribute_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(
+        monkeypatch,
+        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _MissingNameRecognizer)],
+    )
+    registry = load_plugin_registry()
+    assert registry.loaded == ()
+    assert "'name'" in registry.skipped[0].reason
+
+
+def test_missing_entity_types_attribute_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(
+        monkeypatch,
+        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _MissingEntityTypesRecognizer)],
+    )
+    registry = load_plugin_registry()
+    assert registry.loaded == ()
+    assert "entity_types" in registry.skipped[0].reason
+
+
+def test_recognizer_constructor_failure_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(
+        monkeypatch,
+        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _ConstructorRaisingRecognizer)],
+    )
+    registry = load_plugin_registry()
+    assert registry.loaded == ()
+    assert "constructor raised" in registry.skipped[0].reason
+
+
+# ---------------------------------------------------------------------------
+# Name collisions — first wins, second is skipped
+# ---------------------------------------------------------------------------
+
+
+def test_name_collision_first_wins_second_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _AlphaClone(BaseRecognizer):
+        name = _ALPHA_RECOGNIZER_NAME
+        entity_types = ["CLONE_TYPE"]
+
+        def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+            del line, context
+            return []
+
+    _install_fake_entry_points(
+        monkeypatch,
+        [
+            _FakeEntryPoint(
+                _ALPHA_ENTRY_POINT_NAME,
+                _ValidAlphaRecognizer,
+                _FAKE_DISTRIBUTION_ALPHA,
+            ),
+            _FakeEntryPoint(
+                _BETA_ENTRY_POINT_NAME,
+                _AlphaClone,
+                _FAKE_DISTRIBUTION_BETA,
+            ),
+        ],
+    )
+    registry = load_plugin_registry()
+    assert len(registry.loaded) == 1
+    assert registry.loaded[0].distribution_name == _FAKE_DISTRIBUTION_ALPHA
+    assert len(registry.skipped) == 1
+    assert _ALPHA_RECOGNIZER_NAME in registry.skipped[0].reason
+    assert "already registered" in registry.skipped[0].reason
+
+
+# ---------------------------------------------------------------------------
+# Public API re-exports from phi_scan package root
+# ---------------------------------------------------------------------------
+
+
+def test_package_root_reexports_plugin_api_names() -> None:
+    import phi_scan
+
+    assert phi_scan.PLUGIN_API_VERSION == PLUGIN_API_VERSION
+    assert phi_scan.BaseRecognizer is BaseRecognizer
+    assert phi_scan.ScanContext is ScanContext
+    assert phi_scan.ScanFinding is ScanFinding

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -8,7 +8,6 @@ pipeline without needing to build installable fixture packages.
 
 from __future__ import annotations
 
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -40,8 +39,11 @@ _BETA_ENTITY_TYPE: str = "BETA_IDENTIFIER"
 _ALPHA_ENTRY_POINT_NAME: str = "alpha_entry_point"
 _BETA_ENTRY_POINT_NAME: str = "beta_entry_point"
 
+_FIXTURES_SUBDIRECTORY: str = "fixtures"
 _SAMPLE_FILE_NAME: str = "phi-scan-plugin-test-file.py"
-_SAMPLE_FILE_PATH: Path = Path(tempfile.gettempdir()) / _SAMPLE_FILE_NAME
+# Deterministic, test-local path. Never opened (per the ScanContext contract);
+# used only as metadata so plugins can gate on file extension and line number.
+_SAMPLE_FILE_PATH: Path = Path(__file__).parent / _FIXTURES_SUBDIRECTORY / _SAMPLE_FILE_NAME
 _SAMPLE_FILE_EXTENSION: str = ".py"
 _SAMPLE_LINE_NUMBER: int = 10
 _SAMPLE_START_OFFSET: int = 2
@@ -55,14 +57,14 @@ _DUPLICATED_ENTITY_TYPE: str = "DUPLICATED_TYPE"
 _MALFORMED_RECOGNIZER_NAME: str = "1_starts_with_digit"
 
 
-class _FakeDistribution:
+class _DistributionStub:
     """Minimal stand-in for ``importlib.metadata.Distribution``."""
 
     def __init__(self, distribution_name: str) -> None:
         self.name = distribution_name
 
 
-class _FakeEntryPoint:
+class _EntryPointStub:
     """Minimal stand-in for ``importlib.metadata.EntryPoint``.
 
     Only exposes the attributes the loader touches:
@@ -87,17 +89,17 @@ class _FakeEntryPoint:
         return self._loaded_object
 
     @property
-    def dist(self) -> _FakeDistribution | None:
+    def dist(self) -> _DistributionStub | None:
         if self._distribution_name is None:
             return None
-        return _FakeDistribution(self._distribution_name)
+        return _DistributionStub(self._distribution_name)
 
 
 def _install_fake_entry_points(
     monkeypatch: pytest.MonkeyPatch,
-    fake_entry_points: list[_FakeEntryPoint],
+    fake_entry_points: list[_EntryPointStub],
 ) -> None:
-    def _entry_points_replacement(*, group: str) -> list[_FakeEntryPoint]:
+    def _entry_points_replacement(*, group: str) -> list[_EntryPointStub]:
         if group != PLUGIN_ENTRY_POINT_GROUP:
             return []
         return list(fake_entry_points)
@@ -117,6 +119,19 @@ class _ValidAlphaRecognizer(BaseRecognizer):
 class _ValidBetaRecognizer(BaseRecognizer):
     name = _BETA_RECOGNIZER_NAME
     entity_types = [_BETA_ENTITY_TYPE]
+
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        del line, context
+        return []
+
+
+_TUPLE_RECOGNIZER_NAME: str = "tuple_types_recognizer"
+_TUPLE_ENTITY_TYPE: str = "TUPLE_IDENTIFIER"
+
+
+class _TupleEntityTypesRecognizer(BaseRecognizer):
+    name = _TUPLE_RECOGNIZER_NAME
+    entity_types = (_TUPLE_ENTITY_TYPE,)
 
     def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
         del line, context
@@ -344,7 +359,7 @@ def test_single_valid_plugin_is_loaded(
     _install_fake_entry_points(
         monkeypatch,
         [
-            _FakeEntryPoint(
+            _EntryPointStub(
                 _ALPHA_ENTRY_POINT_NAME,
                 _ValidAlphaRecognizer,
                 _FAKE_DISTRIBUTION_ALPHA,
@@ -369,12 +384,12 @@ def test_multiple_valid_plugins_are_sorted_deterministically(
     _install_fake_entry_points(
         monkeypatch,
         [
-            _FakeEntryPoint(
+            _EntryPointStub(
                 _BETA_ENTRY_POINT_NAME,
                 _ValidBetaRecognizer,
                 _FAKE_DISTRIBUTION_BETA,
             ),
-            _FakeEntryPoint(
+            _EntryPointStub(
                 _ALPHA_ENTRY_POINT_NAME,
                 _ValidAlphaRecognizer,
                 _FAKE_DISTRIBUTION_ALPHA,
@@ -393,7 +408,7 @@ def test_plugin_without_distribution_still_loads(
 ) -> None:
     _install_fake_entry_points(
         monkeypatch,
-        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _ValidAlphaRecognizer)],
+        [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _ValidAlphaRecognizer)],
     )
     registry = load_plugin_registry()
     assert len(registry.loaded) == 1
@@ -411,7 +426,7 @@ def test_mismatched_api_version_is_skipped(
     _install_fake_entry_points(
         monkeypatch,
         [
-            _FakeEntryPoint(
+            _EntryPointStub(
                 _ALPHA_ENTRY_POINT_NAME,
                 _MismatchedVersionRecognizer,
                 _FAKE_DISTRIBUTION_ALPHA,
@@ -432,7 +447,7 @@ def test_name_with_hyphen_is_skipped(
 ) -> None:
     _install_fake_entry_points(
         monkeypatch,
-        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _HyphenNameRecognizer)],
+        [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _HyphenNameRecognizer)],
     )
     registry = load_plugin_registry()
     assert registry.loaded == ()
@@ -444,7 +459,7 @@ def test_name_starting_with_digit_is_skipped(
 ) -> None:
     _install_fake_entry_points(
         monkeypatch,
-        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _DigitStartNameRecognizer)],
+        [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _DigitStartNameRecognizer)],
     )
     registry = load_plugin_registry()
     assert registry.loaded == ()
@@ -456,23 +471,36 @@ def test_empty_entity_types_is_skipped(
 ) -> None:
     _install_fake_entry_points(
         monkeypatch,
-        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _EmptyEntityTypesRecognizer)],
+        [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _EmptyEntityTypesRecognizer)],
     )
     registry = load_plugin_registry()
     assert registry.loaded == ()
     assert "empty" in registry.skipped[0].reason
 
 
-def test_non_list_entity_types_is_skipped(
+def test_non_sequence_entity_types_is_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _install_fake_entry_points(
         monkeypatch,
-        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _NonListEntityTypesRecognizer)],
+        [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _NonListEntityTypesRecognizer)],
     )
     registry = load_plugin_registry()
     assert registry.loaded == ()
-    assert "must be a list" in registry.skipped[0].reason
+    assert "must be a tuple or list" in registry.skipped[0].reason
+
+
+def test_tuple_entity_types_is_accepted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_entry_points(
+        monkeypatch,
+        [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _TupleEntityTypesRecognizer)],
+    )
+    registry = load_plugin_registry()
+    assert registry.skipped == ()
+    assert len(registry.loaded) == 1
+    assert registry.loaded[0].recognizer.name == _TUPLE_RECOGNIZER_NAME
 
 
 def test_lowercase_entity_type_is_skipped(
@@ -480,7 +508,7 @@ def test_lowercase_entity_type_is_skipped(
 ) -> None:
     _install_fake_entry_points(
         monkeypatch,
-        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _LowercaseEntityTypeRecognizer)],
+        [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _LowercaseEntityTypeRecognizer)],
     )
     registry = load_plugin_registry()
     assert registry.loaded == ()
@@ -492,7 +520,7 @@ def test_duplicate_entity_types_is_skipped(
 ) -> None:
     _install_fake_entry_points(
         monkeypatch,
-        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _DuplicateEntityTypesRecognizer)],
+        [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _DuplicateEntityTypesRecognizer)],
     )
     registry = load_plugin_registry()
     assert registry.loaded == ()
@@ -504,7 +532,7 @@ def test_non_recognizer_class_is_skipped(
 ) -> None:
     _install_fake_entry_points(
         monkeypatch,
-        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _NotARecognizerClass)],
+        [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _NotARecognizerClass)],
     )
     registry = load_plugin_registry()
     assert registry.loaded == ()
@@ -516,7 +544,7 @@ def test_non_class_entry_point_target_is_skipped(
 ) -> None:
     _install_fake_entry_points(
         monkeypatch,
-        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _plain_function_not_a_class)],
+        [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _plain_function_not_a_class)],
     )
     registry = load_plugin_registry()
     assert registry.loaded == ()
@@ -529,7 +557,7 @@ def test_entry_point_import_error_is_skipped(
     _install_fake_entry_points(
         monkeypatch,
         [
-            _FakeEntryPoint(
+            _EntryPointStub(
                 _ALPHA_ENTRY_POINT_NAME,
                 loaded_object=None,
                 load_error=ImportError("module missing"),
@@ -546,7 +574,7 @@ def test_missing_api_version_attribute_is_skipped(
 ) -> None:
     _install_fake_entry_points(
         monkeypatch,
-        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _MissingApiVersionRecognizer)],
+        [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _MissingApiVersionRecognizer)],
     )
     registry = load_plugin_registry()
     assert registry.loaded == ()
@@ -558,7 +586,7 @@ def test_missing_name_attribute_is_skipped(
 ) -> None:
     _install_fake_entry_points(
         monkeypatch,
-        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _MissingNameRecognizer)],
+        [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _MissingNameRecognizer)],
     )
     registry = load_plugin_registry()
     assert registry.loaded == ()
@@ -570,7 +598,7 @@ def test_missing_entity_types_attribute_is_skipped(
 ) -> None:
     _install_fake_entry_points(
         monkeypatch,
-        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _MissingEntityTypesRecognizer)],
+        [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _MissingEntityTypesRecognizer)],
     )
     registry = load_plugin_registry()
     assert registry.loaded == ()
@@ -582,7 +610,7 @@ def test_recognizer_constructor_failure_is_skipped(
 ) -> None:
     _install_fake_entry_points(
         monkeypatch,
-        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _ConstructorRaisingRecognizer)],
+        [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _ConstructorRaisingRecognizer)],
     )
     registry = load_plugin_registry()
     assert registry.loaded == ()
@@ -596,7 +624,7 @@ def test_recognizer_constructor_error_message_is_not_leaked(
 ) -> None:
     _install_fake_entry_points(
         monkeypatch,
-        [_FakeEntryPoint(_ALPHA_ENTRY_POINT_NAME, _ConstructorRaisingRecognizer)],
+        [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _ConstructorRaisingRecognizer)],
     )
     registry = load_plugin_registry()
     skipped_reason = registry.skipped[0].reason
@@ -624,12 +652,12 @@ def test_name_collision_first_wins_second_skipped(
     _install_fake_entry_points(
         monkeypatch,
         [
-            _FakeEntryPoint(
+            _EntryPointStub(
                 _ALPHA_ENTRY_POINT_NAME,
                 _ValidAlphaRecognizer,
                 _FAKE_DISTRIBUTION_ALPHA,
             ),
-            _FakeEntryPoint(
+            _EntryPointStub(
                 _BETA_ENTRY_POINT_NAME,
                 _AlphaClone,
                 _FAKE_DISTRIBUTION_BETA,

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -95,7 +95,7 @@ class _EntryPointStub:
         return _DistributionStub(self._distribution_name)
 
 
-def _install_fake_entry_points(
+def _patch_entry_point_discovery(
     monkeypatch: pytest.MonkeyPatch,
     fake_entry_points: list[_EntryPointStub],
 ) -> None:
@@ -347,7 +347,7 @@ def test_scan_context_accepts_valid_arguments() -> None:
 def test_empty_entry_point_group_yields_empty_registry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(monkeypatch, [])
+    _patch_entry_point_discovery(monkeypatch, [])
     registry = load_plugin_registry()
     assert registry.loaded == ()
     assert registry.skipped == ()
@@ -356,7 +356,7 @@ def test_empty_entry_point_group_yields_empty_registry(
 def test_single_valid_plugin_is_loaded(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [
             _EntryPointStub(
@@ -381,7 +381,7 @@ def test_single_valid_plugin_is_loaded(
 def test_multiple_valid_plugins_are_sorted_deterministically(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [
             _EntryPointStub(
@@ -406,7 +406,7 @@ def test_multiple_valid_plugins_are_sorted_deterministically(
 def test_plugin_without_distribution_still_loads(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _ValidAlphaRecognizer)],
     )
@@ -423,7 +423,7 @@ def test_plugin_without_distribution_still_loads(
 def test_mismatched_api_version_is_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [
             _EntryPointStub(
@@ -445,7 +445,7 @@ def test_mismatched_api_version_is_skipped(
 def test_name_with_hyphen_is_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _HyphenNameRecognizer)],
     )
@@ -457,7 +457,7 @@ def test_name_with_hyphen_is_skipped(
 def test_name_starting_with_digit_is_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _DigitStartNameRecognizer)],
     )
@@ -469,7 +469,7 @@ def test_name_starting_with_digit_is_skipped(
 def test_empty_entity_types_is_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _EmptyEntityTypesRecognizer)],
     )
@@ -481,7 +481,7 @@ def test_empty_entity_types_is_skipped(
 def test_non_sequence_entity_types_is_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _NonListEntityTypesRecognizer)],
     )
@@ -493,7 +493,7 @@ def test_non_sequence_entity_types_is_skipped(
 def test_tuple_entity_types_is_accepted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _TupleEntityTypesRecognizer)],
     )
@@ -506,7 +506,7 @@ def test_tuple_entity_types_is_accepted(
 def test_lowercase_entity_type_is_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _LowercaseEntityTypeRecognizer)],
     )
@@ -518,7 +518,7 @@ def test_lowercase_entity_type_is_skipped(
 def test_duplicate_entity_types_is_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _DuplicateEntityTypesRecognizer)],
     )
@@ -530,7 +530,7 @@ def test_duplicate_entity_types_is_skipped(
 def test_non_recognizer_class_is_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _NotARecognizerClass)],
     )
@@ -542,7 +542,7 @@ def test_non_recognizer_class_is_skipped(
 def test_non_class_entry_point_target_is_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _plain_function_not_a_class)],
     )
@@ -554,7 +554,7 @@ def test_non_class_entry_point_target_is_skipped(
 def test_entry_point_import_error_is_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [
             _EntryPointStub(
@@ -572,7 +572,7 @@ def test_entry_point_import_error_is_skipped(
 def test_missing_api_version_attribute_is_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _MissingApiVersionRecognizer)],
     )
@@ -584,7 +584,7 @@ def test_missing_api_version_attribute_is_skipped(
 def test_missing_name_attribute_is_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _MissingNameRecognizer)],
     )
@@ -596,7 +596,7 @@ def test_missing_name_attribute_is_skipped(
 def test_missing_entity_types_attribute_is_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _MissingEntityTypesRecognizer)],
     )
@@ -608,7 +608,7 @@ def test_missing_entity_types_attribute_is_skipped(
 def test_recognizer_constructor_failure_is_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _ConstructorRaisingRecognizer)],
     )
@@ -622,7 +622,7 @@ def test_recognizer_constructor_failure_is_skipped(
 def test_recognizer_constructor_error_message_is_not_leaked(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [_EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _ConstructorRaisingRecognizer)],
     )
@@ -649,7 +649,7 @@ def test_name_collision_first_wins_second_skipped(
             del line, context
             return []
 
-    _install_fake_entry_points(
+    _patch_entry_point_discovery(
         monkeypatch,
         [
             _EntryPointStub(


### PR DESCRIPTION
## Problem
PhiScan has no stable public surface for third-party recognizer plugins. External clinical teams want to ship their own detectors without forking the core package, but today any attempt would couple them to internal models that we refactor freely.

## Scope
Scorecard items A1 (plugin API surface), A2 (BaseRecognizer ABC), A3 (entry-point discovery + loader). **PR-2** (A4) adds the `phi-scan plugins list` CLI and wires execution through `detection_coordinator`. **PR-3** (A5) adds the `docs/plugin-api-v1.md` compatibility/deprecation policy. This PR is recognizer-only, discovery-only — nothing is wired into the scan pipeline yet.

## What changed
- **`phi_scan/plugin_api.py`** — `BaseRecognizer` ABC, `ScanContext` + `ScanFinding` frozen dataclasses with `__post_init__` validation, `PLUGIN_API_VERSION = "1.0"`, name/entity-type regex patterns, and bound constants. The public surface is deliberately minimal so future refactors of internal models cannot break installed plugins.
- **`phi_scan/plugin_loader.py`** — entry-point discovery under the `phi_scan.plugins` group, per-plugin validation (api version exact match, snake_case name, uppercase entity types, no duplicates, no name collisions, instantiation guard), fail-safe WARNING logging on skip, deterministic sort by `(distribution_name, entry_point_name)`, and a `PluginRegistry` hand-off for PR-2.
- **`phi_scan/exceptions.py`** — internal `PluginValidationError` (caught by the loader, never raised to callers).
- **`phi_scan/__init__.py`** — re-exports `BaseRecognizer`, `ScanContext`, `ScanFinding`, `PLUGIN_API_VERSION` at the package root.
- **`tests/test_plugin_loader.py`** — 28 tests using synthetic `_FakeEntryPoint` / `_FakeDistribution` stand-ins patched via `monkeypatch`, no installable fixture packages required.

## Files
- `phi_scan/plugin_api.py` (new public API, replaces prior stub)
- `phi_scan/plugin_loader.py` (new)
- `phi_scan/exceptions.py` (+16 lines — `PluginValidationError`)
- `phi_scan/__init__.py` (+16 lines — re-exports)
- `tests/test_plugin_loader.py` (new, 28 tests)

## Tests
- 28 new loader tests — all pass
- Full suite: 1854 passed, 3 skipped
- Coverage on new modules: `plugin_api.py` 100%, `plugin_loader.py` 100%
- `ruff check` / `ruff format --check` / `mypy` all clean

## Security
- No plugin ever receives the raw matched value; the host hashes the line slice after `detect()` returns. Plugins cannot exfiltrate PHI through the registry.
- `detect()` errors are caught by the host and the batch is dropped with a WARNING — a buggy third-party plugin cannot crash the scan or mask findings from other layers.
- Class-attribute validation happens before instantiation, so a malformed plugin cannot run arbitrary code in a constructor that a host helper trusted.

## Backcompat
An install with zero plugins behaves identically to the prior release. `load_plugin_registry()` returns an empty registry and no scan path is touched in this PR — execution wiring is deferred to PR-2. A plugin declaring any `plugin_api_version` other than `"1.0"` is skipped with a WARNING (exact-match policy for v1, documented inline; semver-range support deferred to v2 per the compatibility doc in PR-3).

## Docs
Compatibility/deprecation policy lives in **PR-3** (`docs/plugin-api-v1.md`). This PR only documents the rules inline in the module and class docstrings.

## Rollback
Revert the squash commit. No database migration, no CLI flag changes, no config schema changes, no entry points published from this repo — there is no persistent state to unwind.