### PR TITLE
feat: phi-scan plugins list command (A4)

### DIFF
--- a/phi_scan/cli.py
+++ b/phi_scan/cli.py
@@ -48,6 +48,7 @@ from phi_scan.ci_integration import (
 from phi_scan.cli_baseline import baseline_app
 from phi_scan.cli_config import config_app
 from phi_scan.cli_explain import explain_app
+from phi_scan.cli_plugins import plugins_app
 from phi_scan.cli_scan_config import load_scan_config
 from phi_scan.compliance import (
     ComplianceFramework,
@@ -161,6 +162,7 @@ app = typer.Typer(
 app.add_typer(config_app)
 app.add_typer(explain_app)
 app.add_typer(baseline_app)
+app.add_typer(plugins_app)
 
 # ---------------------------------------------------------------------------
 # Version flag

--- a/phi_scan/cli_plugins.py
+++ b/phi_scan/cli_plugins.py
@@ -1,0 +1,172 @@
+"""Plugins command group — phi-scan plugins <subcommand>."""
+
+from __future__ import annotations
+
+import json
+
+import typer
+from rich import box as rich_box
+from rich.table import Table
+
+from phi_scan.constants import EXIT_CODE_CLEAN
+from phi_scan.output import get_console
+from phi_scan.plugin_loader import (
+    LoadedPlugin,
+    PluginRegistry,
+    SkippedPlugin,
+    discover_plugin_registry,
+)
+
+__all__ = ["plugins_app"]
+
+plugins_app = typer.Typer(
+    name="plugins",
+    help="Discover and inspect installed recognizer plugins.",
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_NO_PLUGINS_MESSAGE: str = "No recognizer plugins discovered."
+
+_STATUS_LOADED: str = "loaded"
+_STATUS_SKIPPED_PREFIX: str = "skipped-invalid"
+
+_TABLE_TITLE: str = "Installed Recognizer Plugins"
+_COLUMN_NAME: str = "Name"
+_COLUMN_VERSION: str = "Version"
+_COLUMN_API_VERSION: str = "API Version"
+_COLUMN_ENTITY_TYPES: str = "Entity Types"
+_COLUMN_STATUS: str = "Status"
+
+_ENTITY_TYPE_SEPARATOR: str = ", "
+
+_JSON_KEY_PLUGINS: str = "plugins"
+_JSON_KEY_NAME: str = "name"
+_JSON_KEY_VERSION: str = "version"
+_JSON_KEY_API_VERSION: str = "api_version"
+_JSON_KEY_ENTITY_TYPES: str = "entity_types"
+_JSON_KEY_STATUS: str = "status"
+_JSON_KEY_REASON: str = "reason"
+_JSON_KEY_DISTRIBUTION: str = "distribution"
+_JSON_KEY_ENTRY_POINT: str = "entry_point"
+
+_JSON_INDENT: int = 2
+
+
+# ---------------------------------------------------------------------------
+# Public command
+# ---------------------------------------------------------------------------
+
+
+@plugins_app.command("list")
+def list_plugins(
+    is_json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Output plugin list as machine-readable JSON.",
+    ),
+) -> None:
+    """Discover installed recognizer plugins and display their metadata."""
+    registry = discover_plugin_registry()
+    if is_json_output:
+        _print_json_output(registry)
+    else:
+        _print_table_output(registry)
+    raise typer.Exit(code=EXIT_CODE_CLEAN)
+
+
+# ---------------------------------------------------------------------------
+# Table output
+# ---------------------------------------------------------------------------
+
+
+def _print_table_output(registry: PluginRegistry) -> None:
+    if not registry.loaded and not registry.skipped:
+        get_console().print(_NO_PLUGINS_MESSAGE)
+        return
+    table = _build_plugin_table(registry)
+    get_console().print(table)
+
+
+def _build_plugin_table(registry: PluginRegistry) -> Table:
+    table = Table(
+        title=_TABLE_TITLE,
+        box=rich_box.ROUNDED,
+        show_lines=True,
+    )
+    table.add_column(_COLUMN_NAME, style="bold")
+    table.add_column(_COLUMN_VERSION)
+    table.add_column(_COLUMN_API_VERSION)
+    table.add_column(_COLUMN_ENTITY_TYPES)
+    table.add_column(_COLUMN_STATUS)
+    for loaded_plugin in registry.loaded:
+        _add_loaded_row(table, loaded_plugin)
+    for skipped_plugin in registry.skipped:
+        _add_skipped_row(table, skipped_plugin)
+    return table
+
+
+def _add_loaded_row(table: Table, loaded_plugin: LoadedPlugin) -> None:
+    recognizer = loaded_plugin.recognizer
+    table.add_row(
+        recognizer.name,
+        recognizer.version,
+        recognizer.plugin_api_version,
+        _ENTITY_TYPE_SEPARATOR.join(recognizer.entity_types),
+        f"[green]{_STATUS_LOADED}[/green]",
+    )
+
+
+def _add_skipped_row(table: Table, skipped_plugin: SkippedPlugin) -> None:
+    table.add_row(
+        skipped_plugin.entry_point_name,
+        "",
+        "",
+        "",
+        f"[red]{_STATUS_SKIPPED_PREFIX}: {skipped_plugin.reason}[/red]",
+    )
+
+
+# ---------------------------------------------------------------------------
+# JSON output
+# ---------------------------------------------------------------------------
+
+
+def _print_json_output(registry: PluginRegistry) -> None:
+    plugin_records = _build_json_records(registry)
+    serialized_output = json.dumps(
+        {_JSON_KEY_PLUGINS: plugin_records},
+        indent=_JSON_INDENT,
+    )
+    typer.echo(serialized_output)
+
+
+def _build_json_records(registry: PluginRegistry) -> list[dict[str, object]]:
+    loaded_records = [_serialize_loaded_plugin(lp) for lp in registry.loaded]
+    skipped_records = [_serialize_skipped_plugin(sp) for sp in registry.skipped]
+    return loaded_records + skipped_records
+
+
+def _serialize_loaded_plugin(loaded_plugin: LoadedPlugin) -> dict[str, object]:
+    recognizer = loaded_plugin.recognizer
+    return {
+        _JSON_KEY_NAME: recognizer.name,
+        _JSON_KEY_VERSION: recognizer.version,
+        _JSON_KEY_API_VERSION: recognizer.plugin_api_version,
+        _JSON_KEY_ENTITY_TYPES: list(recognizer.entity_types),
+        _JSON_KEY_STATUS: _STATUS_LOADED,
+        _JSON_KEY_DISTRIBUTION: loaded_plugin.distribution_name,
+        _JSON_KEY_ENTRY_POINT: loaded_plugin.entry_point_name,
+    }
+
+
+def _serialize_skipped_plugin(skipped_plugin: SkippedPlugin) -> dict[str, object]:
+    return {
+        _JSON_KEY_NAME: skipped_plugin.entry_point_name,
+        _JSON_KEY_STATUS: _STATUS_SKIPPED_PREFIX,
+        _JSON_KEY_REASON: skipped_plugin.reason,
+        _JSON_KEY_DISTRIBUTION: skipped_plugin.distribution_name,
+        _JSON_KEY_ENTRY_POINT: skipped_plugin.entry_point_name,
+    }

--- a/phi_scan/cli_plugins.py
+++ b/phi_scan/cli_plugins.py
@@ -41,6 +41,7 @@ _COLUMN_ENTITY_TYPES: str = "Entity Types"
 _COLUMN_STATUS: str = "Status"
 
 _ENTITY_TYPE_SEPARATOR: str = ", "
+_EMPTY_CELL: str = ""
 
 _JSON_KEY_PLUGINS: str = "plugins"
 _JSON_KEY_NAME: str = "name"
@@ -122,9 +123,9 @@ def _add_loaded_row(table: Table, loaded_plugin: LoadedPlugin) -> None:
 def _add_skipped_row(table: Table, skipped_plugin: SkippedPlugin) -> None:
     table.add_row(
         skipped_plugin.entry_point_name,
-        "",
-        "",
-        "",
+        _EMPTY_CELL,
+        _EMPTY_CELL,
+        _EMPTY_CELL,
         f"[red]{_STATUS_SKIPPED_PREFIX}: {skipped_plugin.reason}[/red]",
     )
 

--- a/phi_scan/cli_plugins.py
+++ b/phi_scan/cli_plugins.py
@@ -31,7 +31,7 @@ plugins_app = typer.Typer(
 _NO_PLUGINS_MESSAGE: str = "No recognizer plugins discovered."
 
 _STATUS_LOADED: str = "loaded"
-_STATUS_SKIPPED_PREFIX: str = "skipped-invalid"
+_STATUS_SKIPPED: str = "skipped-invalid"
 
 _TABLE_TITLE: str = "Installed Recognizer Plugins"
 _COLUMN_NAME: str = "Name"
@@ -126,7 +126,7 @@ def _add_skipped_row(table: Table, skipped_plugin: SkippedPlugin) -> None:
         _EMPTY_CELL,
         _EMPTY_CELL,
         _EMPTY_CELL,
-        f"[red]{_STATUS_SKIPPED_PREFIX}: {skipped_plugin.reason}[/red]",
+        f"[red]{_STATUS_SKIPPED}: {skipped_plugin.reason}[/red]",
     )
 
 
@@ -141,7 +141,7 @@ def _print_json_output(registry: PluginRegistry) -> None:
         {_JSON_KEY_PLUGINS: plugin_records},
         indent=_JSON_INDENT,
     )
-    typer.echo(serialized_output)
+    get_console().print(serialized_output, highlight=False)
 
 
 def _build_json_records(registry: PluginRegistry) -> list[dict[str, object]]:
@@ -166,7 +166,7 @@ def _serialize_loaded_plugin(loaded_plugin: LoadedPlugin) -> dict[str, object]:
 def _serialize_skipped_plugin(skipped_plugin: SkippedPlugin) -> dict[str, object]:
     return {
         _JSON_KEY_NAME: skipped_plugin.entry_point_name,
-        _JSON_KEY_STATUS: _STATUS_SKIPPED_PREFIX,
+        _JSON_KEY_STATUS: _STATUS_SKIPPED,
         _JSON_KEY_REASON: skipped_plugin.reason,
         _JSON_KEY_DISTRIBUTION: skipped_plugin.distribution_name,
         _JSON_KEY_ENTRY_POINT: skipped_plugin.entry_point_name,

--- a/phi_scan/cli_plugins.py
+++ b/phi_scan/cli_plugins.py
@@ -6,6 +6,7 @@ import json
 
 import typer
 from rich import box as rich_box
+from rich.markup import escape as escape_rich_markup
 from rich.table import Table
 
 from phi_scan.constants import EXIT_CODE_CLEAN
@@ -126,7 +127,7 @@ def _add_skipped_row(table: Table, skipped_plugin: SkippedPlugin) -> None:
         _EMPTY_CELL,
         _EMPTY_CELL,
         _EMPTY_CELL,
-        f"[red]{_STATUS_SKIPPED}: {skipped_plugin.reason}[/red]",
+        f"[red]{_STATUS_SKIPPED}: {escape_rich_markup(skipped_plugin.reason)}[/red]",
     )
 
 

--- a/phi_scan/plugin_loader.py
+++ b/phi_scan/plugin_loader.py
@@ -39,6 +39,7 @@ __all__ = [
     "PLUGIN_ENTRY_POINT_GROUP",
     "PluginRegistry",
     "SkippedPlugin",
+    "discover_plugin_registry",
     "load_plugin_registry",
 ]
 
@@ -122,24 +123,39 @@ class PluginRegistry:
     skipped: tuple[SkippedPlugin, ...] = ()
 
 
-def load_plugin_registry() -> PluginRegistry:
+def discover_plugin_registry() -> PluginRegistry:
     """Discover, validate, and instantiate every plugin under the entry-point group.
+
+    Returns the registry without emitting log messages. Use this when the
+    caller will display skipped plugins directly (e.g. ``plugins list``).
 
     Returns:
         A ``PluginRegistry`` with the successfully loaded recognizers
         in ``loaded`` and the rejected ones in ``skipped``. Both
         tuples preserve deterministic discovery order. Never raises;
-        all per-plugin failures are converted to ``SkippedPlugin``
-        entries and logged at WARNING level.
+        all per-plugin failures are converted to ``SkippedPlugin`` entries.
     """
     sorted_entry_points = _sort_entry_points_deterministically(_discover_entry_points())
     loaded_plugins, skipped_plugins = _classify_entry_points(sorted_entry_points)
-    for skipped_plugin in skipped_plugins:
-        _log_skipped_plugin(skipped_plugin)
     return PluginRegistry(
         loaded=tuple(loaded_plugins),
         skipped=tuple(skipped_plugins),
     )
+
+
+def load_plugin_registry() -> PluginRegistry:
+    """Discover, validate, instantiate, and log warnings for every plugin.
+
+    Delegates to ``discover_plugin_registry`` and then emits a
+    WARNING-level log for each skipped plugin. Prefer this function
+    when plugins are loaded silently during a scan; use
+    ``discover_plugin_registry`` when the caller renders the
+    skipped list directly.
+    """
+    registry = discover_plugin_registry()
+    for skipped_plugin in registry.skipped:
+        _log_skipped_plugin(skipped_plugin)
+    return registry
 
 
 def _classify_entry_points(

--- a/tests/test_cli_plugins.py
+++ b/tests/test_cli_plugins.py
@@ -148,7 +148,7 @@ class _MismatchedVersionRecognizer(BaseRecognizer):
 # ---------------------------------------------------------------------------
 
 
-_runner = CliRunner()
+_cli_runner = CliRunner()
 
 
 def _patch_entry_point_discovery(
@@ -174,7 +174,7 @@ def _invoke_plugins_list(
     cli_arguments = ["plugins", "list"]
     if is_json:
         cli_arguments.append("--json")
-    invocation_result = _runner.invoke(app, cli_arguments)
+    invocation_result = _cli_runner.invoke(app, cli_arguments)
     assert invocation_result.exit_code == EXIT_CODE_CLEAN
     return invocation_result.output
 
@@ -391,10 +391,10 @@ class TestJsonOutput:
 class TestCommandIntegration:
     def test_plugins_list_exits_cleanly(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _patch_entry_point_discovery(monkeypatch, [])
-        invocation_result = _runner.invoke(app, ["plugins", "list"])
+        invocation_result = _cli_runner.invoke(app, ["plugins", "list"])
         assert invocation_result.exit_code == EXIT_CODE_CLEAN
 
     def test_plugins_help_shows_subcommand(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _patch_entry_point_discovery(monkeypatch, [])
-        invocation_result = _runner.invoke(app, ["plugins", "--help"])
+        invocation_result = _cli_runner.invoke(app, ["plugins", "--help"])
         assert "list" in invocation_result.output

--- a/tests/test_cli_plugins.py
+++ b/tests/test_cli_plugins.py
@@ -1,0 +1,402 @@
+# phi-scan:ignore-file
+"""Tests for the plugins command group — phi-scan plugins list.
+
+Exercises the plugin listing command with synthetic entry-point stubs
+injected via monkeypatch, covering empty registries, valid plugins,
+skipped plugins, deterministic ordering, and JSON output.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner  # phi-scan:ignore
+
+from phi_scan.cli import app
+from phi_scan.constants import EXIT_CODE_CLEAN
+from phi_scan.plugin_api import PLUGIN_API_VERSION, BaseRecognizer, ScanContext, ScanFinding
+from phi_scan.plugin_loader import PLUGIN_ENTRY_POINT_GROUP
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_ENTRY_POINTS_PATCH_TARGET: str = "phi_scan.plugin_loader.entry_points"
+
+_ALPHA_DISTRIBUTION: str = "phi-scan-ext-alpha"
+_BETA_DISTRIBUTION: str = "phi-scan-ext-beta"
+
+_ALPHA_RECOGNIZER_NAME: str = "alpha_recognizer"
+_BETA_RECOGNIZER_NAME: str = "beta_recognizer"
+_ALPHA_ENTITY_TYPE: str = "ALPHA_IDENTIFIER"
+_BETA_ENTITY_TYPE: str = "BETA_IDENTIFIER"
+
+_ALPHA_ENTRY_POINT_NAME: str = "alpha_entry_point"
+_BETA_ENTRY_POINT_NAME: str = "beta_entry_point"
+_INVALID_ENTRY_POINT_NAME: str = "invalid_entry_point"
+
+_MISMATCHED_API_VERSION: str = "2.0"
+_INVALID_DISTRIBUTION: str = "phi-scan-ext-invalid"
+
+_STATUS_LOADED_LABEL: str = "loaded"
+_STATUS_SKIPPED_LABEL: str = "skipped-invalid"
+
+_JSON_KEY_PLUGINS: str = "plugins"
+_JSON_KEY_NAME: str = "name"
+_JSON_KEY_VERSION: str = "version"
+_JSON_KEY_API_VERSION: str = "api_version"
+_JSON_KEY_ENTITY_TYPES: str = "entity_types"
+_JSON_KEY_STATUS: str = "status"
+_JSON_KEY_REASON: str = "reason"
+_JSON_KEY_DISTRIBUTION: str = "distribution"
+_JSON_KEY_ENTRY_POINT: str = "entry_point"
+
+_EXPECTED_LOADED_JSON_KEYS: frozenset[str] = frozenset(
+    {
+        _JSON_KEY_NAME,
+        _JSON_KEY_VERSION,
+        _JSON_KEY_API_VERSION,
+        _JSON_KEY_ENTITY_TYPES,
+        _JSON_KEY_STATUS,
+        _JSON_KEY_DISTRIBUTION,
+        _JSON_KEY_ENTRY_POINT,
+    }
+)
+
+_EXPECTED_SKIPPED_JSON_KEYS: frozenset[str] = frozenset(
+    {
+        _JSON_KEY_NAME,
+        _JSON_KEY_STATUS,
+        _JSON_KEY_REASON,
+        _JSON_KEY_DISTRIBUTION,
+        _JSON_KEY_ENTRY_POINT,
+    }
+)
+
+_EMPTY_PLUGIN_COUNT: int = 0
+_SINGLE_PLUGIN_COUNT: int = 1
+_TWO_PLUGIN_COUNT: int = 2
+
+_WIDE_TERMINAL_COLUMNS: str = "200"
+
+
+# ---------------------------------------------------------------------------
+# Stubs — same pattern as test_plugin_loader.py
+# ---------------------------------------------------------------------------
+
+
+class _DistributionStub:
+    def __init__(self, distribution_name: str) -> None:
+        self.name = distribution_name
+
+
+class _EntryPointStub:
+    def __init__(
+        self,
+        entry_point_name: str,
+        loaded_class: object,
+        distribution_name: str | None = None,
+    ) -> None:
+        self.name = entry_point_name
+        self._loaded_class = loaded_class
+        self._distribution_name = distribution_name
+
+    def load(self) -> object:
+        return self._loaded_class
+
+    @property
+    def dist(self) -> _DistributionStub | None:
+        if self._distribution_name is None:
+            return None
+        return _DistributionStub(self._distribution_name)
+
+
+# ---------------------------------------------------------------------------
+# Recognizer stubs
+# ---------------------------------------------------------------------------
+
+
+class _AlphaRecognizer(BaseRecognizer):
+    name = _ALPHA_RECOGNIZER_NAME
+    entity_types = [_ALPHA_ENTITY_TYPE]
+
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        del line, context
+        return []
+
+
+class _BetaRecognizer(BaseRecognizer):
+    name = _BETA_RECOGNIZER_NAME
+    entity_types = [_BETA_ENTITY_TYPE]
+
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        del line, context
+        return []
+
+
+class _MismatchedVersionRecognizer(BaseRecognizer):
+    name = "mismatched_version"
+    entity_types = ["MISMATCHED_TYPE"]
+    plugin_api_version = _MISMATCHED_API_VERSION
+
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        del line, context
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_runner = CliRunner()
+
+
+def _patch_entry_point_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+    entry_point_stubs: list[_EntryPointStub],
+) -> None:
+    def _entry_points_replacement(*, group: str) -> list[_EntryPointStub]:
+        if group != PLUGIN_ENTRY_POINT_GROUP:
+            return []
+        return list(entry_point_stubs)
+
+    monkeypatch.setattr(_ENTRY_POINTS_PATCH_TARGET, _entry_points_replacement)
+
+
+def _invoke_plugins_list(
+    monkeypatch: pytest.MonkeyPatch,
+    entry_point_stubs: list[_EntryPointStub],
+    *,
+    is_json: bool = False,
+) -> str:
+    _patch_entry_point_discovery(monkeypatch, entry_point_stubs)
+    monkeypatch.setenv("COLUMNS", _WIDE_TERMINAL_COLUMNS)
+    cli_arguments = ["plugins", "list"]
+    if is_json:
+        cli_arguments.append("--json")
+    invocation_result = _runner.invoke(app, cli_arguments)
+    assert invocation_result.exit_code == EXIT_CODE_CLEAN
+    return invocation_result.output
+
+
+# ---------------------------------------------------------------------------
+# Tests — empty state
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyPluginRegistry:
+    def test_no_plugins_shows_empty_message(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        output = _invoke_plugins_list(monkeypatch, [])
+        assert "No recognizer plugins discovered" in output
+
+    def test_no_plugins_json_returns_empty_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        output = _invoke_plugins_list(monkeypatch, [], is_json=True)
+        parsed_output = json.loads(output)
+        assert parsed_output[_JSON_KEY_PLUGINS] == []
+
+
+# ---------------------------------------------------------------------------
+# Tests — valid plugins
+# ---------------------------------------------------------------------------
+
+
+class TestValidPluginsListed:
+    def test_single_valid_plugin_shows_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stubs = [
+            _EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _AlphaRecognizer, _ALPHA_DISTRIBUTION),
+        ]
+        output = _invoke_plugins_list(monkeypatch, stubs)
+        assert _ALPHA_RECOGNIZER_NAME in output
+
+    def test_single_valid_plugin_shows_entity_type(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stubs = [
+            _EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _AlphaRecognizer, _ALPHA_DISTRIBUTION),
+        ]
+        output = _invoke_plugins_list(monkeypatch, stubs)
+        assert _ALPHA_ENTITY_TYPE in output
+
+    def test_single_valid_plugin_shows_loaded_status(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stubs = [
+            _EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _AlphaRecognizer, _ALPHA_DISTRIBUTION),
+        ]
+        output = _invoke_plugins_list(monkeypatch, stubs)
+        assert _STATUS_LOADED_LABEL in output
+
+    def test_multiple_valid_plugins_both_listed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stubs = [
+            _EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _AlphaRecognizer, _ALPHA_DISTRIBUTION),
+            _EntryPointStub(_BETA_ENTRY_POINT_NAME, _BetaRecognizer, _BETA_DISTRIBUTION),
+        ]
+        output = _invoke_plugins_list(monkeypatch, stubs)
+        assert _ALPHA_RECOGNIZER_NAME in output
+        assert _BETA_RECOGNIZER_NAME in output
+
+
+# ---------------------------------------------------------------------------
+# Tests — skipped / invalid plugins
+# ---------------------------------------------------------------------------
+
+
+class TestSkippedPluginsListed:
+    def test_invalid_plugin_shows_skipped_status(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stubs = [
+            _EntryPointStub(
+                _INVALID_ENTRY_POINT_NAME,
+                _MismatchedVersionRecognizer,
+                _INVALID_DISTRIBUTION,
+            ),
+        ]
+        output = _invoke_plugins_list(monkeypatch, stubs)
+        assert _STATUS_SKIPPED_LABEL in output
+
+    def test_invalid_plugin_shows_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stubs = [
+            _EntryPointStub(
+                _INVALID_ENTRY_POINT_NAME,
+                _MismatchedVersionRecognizer,
+                _INVALID_DISTRIBUTION,
+            ),
+        ]
+        output = _invoke_plugins_list(monkeypatch, stubs)
+        assert "plugin_api_version" in output
+
+    def test_mixed_valid_and_invalid_both_listed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stubs = [
+            _EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _AlphaRecognizer, _ALPHA_DISTRIBUTION),
+            _EntryPointStub(
+                _INVALID_ENTRY_POINT_NAME,
+                _MismatchedVersionRecognizer,
+                _INVALID_DISTRIBUTION,
+            ),
+        ]
+        output = _invoke_plugins_list(monkeypatch, stubs)
+        assert _ALPHA_RECOGNIZER_NAME in output
+        assert _STATUS_SKIPPED_LABEL in output
+
+
+# ---------------------------------------------------------------------------
+# Tests — deterministic ordering
+# ---------------------------------------------------------------------------
+
+
+class TestDeterministicOrdering:
+    def test_plugins_sorted_by_distribution_then_entry_point(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stubs = [
+            _EntryPointStub(_BETA_ENTRY_POINT_NAME, _BetaRecognizer, _BETA_DISTRIBUTION),
+            _EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _AlphaRecognizer, _ALPHA_DISTRIBUTION),
+        ]
+        output = _invoke_plugins_list(monkeypatch, stubs)
+        alpha_position = output.index(_ALPHA_RECOGNIZER_NAME)
+        beta_position = output.index(_BETA_RECOGNIZER_NAME)
+        assert alpha_position < beta_position
+
+    def test_json_ordering_matches_table_ordering(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stubs = [
+            _EntryPointStub(_BETA_ENTRY_POINT_NAME, _BetaRecognizer, _BETA_DISTRIBUTION),
+            _EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _AlphaRecognizer, _ALPHA_DISTRIBUTION),
+        ]
+        output = _invoke_plugins_list(monkeypatch, stubs, is_json=True)
+        parsed_output = json.loads(output)
+        plugin_names = [
+            plugin_record[_JSON_KEY_NAME] for plugin_record in parsed_output[_JSON_KEY_PLUGINS]
+        ]
+        assert plugin_names[0] == _ALPHA_RECOGNIZER_NAME
+        assert plugin_names[1] == _BETA_RECOGNIZER_NAME
+
+
+# ---------------------------------------------------------------------------
+# Tests — JSON output
+# ---------------------------------------------------------------------------
+
+
+class TestJsonOutput:
+    def test_json_output_is_parseable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stubs = [
+            _EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _AlphaRecognizer, _ALPHA_DISTRIBUTION),
+        ]
+        output = _invoke_plugins_list(monkeypatch, stubs, is_json=True)
+        parsed_output = json.loads(output)
+        assert _JSON_KEY_PLUGINS in parsed_output
+
+    def test_loaded_plugin_json_has_expected_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stubs = [
+            _EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _AlphaRecognizer, _ALPHA_DISTRIBUTION),
+        ]
+        output = _invoke_plugins_list(monkeypatch, stubs, is_json=True)
+        parsed_output = json.loads(output)
+        plugin_record = parsed_output[_JSON_KEY_PLUGINS][0]
+        assert frozenset(plugin_record.keys()) == _EXPECTED_LOADED_JSON_KEYS
+
+    def test_loaded_plugin_json_has_correct_metadata(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stubs = [
+            _EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _AlphaRecognizer, _ALPHA_DISTRIBUTION),
+        ]
+        output = _invoke_plugins_list(monkeypatch, stubs, is_json=True)
+        parsed_output = json.loads(output)
+        plugin_record = parsed_output[_JSON_KEY_PLUGINS][0]
+        assert plugin_record[_JSON_KEY_NAME] == _ALPHA_RECOGNIZER_NAME
+        assert plugin_record[_JSON_KEY_API_VERSION] == PLUGIN_API_VERSION
+        assert plugin_record[_JSON_KEY_ENTITY_TYPES] == [_ALPHA_ENTITY_TYPE]
+        assert plugin_record[_JSON_KEY_STATUS] == _STATUS_LOADED_LABEL
+        assert plugin_record[_JSON_KEY_DISTRIBUTION] == _ALPHA_DISTRIBUTION
+
+    def test_skipped_plugin_json_has_expected_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stubs = [
+            _EntryPointStub(
+                _INVALID_ENTRY_POINT_NAME,
+                _MismatchedVersionRecognizer,
+                _INVALID_DISTRIBUTION,
+            ),
+        ]
+        output = _invoke_plugins_list(monkeypatch, stubs, is_json=True)
+        parsed_output = json.loads(output)
+        plugin_record = parsed_output[_JSON_KEY_PLUGINS][0]
+        assert frozenset(plugin_record.keys()) == _EXPECTED_SKIPPED_JSON_KEYS
+
+    def test_skipped_plugin_json_includes_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stubs = [
+            _EntryPointStub(
+                _INVALID_ENTRY_POINT_NAME,
+                _MismatchedVersionRecognizer,
+                _INVALID_DISTRIBUTION,
+            ),
+        ]
+        output = _invoke_plugins_list(monkeypatch, stubs, is_json=True)
+        parsed_output = json.loads(output)
+        plugin_record = parsed_output[_JSON_KEY_PLUGINS][0]
+        assert plugin_record[_JSON_KEY_STATUS] == _STATUS_SKIPPED_LABEL
+        assert "plugin_api_version" in plugin_record[_JSON_KEY_REASON]
+
+    def test_mixed_plugins_json_count_matches(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stubs = [
+            _EntryPointStub(_ALPHA_ENTRY_POINT_NAME, _AlphaRecognizer, _ALPHA_DISTRIBUTION),
+            _EntryPointStub(
+                _INVALID_ENTRY_POINT_NAME,
+                _MismatchedVersionRecognizer,
+                _INVALID_DISTRIBUTION,
+            ),
+        ]
+        output = _invoke_plugins_list(monkeypatch, stubs, is_json=True)
+        parsed_output = json.loads(output)
+        assert len(parsed_output[_JSON_KEY_PLUGINS]) == _TWO_PLUGIN_COUNT
+
+
+# ---------------------------------------------------------------------------
+# Tests — command integration
+# ---------------------------------------------------------------------------
+
+
+class TestCommandIntegration:
+    def test_plugins_list_exits_cleanly(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_entry_point_discovery(monkeypatch, [])
+        invocation_result = _runner.invoke(app, ["plugins", "list"])
+        assert invocation_result.exit_code == EXIT_CODE_CLEAN
+
+    def test_plugins_help_shows_subcommand(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_entry_point_discovery(monkeypatch, [])
+        invocation_result = _runner.invoke(app, ["plugins", "--help"])
+        assert "list" in invocation_result.output

--- a/tests/test_cli_plugins.py
+++ b/tests/test_cli_plugins.py
@@ -148,19 +148,16 @@ class _MismatchedVersionRecognizer(BaseRecognizer):
 # ---------------------------------------------------------------------------
 
 
-_CLI_RUNNER = CliRunner()
-
-
 def _patch_entry_point_discovery(
     monkeypatch: pytest.MonkeyPatch,
     entry_point_stubs: list[_EntryPointStub],
 ) -> None:
-    def _entry_points_replacement(*, group: str) -> list[_EntryPointStub]:
+    def _return_stub_entry_points(*, group: str) -> list[_EntryPointStub]:
         if group != PLUGIN_ENTRY_POINT_GROUP:
             return []
         return list(entry_point_stubs)
 
-    monkeypatch.setattr(_ENTRY_POINTS_PATCH_TARGET, _entry_points_replacement)
+    monkeypatch.setattr(_ENTRY_POINTS_PATCH_TARGET, _return_stub_entry_points)
 
 
 def _invoke_plugins_list(
@@ -174,7 +171,8 @@ def _invoke_plugins_list(
     cli_arguments = ["plugins", "list"]
     if is_json:
         cli_arguments.append("--json")
-    invocation_result = _CLI_RUNNER.invoke(app, cli_arguments)
+    runner = CliRunner()
+    invocation_result = runner.invoke(app, cli_arguments)
     assert invocation_result.exit_code == EXIT_CODE_CLEAN
     return invocation_result.output
 
@@ -391,10 +389,12 @@ class TestJsonOutput:
 class TestCommandIntegration:
     def test_plugins_list_exits_cleanly(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _patch_entry_point_discovery(monkeypatch, [])
-        invocation_result = _CLI_RUNNER.invoke(app, ["plugins", "list"])
+        runner = CliRunner()
+        invocation_result = runner.invoke(app, ["plugins", "list"])
         assert invocation_result.exit_code == EXIT_CODE_CLEAN
 
     def test_plugins_help_shows_subcommand(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _patch_entry_point_discovery(monkeypatch, [])
-        invocation_result = _CLI_RUNNER.invoke(app, ["plugins", "--help"])
+        runner = CliRunner()
+        invocation_result = runner.invoke(app, ["plugins", "--help"])
         assert "list" in invocation_result.output

--- a/tests/test_cli_plugins.py
+++ b/tests/test_cli_plugins.py
@@ -40,7 +40,7 @@ _MISMATCHED_API_VERSION: str = "2.0"
 _INVALID_DISTRIBUTION: str = "phi-scan-ext-invalid"
 
 _STATUS_LOADED_LABEL: str = "loaded"
-_STATUS_SKIPPED_LABEL: str = "skipped-invalid"
+_STATUS_SKIPPED: str = "skipped-invalid"
 
 _JSON_KEY_PLUGINS: str = "plugins"
 _JSON_KEY_NAME: str = "name"
@@ -148,7 +148,7 @@ class _MismatchedVersionRecognizer(BaseRecognizer):
 # ---------------------------------------------------------------------------
 
 
-_cli_runner = CliRunner()
+_CLI_RUNNER = CliRunner()
 
 
 def _patch_entry_point_discovery(
@@ -174,7 +174,7 @@ def _invoke_plugins_list(
     cli_arguments = ["plugins", "list"]
     if is_json:
         cli_arguments.append("--json")
-    invocation_result = _cli_runner.invoke(app, cli_arguments)
+    invocation_result = _CLI_RUNNER.invoke(app, cli_arguments)
     assert invocation_result.exit_code == EXIT_CODE_CLEAN
     return invocation_result.output
 
@@ -247,7 +247,7 @@ class TestSkippedPluginsListed:
             ),
         ]
         output = _invoke_plugins_list(monkeypatch, stubs)
-        assert _STATUS_SKIPPED_LABEL in output
+        assert _STATUS_SKIPPED in output
 
     def test_invalid_plugin_shows_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
         stubs = [
@@ -271,7 +271,7 @@ class TestSkippedPluginsListed:
         ]
         output = _invoke_plugins_list(monkeypatch, stubs)
         assert _ALPHA_RECOGNIZER_NAME in output
-        assert _STATUS_SKIPPED_LABEL in output
+        assert _STATUS_SKIPPED in output
 
 
 # ---------------------------------------------------------------------------
@@ -366,7 +366,7 @@ class TestJsonOutput:
         output = _invoke_plugins_list(monkeypatch, stubs, is_json=True)
         parsed_output = json.loads(output)
         plugin_record = parsed_output[_JSON_KEY_PLUGINS][0]
-        assert plugin_record[_JSON_KEY_STATUS] == _STATUS_SKIPPED_LABEL
+        assert plugin_record[_JSON_KEY_STATUS] == _STATUS_SKIPPED
         assert "plugin_api_version" in plugin_record[_JSON_KEY_REASON]
 
     def test_mixed_plugins_json_count_matches(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -391,10 +391,10 @@ class TestJsonOutput:
 class TestCommandIntegration:
     def test_plugins_list_exits_cleanly(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _patch_entry_point_discovery(monkeypatch, [])
-        invocation_result = _cli_runner.invoke(app, ["plugins", "list"])
+        invocation_result = _CLI_RUNNER.invoke(app, ["plugins", "list"])
         assert invocation_result.exit_code == EXIT_CODE_CLEAN
 
     def test_plugins_help_shows_subcommand(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _patch_entry_point_discovery(monkeypatch, [])
-        invocation_result = _cli_runner.invoke(app, ["plugins", "--help"])
+        invocation_result = _CLI_RUNNER.invoke(app, ["plugins", "--help"])
         assert "list" in invocation_result.output

--- a/tests/test_cli_plugins.py
+++ b/tests/test_cli_plugins.py
@@ -74,8 +74,6 @@ _EXPECTED_SKIPPED_JSON_KEYS: frozenset[str] = frozenset(
     }
 )
 
-_EMPTY_PLUGIN_COUNT: int = 0
-_SINGLE_PLUGIN_COUNT: int = 1
 _TWO_PLUGIN_COUNT: int = 2
 
 _WIDE_TERMINAL_COLUMNS: str = "200"


### PR DESCRIPTION
## Problem statement

After PR #124 landed the plugin API v1 foundation (A1/A2/A3), users have no CLI surface to inspect which recognizer plugins are installed, which ones loaded successfully, and which were skipped due to validation failures.

## Scope

**In scope:**
- `phi-scan plugins list` subcommand with Rich table (default) and `--json` output
- Displays loaded plugin metadata: name, version, API version, entity types, status
- Displays skipped plugins with full validation failure reason
- Deterministic ordering (sorted by distribution name, then entry-point name)
- 19 tests covering all paths

**Out of scope:**
- Plugin execution/wiring into scan pipeline (future PR)
- Plugin install/uninstall commands
- Plugin enable/disable toggling

## What changed

| File | Change |
|------|--------|
| `phi_scan/cli_plugins.py` | New module — `plugins` Typer subgroup with `list` command |
| `phi_scan/cli.py` | Wire `plugins_app` via `app.add_typer()` |
| `phi_scan/plugin_loader.py` | Extract `discover_plugin_registry()` (no logging) from `load_plugin_registry()` |
| `tests/test_cli_plugins.py` | 19 tests — empty state, valid/skipped plugins, ordering, JSON output, CLI integration |

## Files changed

- `phi_scan/cli_plugins.py` (new, 73 statements)
- `phi_scan/cli.py` (+2 lines: import + add_typer)
- `phi_scan/plugin_loader.py` (+23 lines: extracted discover_plugin_registry)
- `tests/test_cli_plugins.py` (new, 19 tests)

## Tests run + results

```
1875 passed, 3 skipped, 7250 warnings in 25.95s
Coverage: 89.83% (>80% threshold)
cli_plugins.py: 100% coverage
plugin_loader.py: 100% coverage
```

## Security impact

None. The command is read-only — it discovers and displays plugin metadata. No PHI is processed, stored, or transmitted. Skipped plugin reasons use the same PHI-safe error strings from the loader (constructor error messages are deliberately stripped to type name only).

## Backward compatibility impact

Additive only. New CLI subcommand `plugins list` does not affect existing commands. The new `discover_plugin_registry()` function is additive to the loader's public API; `load_plugin_registry()` behavior is unchanged.

## Docs/changelog updates

None required for this PR. Plugin compatibility docs will ship in A5.

## Rollback plan

Revert commit. No schema changes, no configuration changes, no data migrations.