### PR TITLE
[C5/C6] Release versioning policy and LTS/EOL policy — scorecard 35/35

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,8 @@ Copy-paste templates for all CI platforms: [docs/ci-cd-integration.md](docs/ci-c
 | [docs/plugin-hooks-v1_1-design.md](docs/plugin-hooks-v1_1-design.md) | Suppressor and output sink plugin hooks (v1.1 design) |
 | [docs/ci-adapter-contract.md](docs/ci-adapter-contract.md) | CI adapter split interface contract and rollout plan |
 | [docs/community-pro-cloud-matrix.md](docs/community-pro-cloud-matrix.md) | Community / Pro / Cloud feature boundary matrix |
+| [docs/release-versioning-policy.md](docs/release-versioning-policy.md) | Release cadence, versioning scheme, and deprecation process |
+| [docs/lts-eol-policy.md](docs/lts-eol-policy.md) | Long-term support and end-of-life policy |
 | [docs/ignore-patterns.md](docs/ignore-patterns.md) | `.phi-scanignore` syntax, suppression comments |
 | [docs/ci-cd-integration.md](docs/ci-cd-integration.md) | CI/CD platform copy-paste templates |
 | [docs/troubleshooting.md](docs/troubleshooting.md) | Common issues, FAQ, debug tips |

--- a/docs/PROGRAM_SCORECARD.md
+++ b/docs/PROGRAM_SCORECARD.md
@@ -80,11 +80,11 @@ is declared production-ready for v1.0.
 | C2 | `SECURITY.md` exists with vulnerability reporting policy | PASS | Present in repo |
 | C3 | Community / Pro / Cloud feature boundary matrix published in docs | PASS | `docs/community-pro-cloud-matrix.md` covers 8 feature categories across Community/Pro/Cloud tiers with guiding principles and "what stays free forever" guarantees. |
 | C4 | "What stays free forever" messaging is explicit in `README.md` | PASS | "Free forever" bullet in Why PhiScan section with link to full boundary matrix. Explicit guarantee that Community capabilities will never be paywalled or degraded. |
-| C5 | Release cadence and versioning policy documented | FAIL | Not yet documented |
-| C6 | Long-term support (LTS) and end-of-life policy documented | FAIL | Not yet documented |
+| C5 | Release cadence and versioning policy documented | PASS | `docs/release-versioning-policy.md` covers semver scheme, patch/minor/major cadence, breaking-change definition, release process, and deprecation cross-reference. |
+| C6 | Long-term support (LTS) and end-of-life policy documented | PASS | `docs/lts-eol-policy.md` covers 12-month LTS window, security backport SLA, EOL process with 90-day notice, LTS overlap, and Python version support policy. |
 | C7 | `docs/PROGRAM_SCORECARD.md` linked from `README.md` | PASS | Added in same PR as scorecard |
 
-**Passing: 5 / 7**
+**Passing: 7 / 7**
 
 ---
 
@@ -95,8 +95,8 @@ is declared production-ready for v1.0.
 | Technical Maturity | 9 | 9 | 100% |
 | Security Posture | 11 | 11 | 100% |
 | Architecture Scalability | 8 | 8 | 100% |
-| Commercial Readiness | 5 | 7 | 71% |
-| **Total** | **33** | **35** | **94%** |
+| Commercial Readiness | 7 | 7 | 100% |
+| **Total** | **35** | **35** | **100%** |
 
 **Target:** 35 / 35 checks passing.
 
@@ -111,7 +111,7 @@ is declared production-ready for v1.0.
 | 2026-04-13 | 9/9 | 8/11 | 1/8 | 3/7 | S5/S7/S8 shipped: 50 adversarial SSRF tests (IPv4-mapped IPv6, unspecified, multicast, mixed-resolution, DNS rebind TOCTOU), full-surface threat model at `docs/threat-model.md`, notifier SSRF fix (unmap IPv4-mapped IPv6 + built-in-property checks). Security category now at 73%. |
 | 2026-04-14 | 9/9 | 11/11 | 1/8 | 3/7 | S9/S10/S11 shipped: pip-audit CI gate with policy-enforced `.pip-audit-ignore.toml`, release-time CycloneDX SBOM via `.github/scripts/sbom_generator.py`, keyless Sigstore signing of wheel+sdist. Baseline CVEs cleared via direct pin bumps (cryptography 46.0.7, pygments 2.20.0). Full supply-chain policy at `docs/supply-chain.md`. Security category at 100%; overall 69%. |
 | 2026-04-15 | 9/9 | 11/11 | 6/8 | 3/7 | A1–A5 shipped: Plugin API v1 core (`BaseRecognizer` ABC, `ScanContext`/`ScanFinding` dataclasses, `PLUGIN_API_VERSION`) in PR #124. `phi-scan plugins list` command with Rich table and `--json` output in PR #125. Plugin compatibility and deprecation policy at `docs/plugin-api-v1.md`. Architecture category at 75%; overall 83%. |
-| 2026-04-16 | 9/9 | 11/11 | 8/8 | 5/7 | A6/A8 shipped: `docs/plugin-hooks-v1_1-design.md` (suppressor + output sink v1.1 design) and `docs/ci-adapter-contract.md` (CI adapter split with `BaseCIAdapter` interface, 3-phase rollout). C3/C4 shipped: `docs/community-pro-cloud-matrix.md` (feature boundary matrix across 8 categories) and "Free forever" messaging in README. Architecture at 100%, Commercial at 71%; overall 94%. |
+| 2026-04-16 | 9/9 | 11/11 | 8/8 | 7/7 | A6/A8 shipped: `docs/plugin-hooks-v1_1-design.md` (suppressor + output sink v1.1 design) and `docs/ci-adapter-contract.md` (CI adapter split with `BaseCIAdapter` interface, 3-phase rollout). C3/C4 shipped: `docs/community-pro-cloud-matrix.md` (feature boundary matrix across 8 categories) and "Free forever" messaging in README. C5/C6 shipped: `docs/release-versioning-policy.md` (semver, cadence, breaking-change rules) and `docs/lts-eol-policy.md` (12-month LTS, 90-day EOL notice). **All 35/35 checks passing — scorecard complete.** |
 
 ---
 
@@ -129,4 +129,4 @@ Checks are addressed in this sequence:
 6. **A6** ✓ Done — Suppressor + output-sink v1.1 design doc (`docs/plugin-hooks-v1_1-design.md`)
 7. **A8** ✓ Done — CI adapter split design doc (`docs/ci-adapter-contract.md`)
 8. **C3, C4** ✓ Done — Feature boundary matrix (`docs/community-pro-cloud-matrix.md`), "Free forever" README messaging
-9. **C5, C6** — Release cadence/versioning policy, LTS/EOL policy
+9. **C5, C6** ✓ Done — Release cadence/versioning policy (`docs/release-versioning-policy.md`), LTS/EOL policy (`docs/lts-eol-policy.md`)

--- a/docs/lts-eol-policy.md
+++ b/docs/lts-eol-policy.md
@@ -1,0 +1,153 @@
+# Long-Term Support (LTS) and End-of-Life (EOL) Policy
+
+This document defines which PhiScan releases receive long-term
+security support, how long that support lasts, and how end-of-life
+transitions are communicated.
+
+**Last updated:** 2026-04-16
+
+---
+
+## LTS Designation
+
+Not every minor release is an LTS release. The maintainers designate
+specific minor releases as LTS based on stability, feature
+completeness, and community adoption.
+
+| Property | LTS release | Standard release |
+|----------|------------|-----------------|
+| Security patches | 12 months from release date | Until the next minor release |
+| Critical bug fixes | 12 months from release date | Until the next minor release |
+| New features | No | Yes |
+| Recommended for production | Yes | Yes (but LTS preferred for regulated environments) |
+
+### LTS Selection Criteria
+
+A minor release is designated as LTS when:
+
+1. It has been stable for at least 30 days after the final release
+   (no critical regressions reported).
+2. All scorecard checks are passing at the time of designation.
+3. The maintainers judge it suitable for long-term production use in
+   regulated (HIPAA, HITRUST) environments.
+
+LTS designation is announced in the GitHub Release notes and in
+`CHANGELOG.md`. The announcement includes the support end date.
+
+### LTS Support Scope
+
+During the 12-month LTS window, the designated release line receives:
+
+- **Security patches**: vulnerabilities in PhiScan code or direct
+  dependencies, rated HIGH or CRITICAL, are backported within 7 days
+  of confirmation. MEDIUM and LOW vulnerabilities are backported on a
+  best-effort basis.
+- **Critical bug fixes**: bugs that cause data loss, incorrect scan
+  results (false negatives on known PHI patterns), or crashes on
+  supported platforms are backported.
+- **Dependency updates**: only security-driven dependency bumps are
+  backported. Feature-driven dependency updates are not backported.
+
+LTS releases do NOT receive:
+
+- New features or detection categories.
+- Performance improvements (unless they fix a critical regression).
+- Support for new CI/CD platforms.
+- Plugin API additions.
+
+---
+
+## Support Timeline
+
+```
+Release 1.2.0 (LTS)
+  │
+  ├─── Active support (0–12 months)
+  │      Security patches, critical bug fixes
+  │
+  ├─── EOL notice issued (at 9 months, 90 days before EOL)
+  │
+  └─── End of life (12 months)
+         No further patches; users must upgrade
+```
+
+### Overlap Between LTS Lines
+
+When a new LTS release is designated, the previous LTS release
+continues to receive support for the remainder of its 12-month window.
+There is no early termination of an LTS line when a newer LTS is
+designated.
+
+Example timeline:
+
+```
+v1.2.0 LTS ──────────────────────────────────── EOL
+              v1.4.0 LTS ─────────────────────────────── EOL
+                            v2.0.0 LTS ─────────────────────── EOL
+```
+
+---
+
+## End-of-Life (EOL) Process
+
+1. **EOL notice** (90 days before): the maintainers publish a notice
+   in the GitHub Release notes, `CHANGELOG.md`, and the project
+   README (if the release is the current recommended version). The
+   notice includes:
+   - The exact EOL date.
+   - The recommended upgrade target (typically the latest LTS).
+   - A summary of breaking changes between the EOL release and the
+     upgrade target.
+   - A link to any migration guide.
+
+2. **Final patch** (at or before EOL): a final patch release is
+   published for the EOL line that includes all pending security
+   backports. This is the last release on that line.
+
+3. **EOL date**: after the EOL date, the release line receives no
+   further patches, security or otherwise. The branch remains
+   available in git history but is not maintained.
+
+4. **PyPI availability**: EOL releases remain available on PyPI
+   indefinitely. They are not yanked unless a critical security
+   vulnerability with no workaround is discovered. Yanking is a last
+   resort and is announced with at least 14 days notice.
+
+---
+
+## Current LTS Releases
+
+| Release | LTS designated | Support ends | Status |
+|---------|---------------|-------------|--------|
+| *(none yet — first LTS will be designated after v1.0 stabilizes)* | — | — | — |
+
+This table will be updated as LTS releases are designated.
+
+---
+
+## Supported Python Versions
+
+Each PhiScan release declares its supported Python versions in
+`pyproject.toml` (`requires-python`). The current minimum is
+Python 3.12.
+
+Python version support follows this policy:
+
+- PhiScan supports all Python versions that are in active support
+  (receiving security updates) per the
+  [Python release schedule](https://devguide.python.org/versions/).
+- When a Python version reaches end of life, PhiScan drops support
+  in the next MINOR release. Dropping a Python version is a MINOR
+  change, not a MAJOR change, because it does not affect the
+  behavior of the tool for users on supported Python versions.
+- LTS releases maintain their declared Python version support for the
+  full 12-month LTS window, even if a Python version reaches EOL
+  during that window.
+
+---
+
+## Version History
+
+| Date | Change |
+|------|--------|
+| 2026-04-16 | Initial LTS and EOL policy for C6 scorecard check |

--- a/docs/release-versioning-policy.md
+++ b/docs/release-versioning-policy.md
@@ -1,0 +1,135 @@
+# Release Cadence and Versioning Policy
+
+This document defines how PhiScan versions are numbered, how often
+releases are published, and what stability guarantees each release
+type carries.
+
+**Last updated:** 2026-04-16
+
+---
+
+## Versioning Scheme
+
+PhiScan follows [Semantic Versioning 2.0.0](https://semver.org/):
+
+```
+MAJOR.MINOR.PATCH
+```
+
+| Component | Incremented when | Example |
+|-----------|-----------------|---------|
+| **MAJOR** | Incompatible changes to the public CLI interface, configuration schema, output format structure, or Plugin API stable surface | `1.0.0` → `2.0.0` |
+| **MINOR** | New features, new detection categories, new output formats, new CLI commands, or Plugin API additions that are backwards-compatible | `1.0.0` → `1.1.0` |
+| **PATCH** | Bug fixes, security patches, documentation corrections, dependency updates with no user-facing behavior change | `1.0.1` → `1.0.2` |
+
+### Pre-release and Build Metadata
+
+- Pre-release versions use the format `X.Y.Z-alpha.N` or `X.Y.Z-rc.N`.
+- Pre-release versions are published to PyPI with the appropriate
+  PEP 440 suffix (e.g. `1.1.0a1`, `1.1.0rc1`).
+- Pre-release versions carry no stability guarantees and SHOULD NOT be
+  used in production CI/CD pipelines.
+
+---
+
+## Release Cadence
+
+| Release type | Target cadence | Trigger |
+|-------------|---------------|---------|
+| **Patch** | As needed (typically monthly) | Security vulnerability, bug fix, or dependency update |
+| **Minor** | Target quarterly | Accumulated feature work, new detection categories, or Plugin API additions |
+| **Major** | As needed (no fixed cadence) | Breaking changes that cannot be delivered as backwards-compatible additions |
+
+### Cadence Commitments
+
+- **Security patches** are released within 7 days of a confirmed
+  vulnerability in PhiScan code or a direct dependency. This timeline
+  applies to vulnerabilities rated HIGH or CRITICAL by the maintainers.
+  MEDIUM and LOW vulnerabilities are addressed in the next scheduled
+  patch or minor release.
+- **Quarterly minor releases** are a target, not a guarantee. A minor
+  release may be delayed if the feature set is incomplete or quality
+  gates are not met. The project will not ship a minor release solely
+  to meet a calendar deadline.
+- **Major releases** are rare and planned well in advance. A major
+  release is preceded by at least one release candidate (`X.0.0-rc.N`)
+  published at least 30 days before the final release.
+
+---
+
+## What Constitutes a Breaking Change
+
+The following are considered breaking changes and require a MAJOR
+version increment:
+
+| Surface | Breaking change example |
+|---------|----------------------|
+| CLI interface | Removing a command or flag, changing default behavior of an existing flag |
+| Configuration schema | Removing a config key, changing the type or semantics of an existing key |
+| Output formats | Changing the JSON schema, SARIF structure, or CSV column order of an existing format |
+| Exit codes | Changing the meaning of exit code 0, 1, or 2 |
+| Plugin API | Removing a stable export, changing `detect()` signature, renaming the entry-point group |
+
+The following are NOT breaking changes:
+
+| Surface | Non-breaking change example |
+|---------|---------------------------|
+| CLI interface | Adding a new command or flag with a sensible default |
+| Configuration schema | Adding a new config key (unknown keys are ignored) |
+| Output formats | Adding a new field to JSON output (consumers SHOULD ignore unknown fields) |
+| Detection | Adding a new entity type or detection category (may produce new findings on existing code) |
+| Plugin API | Adding a new export, adding a new optional attribute with a default value |
+
+### New Findings as a Non-Breaking Change
+
+Adding new detection categories or improving existing recognizers may
+cause PhiScan to report findings that were not reported in a previous
+version. This is explicitly NOT a breaking change. Teams that need
+stable finding sets across upgrades SHOULD use baseline mode
+(`--baseline`) to isolate new findings from previously accepted ones.
+
+---
+
+## Release Process
+
+1. **Feature freeze**: all feature work for the release is merged to
+   `main`. No new features are merged after the freeze.
+2. **Release candidate** (minor/major only): a tagged RC is published
+   to PyPI for community testing. The RC period lasts at least 7 days
+   for minor releases and 30 days for major releases.
+3. **Final release**: the RC is promoted to a final release if no
+   blocking issues are found. The release is tagged in git, published
+   to PyPI, and a GitHub Release is created with:
+   - Wheel and sdist artifacts.
+   - CycloneDX SBOM (`sbom.cyclonedx.json`).
+   - Sigstore signature bundles (`.sigstore.json`).
+4. **Release notes**: published on the GitHub Release page and in
+   `CHANGELOG.md`. Notes include: new features, bug fixes, breaking
+   changes (major only), deprecation notices, migration guidance, and
+   security fixes.
+
+---
+
+## Deprecation Process
+
+Deprecations within a MAJOR version line follow the policy defined in
+[docs/plugin-api-v1.md](plugin-api-v1.md):
+
+- Deprecated features are announced in release notes with a migration
+  path and the earliest removal version.
+- Deprecated features emit `DeprecationWarning` at runtime.
+- Deprecated features are maintained for a minimum of 2 minor releases
+  after the announcement.
+- Removal is documented in the release notes of the version that
+  removes the feature.
+
+This policy applies to all public surfaces: CLI flags, configuration
+keys, output format fields, and Plugin API exports.
+
+---
+
+## Version History
+
+| Date | Change |
+|------|--------|
+| 2026-04-16 | Initial release cadence and versioning policy for C5 scorecard check |

--- a/docs/release-versioning-policy.md
+++ b/docs/release-versioning-policy.md
@@ -113,7 +113,7 @@ stable finding sets across upgrades SHOULD use baseline mode
 ## Deprecation Process
 
 Deprecations within a MAJOR version line follow the policy defined in
-[docs/plugin-api-v1.md](plugin-api-v1.md):
+[plugin-api-v1.md](plugin-api-v1.md):
 
 - Deprecated features are announced in release notes with a migration
   path and the earliest removal version.


### PR DESCRIPTION
## Summary

- Add `docs/release-versioning-policy.md` (C5): semver scheme, target cadence (patch as-needed, minor quarterly, major as-needed), breaking-change definition with concrete examples, release process with RC periods, and deprecation cross-reference to `docs/plugin-api-v1.md`.
- Add `docs/lts-eol-policy.md` (C6): 12-month LTS security patch window, LTS selection criteria, backport scope (security + critical bugs only), EOL process with 90-day advance notice, LTS overlap guarantees, Python version support policy.
- Update scorecard: C5 and C6 → PASS. **All 35/35 checks passing. All four categories at 100%. Scorecard complete.**
- Add doc links to README documentation table.

## Test plan

- [ ] Verify both docs render correctly on GitHub
- [ ] Verify scorecard totals: 35/35, all categories 100%
- [ ] Verify README doc table links resolve to new policy docs
- [ ] Verify weekly log entry is chronologically consistent