### PR TITLE
[A6/A8] Architecture contract docs: plugin hooks v1.1 design + CI adapter split

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ Copy-paste templates for all CI platforms: [docs/ci-cd-integration.md](docs/ci-c
 | [docs/de-identification.md](docs/de-identification.md) | Safe Harbor vs Expert Determination; regulatory scope |
 | [docs/plugin-api-v1.md](docs/plugin-api-v1.md) | Plugin API v1 compatibility, deprecation policy, and authoring constraints |
 | [docs/plugin-developer-guide.md](docs/plugin-developer-guide.md) | Custom recognizer development guide |
+| [docs/plugin-hooks-v1_1-design.md](docs/plugin-hooks-v1_1-design.md) | Suppressor and output sink plugin hooks (v1.1 design) |
+| [docs/ci-adapter-contract.md](docs/ci-adapter-contract.md) | CI adapter split interface contract and rollout plan |
 | [docs/ignore-patterns.md](docs/ignore-patterns.md) | `.phi-scanignore` syntax, suppression comments |
 | [docs/ci-cd-integration.md](docs/ci-cd-integration.md) | CI/CD platform copy-paste templates |
 | [docs/troubleshooting.md](docs/troubleshooting.md) | Common issues, FAQ, debug tips |

--- a/docs/PROGRAM_SCORECARD.md
+++ b/docs/PROGRAM_SCORECARD.md
@@ -64,11 +64,11 @@ is declared production-ready for v1.0.
 | A3 | Plugin discovery via Python entry points implemented and tested | PASS | Entry-point discovery via `phi_scan.plugins` group, fail-safe validation, 30 tests at 100% coverage. Shipped in PR #124. |
 | A4 | `phi-scan plugins list` command implemented with metadata validation tests | PASS | Rich table + `--json` output, 19 tests at 100% coverage. Shipped in PR #125. |
 | A5 | Plugin API compatibility and deprecation policy documented | PASS | `docs/plugin-api-v1.md` covers version contract, compatibility surface, deprecation process (2-minor-release window), failure semantics, authoring constraints. |
-| A6 | Suppressor and output-sink plugin hooks designed (v1.1 shape documented, not implemented) | FAIL | Deferred to v1.1; design not yet written |
+| A6 | Suppressor and output-sink plugin hooks designed (v1.1 shape documented, not implemented) | PASS | `docs/plugin-hooks-v1_1-design.md` covers `BaseSuppressor`, `BaseOutputSink` draft interfaces, execution pipeline, PHI safety model, performance budget, config shape, and open questions. |
 | A7 | Parallel scan determinism validated across `workers=1` and `workers>1` | PASS | Parity tests in `tests/test_scanner.py` validate identical findings and ordering |
-| A8 | `ci_integration.py` adapter split planned with per-platform interface contract documented | FAIL | Planned in roadmap (8F-ext.2); not yet designed |
+| A8 | `ci_integration.py` adapter split planned with per-platform interface contract documented | PASS | `docs/ci-adapter-contract.md` covers target module layout, `BaseCIAdapter` interface, capability flags, shared transport/error model, test strategy, 3-phase rollout plan, and risk/rollback. |
 
-**Passing: 6 / 8**
+**Passing: 8 / 8**
 
 ---
 
@@ -94,9 +94,9 @@ is declared production-ready for v1.0.
 |----------|---------|-------|---|
 | Technical Maturity | 9 | 9 | 100% |
 | Security Posture | 11 | 11 | 100% |
-| Architecture Scalability | 6 | 8 | 75% |
+| Architecture Scalability | 8 | 8 | 100% |
 | Commercial Readiness | 3 | 7 | 43% |
-| **Total** | **29** | **35** | **83%** |
+| **Total** | **31** | **35** | **89%** |
 
 **Target:** 35 / 35 checks passing.
 
@@ -111,6 +111,7 @@ is declared production-ready for v1.0.
 | 2026-04-13 | 9/9 | 8/11 | 1/8 | 3/7 | S5/S7/S8 shipped: 50 adversarial SSRF tests (IPv4-mapped IPv6, unspecified, multicast, mixed-resolution, DNS rebind TOCTOU), full-surface threat model at `docs/threat-model.md`, notifier SSRF fix (unmap IPv4-mapped IPv6 + built-in-property checks). Security category now at 73%. |
 | 2026-04-14 | 9/9 | 11/11 | 1/8 | 3/7 | S9/S10/S11 shipped: pip-audit CI gate with policy-enforced `.pip-audit-ignore.toml`, release-time CycloneDX SBOM via `.github/scripts/sbom_generator.py`, keyless Sigstore signing of wheel+sdist. Baseline CVEs cleared via direct pin bumps (cryptography 46.0.7, pygments 2.20.0). Full supply-chain policy at `docs/supply-chain.md`. Security category at 100%; overall 69%. |
 | 2026-04-15 | 9/9 | 11/11 | 6/8 | 3/7 | A1–A5 shipped: Plugin API v1 core (`BaseRecognizer` ABC, `ScanContext`/`ScanFinding` dataclasses, `PLUGIN_API_VERSION`) in PR #124. `phi-scan plugins list` command with Rich table and `--json` output in PR #125. Plugin compatibility and deprecation policy at `docs/plugin-api-v1.md`. Architecture category at 75%; overall 83%. |
+| 2026-04-16 | 9/9 | 11/11 | 8/8 | 3/7 | A6/A8 shipped: `docs/plugin-hooks-v1_1-design.md` (suppressor + output sink v1.1 design) and `docs/ci-adapter-contract.md` (CI adapter split with `BaseCIAdapter` interface, 3-phase rollout). Architecture category at 100%; overall 89%. |
 
 ---
 
@@ -125,6 +126,6 @@ Checks are addressed in this sequence:
 3. **S5, S7, S8** ✓ Done — SSRF adversarial tests + threat model doc
 4. **S9, S10, S11** ✓ Done — Supply-chain security gates (pip-audit CI gate, CycloneDX SBOM, Sigstore signing)
 5. **A1–A5** ✓ Done — Plugin API v1 core (PR #124), `plugins list` command (PR #125), compatibility/deprecation policy doc
-6. **A6** — Suppressor + output-sink design doc (v1.1 shape)
-7. **A8** — CI adapter split design doc
+6. **A6** ✓ Done — Suppressor + output-sink v1.1 design doc (`docs/plugin-hooks-v1_1-design.md`)
+7. **A8** ✓ Done — CI adapter split design doc (`docs/ci-adapter-contract.md`)
 8. **C3–C6** — Boundary docs, release policy, governance

--- a/docs/ci-adapter-contract.md
+++ b/docs/ci-adapter-contract.md
@@ -1,0 +1,269 @@
+# CI Adapter Split — Interface Contract and Rollout Plan
+
+Status: **DRAFT** — design document for discussion. No implementation yet.
+
+This document describes the planned decomposition of
+`phi_scan/ci_integration.py` (1,960 lines, 7 CI platforms) into a
+per-platform adapter package with a shared interface contract.
+
+---
+
+## Problem Statement
+
+`ci_integration.py` is the largest module in the codebase. It handles:
+
+1. Platform auto-detection from environment variables.
+2. PR/MR context extraction (7 platform-specific builders).
+3. PR comment posting (7 platform-specific HTTP calls).
+4. Commit status reporting (7 platform-specific HTTP calls).
+5. Platform-specific extras: GitHub SARIF upload, Azure build tags,
+   Azure PR status, Azure Boards work items, Bitbucket Code Insights,
+   AWS Security Hub ASFF import.
+
+All 7 platforms share the same outbound interface (`post_pr_comment`,
+`set_commit_status`) but diverge significantly in transport, auth, and
+API shape. The single-module design causes:
+
+- **Merge conflicts**: any CI platform change touches the same file.
+- **Test isolation**: platform-specific test fixtures crowd a single
+  test module (currently `tests/test_ci_integration.py` +
+  `tests/test_ci_integration_remaining.py`).
+- **Cognitive load**: contributors modifying GitHub support must read
+  past Azure, Bitbucket, and CodeBuild code.
+
+---
+
+## Target Module Layout
+
+```
+phi_scan/
+  ci/
+    __init__.py           # re-exports detect_platform, get_pr_context,
+                          #   post_pr_comment, set_commit_status
+    _base.py              # BaseCIAdapter ABC, PRContext, CIIntegrationError
+    _transport.py         # shared _HttpRequestConfig, _execute_http_request
+    _detect.py            # detect_platform(), CIPlatform enum
+    github.py             # GitHubAdapter
+    gitlab.py             # GitLabAdapter
+    azure.py              # AzureAdapter
+    circleci.py           # CircleCIAdapter
+    bitbucket.py          # BitbucketAdapter
+    codebuild.py          # CodeBuildAdapter
+    jenkins.py            # JenkinsAdapter
+
+tests/
+  ci/
+    __init__.py
+    test_github.py
+    test_gitlab.py
+    test_azure.py
+    test_circleci.py
+    test_bitbucket.py
+    test_codebuild.py
+    test_jenkins.py
+    test_detect.py
+    test_transport.py
+```
+
+The top-level `phi_scan/ci/__init__.py` re-exports the public API so
+existing callers (`from phi_scan.ci_integration import post_pr_comment`)
+can migrate with a single import-path change. The old
+`ci_integration.py` module will be retained as a thin re-export shim
+during the deprecation window (see Phase 1 below).
+
+---
+
+## Adapter Interface
+
+```python
+from abc import ABC, abstractmethod
+from phi_scan.models import ScanResult
+
+class BaseCIAdapter(ABC):
+    """Per-platform CI adapter.
+
+    Each adapter encapsulates the platform-specific logic for posting
+    PR comments, setting commit statuses, and any platform-specific
+    extras (SARIF upload, build tags, etc.).
+    """
+
+    @abstractmethod
+    def post_pr_comment(
+        self, comment_body: str, pr_context: PRContext,
+    ) -> None:
+        """Post a comment on the PR/MR associated with this build.
+
+        Raises:
+            CIIntegrationError: On any HTTP or auth failure.
+        """
+
+    @abstractmethod
+    def set_commit_status(
+        self, scan_result: ScanResult, pr_context: PRContext,
+    ) -> None:
+        """Report pass/fail status on the commit that triggered the build.
+
+        Raises:
+            CIIntegrationError: On any HTTP or auth failure.
+        """
+
+    @property
+    def supports_sarif_upload(self) -> bool:
+        """Whether this platform supports native SARIF ingestion."""
+        return False
+
+    @property
+    def supports_code_insights(self) -> bool:
+        """Whether this platform supports inline code annotations."""
+        return False
+
+    @property
+    def supports_work_item_creation(self) -> bool:
+        """Whether this platform supports creating work items from findings."""
+        return False
+```
+
+### Capability Flags
+
+Platform-specific extras are exposed via boolean capability properties
+rather than optional methods. This avoids `hasattr` checks and makes
+the adapter's capabilities inspectable:
+
+| Capability | GitHub | GitLab | Azure | CircleCI | Bitbucket | CodeBuild | Jenkins |
+|-----------|--------|--------|-------|----------|-----------|-----------|---------|
+| `post_pr_comment` | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `set_commit_status` | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `supports_sarif_upload` | Yes | No | No | No | No | No | No |
+| `supports_code_insights` | No | No | No | No | Yes | No | No |
+| `supports_work_item_creation` | No | No | Yes | No | No | No | No |
+| `supports_security_hub` | No | No | No | No | No | Yes | No |
+
+Platforms that support an extra MUST implement the corresponding method
+(e.g. `upload_sarif()` on `GitHubAdapter`). The base class provides a
+default that raises `NotImplementedError` for each extra.
+
+---
+
+## Shared Transport
+
+The `_transport.py` module extracts the existing `_HttpRequestConfig`
+dataclass and `_execute_http_request` function. All adapters use this
+shared transport layer:
+
+- Consistent error wrapping: HTTP failures always raise
+  `CIIntegrationError` with status code and reason phrase only (never
+  response body — see security audit in current `ci_integration.py`).
+- Consistent timeout handling: configurable per-request timeout with a
+  sensible default.
+- Consistent proxy support: `HTTPS_PROXY` / `HTTP_PROXY` environment
+  variables respected.
+
+---
+
+## Error Model
+
+All adapter methods raise `CIIntegrationError` on failure. The error
+message MUST include:
+
+- The platform name.
+- The HTTP status code and reason phrase (for HTTP failures).
+- The operation that failed (e.g. "post PR comment", "set commit
+  status").
+
+The error message MUST NOT include:
+
+- The HTTP response body (may echo back request content containing
+  finding metadata).
+- Authentication tokens or credentials.
+- Raw PHI values.
+
+This matches the existing security contract in `ci_integration.py` and
+is enforced by sentinel tests.
+
+---
+
+## Test Strategy
+
+Each adapter module gets a dedicated test file. Tests follow the
+existing pattern:
+
+1. **Monkeypatch environment variables** for the platform under test.
+2. **Mock `_execute_http_request`** to avoid real HTTP calls.
+3. **Assert outbound request shape**: URL, headers, body structure.
+4. **Assert error wrapping**: HTTP failures produce
+   `CIIntegrationError` with safe messages.
+5. **Sentinel tests**: error messages never contain response body text.
+
+Shared transport tests go in `test_transport.py`. Platform detection
+tests go in `test_detect.py`.
+
+### Coverage Target
+
+Each adapter module MUST maintain >= 90% line coverage. The shared
+transport module MUST maintain 100% coverage (it is security-critical).
+
+---
+
+## Rollout Plan
+
+### Phase 1 — Extract and Shim (non-breaking)
+
+1. Create `phi_scan/ci/` package with `_base.py`, `_transport.py`,
+   `_detect.py`.
+2. Move platform detection logic to `_detect.py`.
+3. Move shared HTTP logic to `_transport.py`.
+4. Keep `ci_integration.py` as a thin re-export shim:
+   ```python
+   # phi_scan/ci_integration.py — deprecated, will be removed in v1.3
+   from phi_scan.ci import *  # noqa: F401,F403
+   ```
+5. Emit `DeprecationWarning` on import of the old module path.
+
+**Verification**: all existing tests pass without modification.
+
+### Phase 2 — Per-Platform Adapters
+
+1. Extract each platform's functions into its adapter class
+   (`github.py`, `gitlab.py`, etc.).
+2. Implement `BaseCIAdapter` interface on each adapter.
+3. Update `phi_scan/ci/__init__.py` to dispatch `post_pr_comment` and
+   `set_commit_status` via the adapter registry.
+4. Split test files into per-platform modules.
+
+**Verification**: full test suite passes, no behavior changes, coverage
+>= 90% per adapter.
+
+### Phase 3 — Remove Shim
+
+1. Remove `ci_integration.py` after the 2-minor-release deprecation
+   window (per `docs/plugin-api-v1.md` deprecation policy).
+2. Update all internal imports to `phi_scan.ci`.
+3. Document the migration in release notes.
+
+**Verification**: `ruff check` confirms no remaining imports of the
+old module path.
+
+---
+
+## Risk and Rollback
+
+| Risk | Mitigation |
+|------|-----------|
+| Import path breakage for downstream consumers | Phase 1 shim preserves the old import path with a deprecation warning. 2-minor-release window before removal. |
+| Behavior regression in platform-specific logic | Each adapter is extracted as a mechanical refactor with no logic changes. Existing tests are moved (not rewritten) in Phase 2. |
+| Test coverage regression | Per-adapter 90% coverage gate prevents merging undertested adapters. |
+| Merge conflicts during phased rollout | Phase 1 (non-breaking) ships first. Phase 2 can be done one platform at a time as independent PRs. |
+
+### Rollback
+
+If Phase 2 introduces regressions, revert the per-platform extraction
+PRs and fall back to Phase 1 (shim + monolith). The shim ensures
+callers are unaffected.
+
+---
+
+## Version History
+
+| Document version | Date | Change |
+|-----------------|------|--------|
+| Draft 1 | 2026-04-16 | Initial design for A8 scorecard check |

--- a/docs/ci-adapter-contract.md
+++ b/docs/ci-adapter-contract.md
@@ -140,7 +140,9 @@ the adapter's capabilities inspectable:
 
 Platforms that support an extra MUST implement the corresponding method
 (e.g. `upload_sarif()` on `GitHubAdapter`). The base class provides a
-default that raises `NotImplementedError` for each extra.
+default that raises `CIIntegrationError` (the domain exception) for
+each extra — not `NotImplementedError`, which is a built-in and does
+not conform to the project's custom-exception-for-domain-errors rule.
 
 ---
 
@@ -212,10 +214,19 @@ transport module MUST maintain 100% coverage (it is security-critical).
    `_detect.py`.
 2. Move platform detection logic to `_detect.py`.
 3. Move shared HTTP logic to `_transport.py`.
-4. Keep `ci_integration.py` as a thin re-export shim:
+4. Keep `ci_integration.py` as a thin re-export shim with explicit
+   named imports (no wildcard `import *`):
    ```python
    # phi_scan/ci_integration.py — deprecated, will be removed in v1.3
-   from phi_scan.ci import *  # noqa: F401,F403
+   from phi_scan.ci import (  # noqa: F401
+       CIIntegrationError,
+       CIPlatform,
+       PRContext,
+       detect_platform,
+       get_pr_context,
+       post_pr_comment,
+       set_commit_status,
+   )
    ```
 5. Emit `DeprecationWarning` on import of the old module path.
 

--- a/docs/plugin-hooks-v1_1-design.md
+++ b/docs/plugin-hooks-v1_1-design.md
@@ -1,0 +1,332 @@
+# Plugin Hooks v1.1 — Suppressor and Output Sink Design
+
+Status: **DRAFT** — design document for discussion. No implementation yet.
+
+This document describes two new plugin extension points planned for
+Plugin API v1.1: **suppressors** (filter findings before output) and
+**output sinks** (consume finalized findings for external delivery).
+Neither hook exists in v1.0. Both are additive — existing v1.0
+recognizer plugins will continue to work unchanged.
+
+The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY in this
+document are to be interpreted as described in
+[RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+---
+
+## Motivation
+
+PhiScan v1.0 ships three built-in escape hatches for false positives:
+
+1. `# phi-scan:ignore` inline comments.
+2. `.phi-scanignore` file-level exclusions.
+3. Baseline mode (`--baseline`).
+
+These cover the common cases, but teams with domain-specific suppression
+logic (e.g. "findings inside `test_fixtures/` with confidence below 0.6
+are always false positives") cannot express that today without forking
+the scanner. Similarly, teams that need to push findings to a
+ticketing system, SIEM, or dashboard must parse the output formats
+themselves.
+
+Suppressors and output sinks solve these two problems as first-class
+plugin hooks.
+
+---
+
+## Execution Pipeline
+
+The current v1.0 pipeline and the proposed v1.1 additions:
+
+```
+  Files
+    │
+    ▼
+  ┌──────────────────────┐
+  │  Recognizer plugins   │  ← v1.0 (BaseRecognizer.detect)
+  │  + built-in layers    │
+  └──────────┬───────────┘
+             │ raw findings
+             ▼
+  ┌──────────────────────┐
+  │  Suppressor plugins   │  ← v1.1 NEW
+  │  (BaseSuppressor)     │
+  └──────────┬───────────┘
+             │ filtered findings
+             ▼
+  ┌──────────────────────┐
+  │  Severity / scoring   │  (host-internal)
+  └──────────┬───────────┘
+             │ scored findings
+             ▼
+  ┌──────────────────────┐
+  │  Built-in formatters  │  (JSON, SARIF, CSV, …)
+  │  + Output sink plugins│  ← v1.1 NEW
+  │  (BaseOutputSink)     │
+  └──────────────────────┘
+```
+
+### Ordering Guarantees
+
+1. **Recognizers** run first. All built-in detection layers and all
+   loaded `BaseRecognizer` plugins execute before any suppressor is
+   consulted.
+2. **Suppressors** run in deterministic order: sorted by
+   `(distribution_name, entry_point_name)`, same as recognizers. Each
+   suppressor sees the output of the previous one (pipeline, not
+   fan-out). A finding removed by an earlier suppressor is not visible
+   to later suppressors.
+3. **Output sinks** run after severity scoring and built-in formatting.
+   Sinks receive the final, immutable finding list. Sink execution order
+   is deterministic (same sort key) but sinks MUST NOT depend on
+   execution order — they receive the same input and MUST NOT mutate it.
+
+---
+
+## `BaseSuppressor` — Draft Interface
+
+```python
+from phi_scan.plugin_api import ScanContext, ScanFinding
+
+class SuppressDecision:
+    """Returned by a suppressor for each finding."""
+    # True  → suppress (drop the finding from results)
+    # False → keep (finding passes through unchanged)
+    is_suppressed: bool
+    reason: str  # human-readable, logged at DEBUG level
+
+class BaseSuppressor(ABC):
+    """Abstract base class for suppressor plugins."""
+
+    name: str                          # same naming rules as BaseRecognizer
+    plugin_api_version: str = PLUGIN_API_VERSION
+    version: str = "0.0.0"
+    description: str = ""
+
+    @abstractmethod
+    def evaluate(
+        self, finding: ScanFinding, context: ScanContext, line: str,
+    ) -> SuppressDecision:
+        """Decide whether to suppress a single finding.
+
+        Args:
+            finding: The candidate finding to evaluate.
+            context: Same ScanContext the recognizer received.
+            line: The full text of the line (without trailing newline).
+
+        Returns:
+            A SuppressDecision indicating whether to suppress.
+        """
+```
+
+### Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Per-finding evaluation (not batch) | Keeps the interface simple and stateless. Batch filtering can be layered on top via internal buffering in a future API version if profiling shows a need. |
+| `SuppressDecision` dataclass (not bare `bool`) | Captures the reason for audit-trail logging. A suppressed finding with no reason is hard to debug in compliance reviews. |
+| Receives `line` text | Suppressors MAY need linguistic context (e.g. "this line is a comment in language X"). Passing the line avoids suppressors reading the file directly, preserving the no-file-access contract. |
+| No access to other findings | Suppressors see one finding at a time. Cross-finding correlation (e.g. "suppress if another finding on the same line has higher confidence") is intentionally out of scope for v1.1. |
+
+### Prohibited Actions
+
+Suppressor plugins inherit all prohibitions from `BaseRecognizer`
+plugins (see `docs/plugin-api-v1.md`):
+
+- MUST NOT open, read, or stat files at `context.file_path`.
+- MUST NOT include raw PHI values in `SuppressDecision.reason` or log
+  output.
+- MUST NOT send data to any remote service.
+
+### Constructor
+
+Same as recognizers: `SuppressorClass()` with **no arguments**.
+
+---
+
+## `BaseOutputSink` — Draft Interface
+
+```python
+from pathlib import Path
+from phi_scan.plugin_api import ScanFinding, ScanContext
+
+@dataclass(frozen=True)
+class FinalizedFinding:
+    """A scored, post-suppression finding delivered to output sinks."""
+    finding: ScanFinding
+    context: ScanContext
+    severity: str          # "info" | "low" | "medium" | "high"
+    value_hash: str        # SHA-256 hex digest — never raw PHI
+
+class BaseOutputSink(ABC):
+    """Abstract base class for output sink plugins."""
+
+    name: str
+    plugin_api_version: str = PLUGIN_API_VERSION
+    version: str = "0.0.0"
+    description: str = ""
+
+    @abstractmethod
+    def deliver(
+        self,
+        findings: Sequence[FinalizedFinding],
+        scan_root: Path,
+    ) -> None:
+        """Deliver the finalized finding set to an external destination.
+
+        Args:
+            findings: Immutable sequence of all findings that survived
+                suppression and met the confidence/severity thresholds.
+                Plugins MUST NOT mutate this sequence.
+            scan_root: The root directory that was scanned. Plugins MAY
+                use this to compute relative paths for display.
+
+        Raises:
+            Any exception raised is caught by the host and logged at
+            WARNING level. A failing sink does not affect other sinks
+            or the scan exit code.
+        """
+```
+
+### Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| `FinalizedFinding` wrapper | Exposes severity and value_hash (both host-computed) without leaking internal `Finding` model fields. Plugins never see raw PHI — only the hash. |
+| `deliver()` receives full batch | Output sinks typically need the complete finding set (to POST a summary, write a file, update a dashboard). Per-finding delivery would force plugins to buffer internally. |
+| `scan_root` argument | Sinks that generate reports need to compute relative paths. Passing the root avoids sinks guessing or reading config. |
+| Failure isolation | A broken sink MUST NOT block the scan or suppress built-in output. The host catches `Exception` (not `BaseException`) and logs a WARNING. |
+
+### PHI Safety
+
+Output sinks receive `FinalizedFinding` objects that contain:
+
+- `value_hash` (SHA-256 hex) — **never** raw PHI.
+- `context.file_path` — the file path, which is metadata, not PHI.
+- `finding.start_offset` / `finding.end_offset` — column offsets only.
+- `severity` — a classification label.
+
+Sinks MUST NOT attempt to reconstruct the original PHI value from the
+hash or from the file path + offsets. The host does not pass the line
+text to sinks — this is a deliberate omission to prevent accidental PHI
+exfiltration by a sink that forwards findings to a remote service.
+
+### Remote Communication
+
+Unlike recognizers and suppressors, output sinks MAY communicate with
+remote services (that is their purpose). However:
+
+- Sinks MUST NOT include raw PHI in any outbound payload. The
+  `FinalizedFinding` contract enforces this by design: no line text,
+  no raw values.
+- Sinks SHOULD document which remote service they communicate with and
+  what data they send.
+- Sinks SHOULD respect `HTTPS_PROXY` / `HTTP_PROXY` environment
+  variables.
+
+---
+
+## Entry-Point Groups
+
+| Hook type | Entry-point group | API version |
+|-----------|-------------------|-------------|
+| Recognizer | `phi_scan.plugins` | `1.0` (current) |
+| Suppressor | `phi_scan.suppressors` | `1.1` (planned) |
+| Output sink | `phi_scan.output_sinks` | `1.1` (planned) |
+
+Each hook type uses a separate entry-point group to avoid ambiguity in
+the loader. A single distribution MAY register plugins in all three
+groups.
+
+---
+
+## Performance Budget
+
+| Hook | Budget per invocation | Rationale |
+|------|----------------------|-----------|
+| `BaseSuppressor.evaluate()` | < 1 ms per finding | Called once per finding per suppressor. At 10,000 findings × 3 suppressors = 30,000 calls. Budget prevents suppressors from dominating scan time. |
+| `BaseOutputSink.deliver()` | < 30 s total | Called once per scan with the full batch. Network I/O is expected; 30 s accommodates slow endpoints without blocking the CLI indefinitely. |
+
+The host MAY enforce these budgets via timeouts in a future release.
+v1.1 will document the budgets as SHOULD-level guidance; enforcement
+is deferred to v1.2 pending real-world profiling data.
+
+---
+
+## Configuration Shape
+
+Suppressors and output sinks will be configurable in `.phi-scanner.yml`:
+
+```yaml
+version: 1
+
+plugins:
+  suppressors:
+    enabled: true                   # default: true
+    # Per-suppressor overrides:
+    # my_custom_suppressor:
+    #   enabled: false
+
+  output_sinks:
+    enabled: true                   # default: true
+    # Per-sink overrides:
+    # jira_sink:
+    #   enabled: false
+```
+
+The `plugins` key is new in v1.1. Unrecognized keys under `plugins`
+are ignored with a WARNING (forward-compatibility).
+
+---
+
+## Discovery and Validation
+
+Suppressor and output sink discovery follows the same pattern as
+recognizer discovery:
+
+1. Enumerate entry points in the relevant group.
+2. Sort deterministically by `(distribution_name, entry_point_name)`.
+3. Validate class attributes (name, plugin_api_version, entity_types
+   where applicable).
+4. Instantiate with no arguments.
+5. Skip with WARNING on any validation or instantiation failure.
+
+The `PluginRegistry` dataclass will be extended with `suppressors` and
+`output_sinks` tuples. The `phi-scan plugins list` command will display
+all three hook types.
+
+---
+
+## Migration and Compatibility
+
+- v1.1 is a **pure addition** to v1.0. No existing recognizer plugins
+  need changes.
+- `PLUGIN_API_VERSION` remains `"1.0"` for recognizer plugins. A new
+  constant `SUPPRESSOR_API_VERSION = "1.1"` and
+  `OUTPUT_SINK_API_VERSION = "1.1"` will be introduced for the new
+  hook types.
+- The `docs/plugin-api-v1.md` compatibility surface (4 stable exports +
+  entry-point group) is unaffected. New exports for v1.1 will be
+  documented in a separate `docs/plugin-api-v1_1.md` addendum.
+- The 2-minor-release deprecation policy from `docs/plugin-api-v1.md`
+  applies to all v1.1 additions once they ship.
+
+---
+
+## Open Questions
+
+| # | Question | Leaning | Status |
+|---|----------|---------|--------|
+| 1 | Should suppressors receive the full `Finding` (internal model) or only `ScanFinding` (plugin API model)? | `ScanFinding` — keeps the plugin surface minimal and avoids coupling to internal fields. | Tentative |
+| 2 | Should output sinks receive line text for context-rich reporting? | No — PHI safety outweighs convenience. Sinks that need context can read the file themselves (they already have `file_path` + offsets). | Tentative |
+| 3 | Should suppressor ordering be configurable? | Deferred to v1.2. Deterministic sort is sufficient for v1.1. | Deferred |
+| 4 | Should the host enforce performance budgets via hard timeouts? | Deferred to v1.2 pending profiling data. v1.1 documents budgets as guidance. | Deferred |
+| 5 | Should `FinalizedFinding` include the recognizer name that produced it? | Likely yes — useful for sink-side filtering ("only send NLP findings to SIEM"). Needs API surface review. | Open |
+
+---
+
+## Version History
+
+| Document version | Date | Change |
+|-----------------|------|--------|
+| Draft 1 | 2026-04-16 | Initial design for A6 scorecard check |

--- a/docs/plugin-hooks-v1_1-design.md
+++ b/docs/plugin-hooks-v1_1-design.md
@@ -88,6 +88,7 @@ The current v1.0 pipeline and the proposed v1.1 additions:
 ```python
 from phi_scan.plugin_api import ScanContext, ScanFinding
 
+@dataclass(frozen=True)
 class SuppressDecision:
     """Returned by a suppressor for each finding."""
     # True  → suppress (drop the finding from results)
@@ -127,6 +128,7 @@ class BaseSuppressor(ABC):
 | `SuppressDecision` dataclass (not bare `bool`) | Captures the reason for audit-trail logging. A suppressed finding with no reason is hard to debug in compliance reviews. |
 | Receives `line` text | Suppressors MAY need linguistic context (e.g. "this line is a comment in language X"). Passing the line avoids suppressors reading the file directly, preserving the no-file-access contract. |
 | No access to other findings | Suppressors see one finding at a time. Cross-finding correlation (e.g. "suppress if another finding on the same line has higher confidence") is intentionally out of scope for v1.1. |
+| 3-argument limit on `evaluate()` | `evaluate(finding, context, line)` is at the maximum of 3 non-self arguments per project code standards. Any future expansion MUST use a `@dataclass` parameter object rather than adding a fourth argument. |
 
 ### Prohibited Actions
 
@@ -155,7 +157,7 @@ class FinalizedFinding:
     """A scored, post-suppression finding delivered to output sinks."""
     finding: ScanFinding
     context: ScanContext
-    severity: str          # "info" | "low" | "medium" | "high"
+    severity: SeverityLevel  # Enum: INFO, LOW, MEDIUM, HIGH
     value_hash: str        # SHA-256 hex digest — never raw PHI
 
 class BaseOutputSink(ABC):
@@ -204,12 +206,15 @@ Output sinks receive `FinalizedFinding` objects that contain:
 - `value_hash` (SHA-256 hex) — **never** raw PHI.
 - `context.file_path` — the file path, which is metadata, not PHI.
 - `finding.start_offset` / `finding.end_offset` — column offsets only.
-- `severity` — a classification label.
+- `severity` — a `SeverityLevel` enum member.
 
 Sinks MUST NOT attempt to reconstruct the original PHI value from the
-hash or from the file path + offsets. The host does not pass the line
-text to sinks — this is a deliberate omission to prevent accidental PHI
-exfiltration by a sink that forwards findings to a remote service.
+hash or from the file path + offsets. Sinks MUST NOT open, read, or
+stat files at `context.file_path` — doing so would bypass the PHI
+safety boundary that the `FinalizedFinding` contract is designed to
+enforce. The host does not pass the line text to sinks — this is a
+deliberate omission to prevent accidental PHI exfiltration by a sink
+that forwards findings to a remote service.
 
 ### Remote Communication
 
@@ -318,7 +323,7 @@ all three hook types.
 | # | Question | Leaning | Status |
 |---|----------|---------|--------|
 | 1 | Should suppressors receive the full `Finding` (internal model) or only `ScanFinding` (plugin API model)? | `ScanFinding` — keeps the plugin surface minimal and avoids coupling to internal fields. | Tentative |
-| 2 | Should output sinks receive line text for context-rich reporting? | No — PHI safety outweighs convenience. Sinks that need context can read the file themselves (they already have `file_path` + offsets). | Tentative |
+| 2 | Should output sinks receive line text for context-rich reporting? | No — PHI safety outweighs convenience. Sinks MUST NOT read file content to reconstruct PHI from `file_path` + offsets; the no-line-text contract exists precisely to prevent this exfiltration path. Sinks that need richer context should request a host-redacted snippet in a future API version. | Tentative |
 | 3 | Should suppressor ordering be configurable? | Deferred to v1.2. Deterministic sort is sufficient for v1.1. | Deferred |
 | 4 | Should the host enforce performance budgets via hard timeouts? | Deferred to v1.2 pending profiling data. v1.1 documents budgets as guidance. | Deferred |
 | 5 | Should `FinalizedFinding` include the recognizer name that produced it? | Likely yes — useful for sink-side filtering ("only send NLP findings to SIEM"). Needs API surface review. | Open |


### PR DESCRIPTION
## Summary

- Add `docs/plugin-hooks-v1_1-design.md` (A6): RFC-style design for `BaseSuppressor` and `BaseOutputSink` plugin hooks planned for v1.1. Covers draft interfaces, execution pipeline ordering, PHI safety model, performance budget, configuration shape, migration/compatibility, and open questions.
- Add `docs/ci-adapter-contract.md` (A8): Design for decomposing the 1,960-line `ci_integration.py` into per-platform adapter modules under `phi_scan/ci/`. Covers `BaseCIAdapter` interface with capability flags, shared transport/error model, per-platform test strategy, 3-phase rollout plan (extract+shim → per-platform adapters → remove shim), and risk/rollback.
- Update scorecard: A6 and A8 → PASS, Architecture Scalability at 100% (8/8), overall 31/35 (89%).
- Add doc links to README documentation table.

## Test plan

- [ ] Verify both docs render correctly on GitHub
- [ ] Verify scorecard totals are consistent (8/8 Architecture, 31/35 overall)
- [ ] Verify README doc table links resolve