### PR TITLE
docs: plugin API v1 compatibility policy + scorecard A4/A5 (A5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Copy-paste templates for all CI platforms: [docs/ci-cd-integration.md](docs/ci-c
 | [docs/compliance-frameworks.md](docs/compliance-frameworks.md) | Complete regulatory reference for all 12 frameworks |
 | [docs/remediation-guide.md](docs/remediation-guide.md) | Per-category PHI removal playbook and `phi-scan fix` workflow |
 | [docs/de-identification.md](docs/de-identification.md) | Safe Harbor vs Expert Determination; regulatory scope |
+| [docs/plugin-api-v1.md](docs/plugin-api-v1.md) | Plugin API v1 compatibility, deprecation policy, and authoring constraints |
 | [docs/plugin-developer-guide.md](docs/plugin-developer-guide.md) | Custom recognizer development guide |
 | [docs/ignore-patterns.md](docs/ignore-patterns.md) | `.phi-scanignore` syntax, suppression comments |
 | [docs/ci-cd-integration.md](docs/ci-cd-integration.md) | CI/CD platform copy-paste templates |
@@ -286,6 +287,26 @@ Copy-paste templates for all CI platforms: [docs/ci-cd-integration.md](docs/ci-c
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Development setup, standards, PR process |
 | [SECURITY.md](SECURITY.md) | Vulnerability reporting policy |
 | [docs/PROGRAM_SCORECARD.md](docs/PROGRAM_SCORECARD.md) | Public-repo quality scorecard (10/10 criteria and status) |
+
+---
+
+## Plugin Development
+
+PhiScan supports third-party recognizer plugins that extend the scanner
+with custom detection logic. Plugins register under the `phi_scan.plugins`
+entry-point group and are discovered automatically at startup.
+
+```bash
+# List all installed plugins and their status
+phi-scan plugins list
+```
+
+Plugins MUST declare `plugin_api_version = "1.0"` to match the current
+host version. Incompatible or invalid plugins are skipped with a warning;
+the core scanner continues functioning.
+
+See [docs/plugin-api-v1.md](docs/plugin-api-v1.md) for the full
+compatibility policy, deprecation rules, and a minimal plugin example.
 
 ---
 

--- a/docs/PROGRAM_SCORECARD.md
+++ b/docs/PROGRAM_SCORECARD.md
@@ -4,7 +4,7 @@ Tracks progress toward 10/10 public-repo quality across four categories.
 Each check has a binary pass/fail state. All checks must pass before the repo
 is declared production-ready for v1.0.
 
-**Last updated:** 2026-04-11
+**Last updated:** 2026-04-15
 
 ---
 
@@ -110,7 +110,7 @@ is declared production-ready for v1.0.
 | 2026-04-12 | 9/9 | 5/11 | 1/8 | 3/7 | T8/T9 shipped: synthetic small/medium/large corpora and per-size runtime + throughput thresholds enforced in the Linux pytest job. Technical Maturity category now at 100%. |
 | 2026-04-13 | 9/9 | 8/11 | 1/8 | 3/7 | S5/S7/S8 shipped: 50 adversarial SSRF tests (IPv4-mapped IPv6, unspecified, multicast, mixed-resolution, DNS rebind TOCTOU), full-surface threat model at `docs/threat-model.md`, notifier SSRF fix (unmap IPv4-mapped IPv6 + built-in-property checks). Security category now at 73%. |
 | 2026-04-14 | 9/9 | 11/11 | 1/8 | 3/7 | S9/S10/S11 shipped: pip-audit CI gate with policy-enforced `.pip-audit-ignore.toml`, release-time CycloneDX SBOM via `.github/scripts/sbom_generator.py`, keyless Sigstore signing of wheel+sdist. Baseline CVEs cleared via direct pin bumps (cryptography 46.0.7, pygments 2.20.0). Full supply-chain policy at `docs/supply-chain.md`. Security category at 100%; overall 69%. |
-| 2026-04-11 | 9/9 | 11/11 | 6/8 | 3/7 | A1–A5 shipped: Plugin API v1 core (`BaseRecognizer` ABC, `ScanContext`/`ScanFinding` dataclasses, `PLUGIN_API_VERSION`) in PR #124. `phi-scan plugins list` command with Rich table and `--json` output in PR #125. Plugin compatibility and deprecation policy at `docs/plugin-api-v1.md`. Architecture category at 75%; overall 83%. |
+| 2026-04-15 | 9/9 | 11/11 | 6/8 | 3/7 | A1–A5 shipped: Plugin API v1 core (`BaseRecognizer` ABC, `ScanContext`/`ScanFinding` dataclasses, `PLUGIN_API_VERSION`) in PR #124. `phi-scan plugins list` command with Rich table and `--json` output in PR #125. Plugin compatibility and deprecation policy at `docs/plugin-api-v1.md`. Architecture category at 75%; overall 83%. |
 
 ---
 

--- a/docs/PROGRAM_SCORECARD.md
+++ b/docs/PROGRAM_SCORECARD.md
@@ -4,7 +4,7 @@ Tracks progress toward 10/10 public-repo quality across four categories.
 Each check has a binary pass/fail state. All checks must pass before the repo
 is declared production-ready for v1.0.
 
-**Last updated:** 2026-04-14
+**Last updated:** 2026-04-11
 
 ---
 
@@ -59,16 +59,16 @@ is declared production-ready for v1.0.
 
 | # | Check | Status | Notes |
 |---|-------|--------|-------|
-| A1 | Plugin API v1 interface defined with explicit version constant | FAIL | `plugin_api.py` is a stub |
-| A2 | `BaseRecognizer` abstract class published with stable method signatures | FAIL | Not yet implemented |
-| A3 | Plugin discovery via Python entry points implemented and tested | FAIL | Not yet implemented |
-| A4 | `phi-scan plugins list` command implemented with metadata validation tests | FAIL | Not yet implemented |
-| A5 | Plugin API compatibility and deprecation policy documented | FAIL | Not yet documented |
+| A1 | Plugin API v1 interface defined with explicit version constant | PASS | `PLUGIN_API_VERSION = "1.0"` in `phi_scan/plugin_api.py`; exact-match enforced by loader. Shipped in PR #124. |
+| A2 | `BaseRecognizer` abstract class published with stable method signatures | PASS | ABC with `detect(line, context)` method, `ScanContext`/`ScanFinding` frozen dataclasses. Shipped in PR #124. |
+| A3 | Plugin discovery via Python entry points implemented and tested | PASS | Entry-point discovery via `phi_scan.plugins` group, fail-safe validation, 30 tests at 100% coverage. Shipped in PR #124. |
+| A4 | `phi-scan plugins list` command implemented with metadata validation tests | PASS | Rich table + `--json` output, 19 tests at 100% coverage. Shipped in PR #125. |
+| A5 | Plugin API compatibility and deprecation policy documented | PASS | `docs/plugin-api-v1.md` covers version contract, compatibility surface, deprecation process (2-minor-release window), failure semantics, authoring constraints. |
 | A6 | Suppressor and output-sink plugin hooks designed (v1.1 shape documented, not implemented) | FAIL | Deferred to v1.1; design not yet written |
 | A7 | Parallel scan determinism validated across `workers=1` and `workers>1` | PASS | Parity tests in `tests/test_scanner.py` validate identical findings and ordering |
 | A8 | `ci_integration.py` adapter split planned with per-platform interface contract documented | FAIL | Planned in roadmap (8F-ext.2); not yet designed |
 
-**Passing: 1 / 8**
+**Passing: 6 / 8**
 
 ---
 
@@ -94,9 +94,9 @@ is declared production-ready for v1.0.
 |----------|---------|-------|---|
 | Technical Maturity | 9 | 9 | 100% |
 | Security Posture | 11 | 11 | 100% |
-| Architecture Scalability | 1 | 8 | 13% |
+| Architecture Scalability | 6 | 8 | 75% |
 | Commercial Readiness | 3 | 7 | 43% |
-| **Total** | **24** | **35** | **69%** |
+| **Total** | **29** | **35** | **83%** |
 
 **Target:** 35 / 35 checks passing.
 
@@ -110,6 +110,7 @@ is declared production-ready for v1.0.
 | 2026-04-12 | 9/9 | 5/11 | 1/8 | 3/7 | T8/T9 shipped: synthetic small/medium/large corpora and per-size runtime + throughput thresholds enforced in the Linux pytest job. Technical Maturity category now at 100%. |
 | 2026-04-13 | 9/9 | 8/11 | 1/8 | 3/7 | S5/S7/S8 shipped: 50 adversarial SSRF tests (IPv4-mapped IPv6, unspecified, multicast, mixed-resolution, DNS rebind TOCTOU), full-surface threat model at `docs/threat-model.md`, notifier SSRF fix (unmap IPv4-mapped IPv6 + built-in-property checks). Security category now at 73%. |
 | 2026-04-14 | 9/9 | 11/11 | 1/8 | 3/7 | S9/S10/S11 shipped: pip-audit CI gate with policy-enforced `.pip-audit-ignore.toml`, release-time CycloneDX SBOM via `.github/scripts/sbom_generator.py`, keyless Sigstore signing of wheel+sdist. Baseline CVEs cleared via direct pin bumps (cryptography 46.0.7, pygments 2.20.0). Full supply-chain policy at `docs/supply-chain.md`. Security category at 100%; overall 69%. |
+| 2026-04-11 | 9/9 | 11/11 | 6/8 | 3/7 | A1–A5 shipped: Plugin API v1 core (`BaseRecognizer` ABC, `ScanContext`/`ScanFinding` dataclasses, `PLUGIN_API_VERSION`) in PR #124. `phi-scan plugins list` command with Rich table and `--json` output in PR #125. Plugin compatibility and deprecation policy at `docs/plugin-api-v1.md`. Architecture category at 75%; overall 83%. |
 
 ---
 
@@ -123,7 +124,7 @@ Checks are addressed in this sequence:
     - T8, T9 ✓ Done — synthetic corpora + runtime/throughput CI thresholds
 3. **S5, S7, S8** ✓ Done — SSRF adversarial tests + threat model doc
 4. **S9, S10, S11** ✓ Done — Supply-chain security gates (pip-audit CI gate, CycloneDX SBOM, Sigstore signing)
-5. **A1–A5** — Plugin API v1 implementation
+5. **A1–A5** ✓ Done — Plugin API v1 core (PR #124), `plugins list` command (PR #125), compatibility/deprecation policy doc
 6. **A6** — Suppressor + output-sink design doc (v1.1 shape)
 7. **A8** — CI adapter split design doc
 8. **C3–C6** — Boundary docs, release policy, governance

--- a/docs/plugin-api-v1.md
+++ b/docs/plugin-api-v1.md
@@ -224,10 +224,7 @@ Plugin authors MUST NOT:
 ### Recognizer Class
 
 ```python
-from phi_scan import BaseRecognizer, ScanContext, ScanFinding
-
-# A real plugin should define all literals as module-level constants.
-# This example inlines values for brevity.
+from phi_scan import BaseRecognizer, PLUGIN_API_VERSION, ScanContext, ScanFinding
 
 ENTITY_TYPE_INTERNAL_ID: str = "INTERNAL_ID"
 MARKER_PREFIX: str = "PATIENT-"
@@ -239,7 +236,7 @@ PYTHON_EXTENSION: str = ".py"
 class InternalIdRecognizer(BaseRecognizer):
     name = "internal_id"
     entity_types = [ENTITY_TYPE_INTERNAL_ID]
-    plugin_api_version = "1.0"
+    plugin_api_version = PLUGIN_API_VERSION
     version = "0.1.0"
     description = "Detects internal patient identifiers."
 

--- a/docs/plugin-api-v1.md
+++ b/docs/plugin-api-v1.md
@@ -224,31 +224,39 @@ Plugin authors MUST NOT:
 ```python
 from phi_scan import BaseRecognizer, ScanContext, ScanFinding
 
+# A real plugin should define all literals as module-level constants.
+# This example inlines values for brevity.
+
+ENTITY_TYPE_INTERNAL_ID: str = "INTERNAL_ID"
+MARKER_PREFIX: str = "PATIENT-"
+SUFFIX_LENGTH: int = 6  # digits after the PATIENT- prefix
+MATCH_CONFIDENCE: float = 0.9
+PYTHON_EXTENSION: str = ".py"
+
+
 class InternalIdRecognizer(BaseRecognizer):
     name = "internal_id"
-    entity_types = ["INTERNAL_ID"]
+    entity_types = [ENTITY_TYPE_INTERNAL_ID]
     plugin_api_version = "1.0"
     version = "0.1.0"
     description = "Detects internal patient identifiers."
 
     def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
-        # Skip non-Python files
-        if context.file_extension != ".py":
+        if context.file_extension != PYTHON_EXTENSION:
             return []
 
-        marker = "PATIENT-"
         findings: list[ScanFinding] = []
         search_start = 0
         while True:
-            position = line.find(marker, search_start)
+            position = line.find(MARKER_PREFIX, search_start)
             if position < 0:
                 break
             findings.append(
                 ScanFinding(
-                    entity_type="INTERNAL_ID",
+                    entity_type=ENTITY_TYPE_INTERNAL_ID,
                     start_offset=position,
-                    end_offset=position + len(marker) + 6,
-                    confidence=0.9,
+                    end_offset=position + len(MARKER_PREFIX) + SUFFIX_LENGTH,
+                    confidence=MATCH_CONFIDENCE,
                 )
             )
             search_start = position + 1

--- a/docs/plugin-api-v1.md
+++ b/docs/plugin-api-v1.md
@@ -209,8 +209,10 @@ values in any `ScanFinding`.
 
 Plugin authors MUST NOT:
 
-- Open, read, or stat the file at `context.file_path` — it is provided
-  for language-gating and logging only.
+- Open, read, stat, or follow symlinks at `context.file_path` — it is
+  provided for language-gating and logging only. PhiScan never follows
+  symlinks during directory traversal and plugins MUST NOT circumvent
+  that guarantee.
 - Include raw PHI values in any `ScanFinding` or log output.
 - Send data to any remote service — PhiScan is an offline scanner and
   plugins inherit that guarantee.
@@ -251,11 +253,16 @@ class InternalIdRecognizer(BaseRecognizer):
             position = line.find(MARKER_PREFIX, search_start)
             if position < 0:
                 break
+            match_end = position + len(MARKER_PREFIX) + SUFFIX_LENGTH
+            # Guard: end_offset must not exceed the line length
+            if match_end > len(line):
+                search_start = position + 1
+                continue
             findings.append(
                 ScanFinding(
                     entity_type=ENTITY_TYPE_INTERNAL_ID,
                     start_offset=position,
-                    end_offset=position + len(MARKER_PREFIX) + SUFFIX_LENGTH,
+                    end_offset=match_end,
                     confidence=MATCH_CONFIDENCE,
                 )
             )

--- a/docs/plugin-api-v1.md
+++ b/docs/plugin-api-v1.md
@@ -1,0 +1,299 @@
+# Plugin API v1 — Compatibility and Deprecation Policy
+
+This document defines the compatibility contract, deprecation rules, and
+authoring constraints for third-party recognizer plugins that register
+under the `phi_scan.plugins` entry-point group.
+
+The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY in this
+document are to be interpreted as described in
+[RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+---
+
+## API Version Contract
+
+The host declares its plugin API version as the string constant
+`PLUGIN_API_VERSION` (currently `"1.0"`).
+
+Every recognizer plugin MUST declare the same version string on its
+`plugin_api_version` class attribute. The loader enforces an **exact
+match**: if the declared version does not equal the host version, the
+plugin is skipped with a WARNING and the scan continues without it.
+
+```
+Host: PLUGIN_API_VERSION = "1.0"
+Plugin: plugin_api_version = "1.0"   # exact match required
+```
+
+The exact-match rule is deliberate for v1. Semver-range negotiation MAY
+be added in a future API version once the deprecation process described
+below is in place.
+
+---
+
+## Compatibility Policy
+
+### Stable v1 Surface
+
+The following names are the stable public contract for the 1.x line.
+They MUST NOT be removed, renamed, or have their signatures changed
+in any 1.x release:
+
+| Name | Module | Kind |
+|------|--------|------|
+| `BaseRecognizer` | `phi_scan.plugin_api` | Abstract base class |
+| `ScanContext` | `phi_scan.plugin_api` | Frozen dataclass |
+| `ScanFinding` | `phi_scan.plugin_api` | Frozen dataclass |
+| `PLUGIN_API_VERSION` | `phi_scan.plugin_api` | String constant |
+
+All four names are re-exported at the `phi_scan` package root for
+convenience. Both import paths are supported and stable:
+
+```python
+# Either import path is stable across the 1.x line:
+from phi_scan.plugin_api import BaseRecognizer, ScanContext, ScanFinding
+from phi_scan import BaseRecognizer, ScanContext, ScanFinding
+```
+
+### Stable Entry-Point Group
+
+Plugins register under the entry-point group `phi_scan.plugins`. This
+group name MUST NOT change within the 1.x line.
+
+### Internal / Private Surface
+
+Any name prefixed with `_` (single underscore) is private and MAY
+change without notice in any release. Plugin authors MUST NOT import
+or depend on private names.
+
+The following public names in `phi_scan.plugin_api` are implementation
+details used by the loader. They are importable but are NOT part of the
+stable plugin-author contract and MAY be relocated or renamed in a
+future 1.x release:
+
+- `RECOGNIZER_NAME_PATTERN`
+- `ENTITY_TYPE_PATTERN`
+- `MIN_CONFIDENCE_SCORE` / `MAX_CONFIDENCE_SCORE`
+- `MIN_START_OFFSET`
+- `MIN_LINE_NUMBER`
+
+Plugin authors SHOULD NOT reference these constants directly. The
+loader validates recognizer metadata; plugins do not need to duplicate
+those checks.
+
+---
+
+## Deprecation Policy
+
+When a stable v1 surface element is scheduled for removal or
+incompatible change, the following process MUST be followed:
+
+1. **Announce** the deprecation in release notes and in this document.
+   The announcement MUST include the earliest version in which the
+   removal will take effect and a migration path.
+
+2. **Maintain** the deprecated element for a minimum of **2 minor
+   releases** after the announcement. For example, if deprecation is
+   announced in v1.3.0, the element MUST remain functional through
+   v1.4.x and MUST NOT be removed before v1.5.0.
+
+3. **Emit** a `DeprecationWarning` at runtime when the deprecated
+   element is used, starting from the announcement release.
+
+4. **Remove** the element no earlier than the version stated in the
+   announcement. The removal MUST be documented in the release notes
+   with a final migration reminder.
+
+Breaking changes to the stable surface (removing `BaseRecognizer`,
+changing `detect()` signature, renaming the entry-point group) MUST
+NOT occur in any 1.x release. Such changes require a new major API
+version (`PLUGIN_API_VERSION = "2.0"`) with its own compatibility
+policy.
+
+---
+
+## Failure Semantics and Safety
+
+### Invalid or Incompatible Plugins
+
+A plugin that fails any validation check is **skipped with a WARNING**.
+The scanner continues functioning with all remaining valid plugins. A
+scan with zero valid plugins is indistinguishable from a scan with no
+plugins installed — both produce an empty plugin list.
+
+Validation checks that trigger skipping:
+
+| Check | Reason |
+|-------|--------|
+| `plugin_api_version` does not match host | Version incompatibility |
+| `name` missing or does not match pattern | Invalid metadata |
+| `entity_types` missing, empty, or malformed | Invalid metadata |
+| Entry-point target is not a `BaseRecognizer` subclass | Structural incompatibility |
+| Entry-point import fails (`ImportError`, `AttributeError`) | Broken package metadata |
+| Constructor raises an exception | Runtime failure |
+
+### Name Collision Rule
+
+Plugin names MUST be unique across all installed distributions. When
+two plugins declare the same `name`, the loader applies a
+**deterministic first-wins** rule: plugins are sorted by
+`(distribution_name, entry_point_name)` and the first occurrence is
+loaded. All subsequent duplicates are skipped with a WARNING that
+identifies the collision.
+
+### Constructor Error Safety
+
+Plugin constructor exceptions are caught and converted to skip entries.
+Only the exception **type name** is recorded in the skip reason — the
+raw error message is intentionally dropped because a constructor MAY
+have read values from the environment that could incidentally contain
+PHI. `BaseException` subclasses (`SystemExit`, `KeyboardInterrupt`)
+are NOT caught.
+
+---
+
+## Authoring Constraints (v1)
+
+### Required Class Attributes
+
+Every `BaseRecognizer` subclass MUST declare:
+
+| Attribute | Type | Constraint |
+|-----------|------|------------|
+| `name` | `str` | Matches `^[a-z][a-z0-9_]*$` (lowercase snake_case) |
+| `entity_types` | `tuple[str, ...]` or `list[str]` | Non-empty; each element matches `^[A-Z][A-Z0-9_]*$`; no duplicates |
+| `plugin_api_version` | `str` | Must equal host `PLUGIN_API_VERSION` (`"1.0"`) |
+
+Optional attributes with defaults:
+
+| Attribute | Type | Default |
+|-----------|------|---------|
+| `version` | `str` | `"0.0.0"` |
+| `description` | `str` | `""` |
+
+### Constructor
+
+The host calls `RecognizerClass()` with **no arguments**. Plugin
+constructors MUST accept zero positional or keyword arguments.
+
+### `detect()` Method
+
+```python
+def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+    ...
+```
+
+- `line`: Full text of the line being scanned, without trailing newline.
+- `context`: A `ScanContext` with `file_path`, `line_number`, and
+  `file_extension`.
+- Return a **freshly constructed** `list` of zero or more `ScanFinding`
+  objects on every call. MUST NOT reuse a shared mutable list across
+  invocations.
+- Raising from `detect()` is permitted; the host catches the exception
+  and drops findings for that line with a WARNING.
+
+### `ScanFinding` Fields
+
+| Field | Type | Constraint |
+|-------|------|------------|
+| `entity_type` | `str` | MUST appear in the recognizer's `entity_types` list |
+| `start_offset` | `int` | 0-indexed column; MUST be >= 0 |
+| `end_offset` | `int` | Exclusive; MUST be > `start_offset` |
+| `confidence` | `float` | MUST be in [0.0, 1.0] |
+
+The host derives severity and computes the value hash from the matched
+line slice. Plugins MUST NOT attempt to set severity or include raw PHI
+values in any `ScanFinding`.
+
+### Prohibited Actions
+
+Plugin authors MUST NOT:
+
+- Open, read, or stat the file at `context.file_path` — it is provided
+  for language-gating and logging only.
+- Include raw PHI values in any `ScanFinding` or log output.
+- Send data to any remote service — PhiScan is an offline scanner and
+  plugins inherit that guarantee.
+
+---
+
+## Minimal Plugin Example
+
+### Recognizer Class
+
+```python
+from phi_scan import BaseRecognizer, ScanContext, ScanFinding
+
+class InternalIdRecognizer(BaseRecognizer):
+    name = "internal_id"
+    entity_types = ["INTERNAL_ID"]
+    plugin_api_version = "1.0"
+    version = "0.1.0"
+    description = "Detects internal patient identifiers."
+
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        # Skip non-Python files
+        if context.file_extension != ".py":
+            return []
+
+        marker = "PATIENT-"
+        findings: list[ScanFinding] = []
+        search_start = 0
+        while True:
+            position = line.find(marker, search_start)
+            if position < 0:
+                break
+            findings.append(
+                ScanFinding(
+                    entity_type="INTERNAL_ID",
+                    start_offset=position,
+                    end_offset=position + len(marker) + 6,
+                    confidence=0.9,
+                )
+            )
+            search_start = position + 1
+        return findings
+```
+
+### Entry-Point Registration (`pyproject.toml`)
+
+```toml
+[project.entry-points."phi_scan.plugins"]
+internal_id = "my_package.recognizers:InternalIdRecognizer"
+```
+
+### Verify Installation
+
+```bash
+phi-scan plugins list
+```
+
+The recognizer appears as `loaded` if metadata is valid, or
+`skipped-invalid` with a reason if any check fails.
+
+---
+
+## Inspecting Installed Plugins
+
+The `phi-scan plugins list` command discovers all installed recognizer
+plugins and displays their status:
+
+```bash
+# Rich table (default)
+phi-scan plugins list
+
+# Machine-readable JSON
+phi-scan plugins list --json
+```
+
+Loaded plugins display name, version, API version, entity types, and
+a `loaded` status. Skipped plugins display the entry-point name and
+the validation failure reason.
+
+---
+
+## Version History
+
+| API Version | Host Version | Status |
+|-------------|-------------|--------|
+| `1.0` | v0.5.0+ | **Current** — exact match enforced |


### PR DESCRIPTION
## Problem statement

After A1-A4 shipped the plugin API v1 runtime (PR #124, #125), plugin authors have no documented contract for what is stable, how deprecations work, or what constraints they must follow. The scorecard still shows A1-A5 as FAIL.

## Scope

**In scope:**
- `docs/plugin-api-v1.md` — canonical policy document
- README "Plugin Development" section
- Scorecard updates for A1-A5

**Non-goals:**
- No runtime code changes
- No CLI behavior changes
- No unrelated doc cleanup

## Files changed

| File | Change |
|------|--------|
| `docs/plugin-api-v1.md` | New — full compatibility/deprecation policy with RFC 2119 language |
| `README.md` | Add Plugin Development section + doc table entry |
| `docs/PROGRAM_SCORECARD.md` | A1-A5 PASS, Architecture 6/8, overall 29/35 (83%) |

## Validation steps

- Full test suite passes (1875 passed, 3 skipped)
- Ruff lint clean
- Doc content verified against implemented behavior in plugin_api.py and plugin_loader.py

## Security impact

None. Documentation-only change. No PHI handling, no runtime behavior changes.

## Backward compatibility impact

None. Additive documentation.

## Rollback plan

Revert commit. No runtime changes to roll back.