### PR TITLE
Split ci_integration.py into per-platform adapter package

### DIFF
--- a/docs/ci-adapter-contract.md
+++ b/docs/ci-adapter-contract.md
@@ -108,17 +108,17 @@ class BaseCIAdapter(ABC):
         """
 
     @property
-    def can_upload_sarif(self) -> bool:
+    def can_upload_sarif_report(self) -> bool:
         """Whether this platform supports native SARIF ingestion."""
         return False
 
     @property
-    def can_annotate_code(self) -> bool:
+    def can_annotate_code_findings(self) -> bool:
         """Whether this platform supports inline code annotations."""
         return False
 
     @property
-    def can_create_work_item(self) -> bool:
+    def can_create_work_item_from_findings(self) -> bool:
         """Whether this platform supports creating work items from findings."""
         return False
 ```
@@ -133,13 +133,13 @@ the adapter's capabilities inspectable:
 |-----------|--------|--------|-------|----------|-----------|-----------|---------|
 | `post_pr_comment` | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | `set_commit_status` | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| `can_upload_sarif` | Yes | No | No | No | No | No | No |
-| `can_annotate_code` | No | No | No | No | Yes | No | No |
-| `can_create_work_item` | No | No | Yes | No | No | No | No |
-| `can_import_to_security_hub` | No | No | No | No | No | Yes | No |
+| `can_upload_sarif_report` | Yes | No | No | No | No | No | No |
+| `can_annotate_code_findings` | No | No | No | No | Yes | No | No |
+| `can_create_work_item_from_findings` | No | No | Yes | No | No | No | No |
+| `can_import_findings_to_security_hub` | No | No | No | No | No | Yes | No |
 
 Platforms that support an extra MUST implement the corresponding method
-(e.g. `upload_sarif()` on `GitHubAdapter`). The base class provides a
+(e.g. `upload_sarif_report()` on `GitHubAdapter`). The base class provides a
 default that raises `CIIntegrationError` (the domain exception) for
 each extra — not `NotImplementedError`, which is a built-in and does
 not conform to the project's custom-exception-for-domain-errors rule.

--- a/docs/ci-adapter-contract.md
+++ b/docs/ci-adapter-contract.md
@@ -20,7 +20,7 @@ per-platform adapter package with a shared interface contract.
    Azure PR status, Azure Boards work items, Bitbucket Code Insights,
    AWS Security Hub ASFF import.
 
-All 7 platforms share the same outbound interface (`post_pr_comment`,
+All 7 platforms share the same outbound interface (`post_pull_request_comment`,
 `set_commit_status`) but diverge significantly in transport, auth, and
 API shape. The single-module design causes:
 
@@ -38,9 +38,9 @@ API shape. The single-module design causes:
 ```
 phi_scan/
   ci/
-    __init__.py           # re-exports detect_platform, get_pr_context,
-                          #   post_pr_comment, set_commit_status
-    _base.py              # BaseCIAdapter ABC, PRContext, CIIntegrationError
+    __init__.py           # re-exports detect_platform, get_pull_request_context,
+                          #   post_pull_request_comment, set_commit_status
+    _base.py              # BaseCIAdapter ABC, PullRequestContext, CIIntegrationError
     _transport.py         # shared _HttpRequestConfig, _execute_http_request
     _detect.py            # detect_platform(), CIPlatform enum
     github.py             # GitHubAdapter
@@ -66,7 +66,7 @@ tests/
 ```
 
 The top-level `phi_scan/ci/__init__.py` re-exports the public API so
-existing callers (`from phi_scan.ci_integration import post_pr_comment`)
+existing callers (`from phi_scan.ci_integration import post_pull_request_comment`)
 can migrate with a single import-path change. The old
 `ci_integration.py` module will be retained as a thin re-export shim
 during the deprecation window (see Phase 1 below).
@@ -88,8 +88,8 @@ class BaseCIAdapter(ABC):
     """
 
     @abstractmethod
-    def post_pr_comment(
-        self, comment_body: str, pr_context: PRContext,
+    def post_pull_request_comment(
+        self, comment_body: str, pull_request_context: PullRequestContext,
     ) -> None:
         """Post a comment on the PR/MR associated with this build.
 
@@ -99,7 +99,7 @@ class BaseCIAdapter(ABC):
 
     @abstractmethod
     def set_commit_status(
-        self, scan_result: ScanResult, pr_context: PRContext,
+        self, scan_result: ScanResult, pull_request_context: PullRequestContext,
     ) -> None:
         """Report pass/fail status on the commit that triggered the build.
 
@@ -131,7 +131,7 @@ the adapter's capabilities inspectable:
 
 | Capability | GitHub | GitLab | Azure | CircleCI | Bitbucket | CodeBuild | Jenkins |
 |-----------|--------|--------|-------|----------|-----------|-----------|---------|
-| `post_pr_comment` | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `post_pull_request_comment` | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | `set_commit_status` | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | `can_upload_sarif_report` | Yes | No | No | No | No | No | No |
 | `can_annotate_code_findings` | No | No | No | No | Yes | No | No |
@@ -221,10 +221,10 @@ transport module MUST maintain 100% coverage (it is security-critical).
    from phi_scan.ci import (  # noqa: F401
        CIIntegrationError,
        CIPlatform,
-       PRContext,
+       PullRequestContext,
        detect_platform,
-       get_pr_context,
-       post_pr_comment,
+       get_pull_request_context,
+       post_pull_request_comment,
        set_commit_status,
    )
    ```
@@ -237,7 +237,7 @@ transport module MUST maintain 100% coverage (it is security-critical).
 1. Extract each platform's functions into its adapter class
    (`github.py`, `gitlab.py`, etc.).
 2. Implement `BaseCIAdapter` interface on each adapter.
-3. Update `phi_scan/ci/__init__.py` to dispatch `post_pr_comment` and
+3. Update `phi_scan/ci/__init__.py` to dispatch `post_pull_request_comment` and
    `set_commit_status` via the adapter registry.
 4. Split test files into per-platform modules.
 

--- a/docs/ci-adapter-contract.md
+++ b/docs/ci-adapter-contract.md
@@ -108,17 +108,17 @@ class BaseCIAdapter(ABC):
         """
 
     @property
-    def supports_sarif_upload(self) -> bool:
+    def can_upload_sarif(self) -> bool:
         """Whether this platform supports native SARIF ingestion."""
         return False
 
     @property
-    def supports_code_insights(self) -> bool:
+    def can_annotate_code(self) -> bool:
         """Whether this platform supports inline code annotations."""
         return False
 
     @property
-    def supports_work_item_creation(self) -> bool:
+    def can_create_work_item(self) -> bool:
         """Whether this platform supports creating work items from findings."""
         return False
 ```
@@ -133,10 +133,10 @@ the adapter's capabilities inspectable:
 |-----------|--------|--------|-------|----------|-----------|-----------|---------|
 | `post_pr_comment` | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | `set_commit_status` | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| `supports_sarif_upload` | Yes | No | No | No | No | No | No |
-| `supports_code_insights` | No | No | No | No | Yes | No | No |
-| `supports_work_item_creation` | No | No | Yes | No | No | No | No |
-| `supports_security_hub` | No | No | No | No | No | Yes | No |
+| `can_upload_sarif` | Yes | No | No | No | No | No | No |
+| `can_annotate_code` | No | No | No | No | Yes | No | No |
+| `can_create_work_item` | No | No | Yes | No | No | No | No |
+| `can_import_to_security_hub` | No | No | No | No | No | Yes | No |
 
 Platforms that support an extra MUST implement the corresponding method
 (e.g. `upload_sarif()` on `GitHubAdapter`). The base class provides a

--- a/phi_scan/ci/__init__.py
+++ b/phi_scan/ci/__init__.py
@@ -33,9 +33,6 @@ from phi_scan.ci.gitlab import GitLabAdapter
 from phi_scan.ci.jenkins import JenkinsAdapter
 from phi_scan.exceptions import CIIntegrationError
 
-PRContext = PullRequestContext
-get_pr_context = get_pull_request_context
-
 _PLATFORM_ADAPTERS: dict[CIPlatform, type[BaseCIAdapter]] = {
     CIPlatform.GITHUB_ACTIONS: GitHubAdapter,
     CIPlatform.GITLAB_CI: GitLabAdapter,

--- a/phi_scan/ci/__init__.py
+++ b/phi_scan/ci/__init__.py
@@ -72,11 +72,9 @@ __all__ = [
     "GitHubAdapter",
     "GitLabAdapter",
     "JenkinsAdapter",
-    "PRContext",
     "PullRequestContext",
     "SanitisedCommentBody",
     "detect_platform",
-    "get_pr_context",
     "get_pull_request_context",
     "resolve_adapter",
 ]

--- a/phi_scan/ci/__init__.py
+++ b/phi_scan/ci/__init__.py
@@ -8,9 +8,9 @@ Public API — all names below are importable from ``phi_scan.ci``:
     from phi_scan.ci import (
         BaseCIAdapter,
         CIPlatform,
-        PRContext,
+        PullRequestContext,
         detect_platform,
-        get_pr_context,
+        get_pull_request_context,
         resolve_adapter,
     )
 """
@@ -18,7 +18,12 @@ Public API — all names below are importable from ``phi_scan.ci``:
 from __future__ import annotations
 
 from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody
-from phi_scan.ci._detect import CIPlatform, PRContext, detect_platform, get_pr_context
+from phi_scan.ci._detect import (
+    CIPlatform,
+    PullRequestContext,
+    detect_platform,
+    get_pull_request_context,
+)
 from phi_scan.ci.azure import AzureAdapter
 from phi_scan.ci.bitbucket import BitbucketAdapter
 from phi_scan.ci.circleci import CircleCIAdapter
@@ -27,6 +32,9 @@ from phi_scan.ci.github import GitHubAdapter
 from phi_scan.ci.gitlab import GitLabAdapter
 from phi_scan.ci.jenkins import JenkinsAdapter
 from phi_scan.exceptions import CIIntegrationError
+
+PRContext = PullRequestContext
+get_pr_context = get_pull_request_context
 
 _PLATFORM_ADAPTERS: dict[CIPlatform, type[BaseCIAdapter]] = {
     CIPlatform.GITHUB_ACTIONS: GitHubAdapter,
@@ -65,8 +73,10 @@ __all__ = [
     "GitLabAdapter",
     "JenkinsAdapter",
     "PRContext",
+    "PullRequestContext",
     "SanitisedCommentBody",
     "detect_platform",
     "get_pr_context",
+    "get_pull_request_context",
     "resolve_adapter",
 ]

--- a/phi_scan/ci/__init__.py
+++ b/phi_scan/ci/__init__.py
@@ -26,6 +26,7 @@ from phi_scan.ci.codebuild import CodeBuildAdapter
 from phi_scan.ci.github import GitHubAdapter
 from phi_scan.ci.gitlab import GitLabAdapter
 from phi_scan.ci.jenkins import JenkinsAdapter
+from phi_scan.exceptions import CIIntegrationError
 
 _PLATFORM_ADAPTERS: dict[CIPlatform, type[BaseCIAdapter]] = {
     CIPlatform.GITHUB_ACTIONS: GitHubAdapter,
@@ -38,11 +39,18 @@ _PLATFORM_ADAPTERS: dict[CIPlatform, type[BaseCIAdapter]] = {
 }
 
 
-def resolve_adapter(platform: CIPlatform) -> BaseCIAdapter | None:
-    """Return an adapter instance for the given platform, or None if unknown."""
+_UNKNOWN_PLATFORM_MESSAGE: str = "No CI adapter available for platform: {platform}"
+
+
+def resolve_adapter(platform: CIPlatform) -> BaseCIAdapter:
+    """Return an adapter instance for the given platform.
+
+    Raises:
+        CIIntegrationError: When no adapter exists for the platform.
+    """
     adapter_class = _PLATFORM_ADAPTERS.get(platform)
     if adapter_class is None:
-        return None
+        raise CIIntegrationError(_UNKNOWN_PLATFORM_MESSAGE.format(platform=platform.value))
     return adapter_class()
 
 

--- a/phi_scan/ci/__init__.py
+++ b/phi_scan/ci/__init__.py
@@ -27,22 +27,6 @@ from phi_scan.ci.github import GitHubAdapter
 from phi_scan.ci.gitlab import GitLabAdapter
 from phi_scan.ci.jenkins import JenkinsAdapter
 
-__all__ = [
-    "AzureAdapter",
-    "BaseCIAdapter",
-    "BitbucketAdapter",
-    "CIPlatform",
-    "CircleCIAdapter",
-    "CodeBuildAdapter",
-    "GitHubAdapter",
-    "GitLabAdapter",
-    "JenkinsAdapter",
-    "PRContext",
-    "detect_platform",
-    "get_pr_context",
-    "resolve_adapter",
-]
-
 _PLATFORM_ADAPTERS: dict[CIPlatform, type[BaseCIAdapter]] = {
     CIPlatform.GITHUB_ACTIONS: GitHubAdapter,
     CIPlatform.GITLAB_CI: GitLabAdapter,
@@ -60,3 +44,20 @@ def resolve_adapter(platform: CIPlatform) -> BaseCIAdapter | None:
     if adapter_class is None:
         return None
     return adapter_class()
+
+
+__all__ = [
+    "AzureAdapter",
+    "BaseCIAdapter",
+    "BitbucketAdapter",
+    "CIPlatform",
+    "CircleCIAdapter",
+    "CodeBuildAdapter",
+    "GitHubAdapter",
+    "GitLabAdapter",
+    "JenkinsAdapter",
+    "PRContext",
+    "detect_platform",
+    "get_pr_context",
+    "resolve_adapter",
+]

--- a/phi_scan/ci/__init__.py
+++ b/phi_scan/ci/__init__.py
@@ -17,7 +17,7 @@ Public API — all names below are importable from ``phi_scan.ci``:
 
 from __future__ import annotations
 
-from phi_scan.ci._base import BaseCIAdapter
+from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody
 from phi_scan.ci._detect import CIPlatform, PRContext, detect_platform, get_pr_context
 from phi_scan.ci.azure import AzureAdapter
 from phi_scan.ci.bitbucket import BitbucketAdapter
@@ -57,6 +57,7 @@ __all__ = [
     "GitLabAdapter",
     "JenkinsAdapter",
     "PRContext",
+    "SanitisedCommentBody",
     "detect_platform",
     "get_pr_context",
     "resolve_adapter",

--- a/phi_scan/ci/__init__.py
+++ b/phi_scan/ci/__init__.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 from phi_scan.ci._base import BaseCIAdapter
 from phi_scan.ci._detect import CIPlatform, PRContext, detect_platform, get_pr_context
-from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
 from phi_scan.ci.azure import AzureAdapter
 from phi_scan.ci.bitbucket import BitbucketAdapter
 from phi_scan.ci.circleci import CircleCIAdapter
@@ -37,12 +36,9 @@ __all__ = [
     "CodeBuildAdapter",
     "GitHubAdapter",
     "GitLabAdapter",
-    "HttpMethod",
-    "HttpRequestConfig",
     "JenkinsAdapter",
     "PRContext",
     "detect_platform",
-    "execute_http_request",
     "get_pr_context",
     "resolve_adapter",
 ]

--- a/phi_scan/ci/__init__.py
+++ b/phi_scan/ci/__init__.py
@@ -1,0 +1,66 @@
+"""CI/CD platform integration package.
+
+Provides per-platform adapters for posting PR comments and setting
+commit statuses, plus platform auto-detection from environment variables.
+
+Public API — all names below are importable from ``phi_scan.ci``:
+
+    from phi_scan.ci import (
+        BaseCIAdapter,
+        CIPlatform,
+        PRContext,
+        detect_platform,
+        get_pr_context,
+        resolve_adapter,
+    )
+"""
+
+from __future__ import annotations
+
+from phi_scan.ci._base import BaseCIAdapter
+from phi_scan.ci._detect import CIPlatform, PRContext, detect_platform, get_pr_context
+from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
+from phi_scan.ci.azure import AzureAdapter
+from phi_scan.ci.bitbucket import BitbucketAdapter
+from phi_scan.ci.circleci import CircleCIAdapter
+from phi_scan.ci.codebuild import CodeBuildAdapter
+from phi_scan.ci.github import GitHubAdapter
+from phi_scan.ci.gitlab import GitLabAdapter
+from phi_scan.ci.jenkins import JenkinsAdapter
+
+__all__ = [
+    "AzureAdapter",
+    "BaseCIAdapter",
+    "BitbucketAdapter",
+    "CIPlatform",
+    "CircleCIAdapter",
+    "CodeBuildAdapter",
+    "GitHubAdapter",
+    "GitLabAdapter",
+    "HttpMethod",
+    "HttpRequestConfig",
+    "JenkinsAdapter",
+    "PRContext",
+    "detect_platform",
+    "execute_http_request",
+    "get_pr_context",
+    "resolve_adapter",
+]
+
+_PLATFORM_ADAPTERS: dict[CIPlatform, type[BaseCIAdapter]] = {
+    CIPlatform.GITHUB_ACTIONS: GitHubAdapter,
+    CIPlatform.GITLAB_CI: GitLabAdapter,
+    CIPlatform.AZURE_DEVOPS: AzureAdapter,
+    CIPlatform.BITBUCKET: BitbucketAdapter,
+    CIPlatform.CIRCLECI: CircleCIAdapter,
+    CIPlatform.CODEBUILD: CodeBuildAdapter,
+    CIPlatform.JENKINS: JenkinsAdapter,
+}
+
+
+def resolve_adapter(platform: CIPlatform) -> BaseCIAdapter | None:
+    """Return an adapter instance for the given platform, or None if unknown."""
+    adapter_class = _PLATFORM_ADAPTERS.get(platform)
+    if adapter_class is None:
+        return None
+    return adapter_class()

--- a/phi_scan/ci/_base.py
+++ b/phi_scan/ci/_base.py
@@ -16,7 +16,12 @@ from phi_scan.models import ScanResult
 
 
 class UnsupportedOperation(enum.StrEnum):
-    """Named operations that an adapter may not support."""
+    """Named operations that an adapter may not support.
+
+    ``COMMIT_STATUS`` is used by adapters whose ``set_commit_status``
+    implementation explicitly aborts (e.g. AzureAdapter), since
+    ``set_commit_status`` is abstract rather than a default-abort stub.
+    """
 
     COMMIT_STATUS = "commit status"
     SARIF_UPLOAD = "SARIF upload"
@@ -81,22 +86,22 @@ class BaseCIAdapter(ABC):
         return True
 
     @property
-    def can_upload_sarif(self) -> bool:
+    def can_upload_sarif_report(self) -> bool:
         """Whether this platform supports native SARIF ingestion."""
         return False
 
     @property
-    def can_annotate_code(self) -> bool:
+    def can_annotate_code_findings(self) -> bool:
         """Whether this platform supports inline code annotations."""
         return False
 
     @property
-    def can_create_work_item(self) -> bool:
+    def can_create_work_item_from_findings(self) -> bool:
         """Whether this platform supports creating work items from findings."""
         return False
 
     @property
-    def can_import_to_security_hub(self) -> bool:
+    def can_import_findings_to_security_hub(self) -> bool:
         """Whether this platform supports AWS Security Hub import."""
         return False
 
@@ -108,18 +113,22 @@ class BaseCIAdapter(ABC):
             )
         )
 
-    def upload_sarif(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+    def upload_sarif_report(self, scan_result: ScanResult, pr_context: PRContext) -> None:
         """Upload SARIF to the platform's code scanning API."""
         self._abort_unsupported_operation(UnsupportedOperation.SARIF_UPLOAD)
 
-    def annotate_code(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+    def annotate_code_findings(self, scan_result: ScanResult, pr_context: PRContext) -> None:
         """Post inline code annotations to the platform."""
         self._abort_unsupported_operation(UnsupportedOperation.CODE_ANNOTATIONS)
 
-    def create_work_item(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+    def create_work_item_from_findings(
+        self, scan_result: ScanResult, pr_context: PRContext
+    ) -> None:
         """Create a work item or ticket from scan findings."""
         self._abort_unsupported_operation(UnsupportedOperation.WORK_ITEM_CREATION)
 
-    def import_to_security_hub(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+    def import_findings_to_security_hub(
+        self, scan_result: ScanResult, pr_context: PRContext
+    ) -> None:
         """Import findings into AWS Security Hub."""
         self._abort_unsupported_operation(UnsupportedOperation.SECURITY_HUB_IMPORT)

--- a/phi_scan/ci/_base.py
+++ b/phi_scan/ci/_base.py
@@ -1,7 +1,7 @@
 """Base adapter class for CI/CD platform integrations.
 
 All per-platform adapters inherit from ``BaseCIAdapter`` and implement
-the two core methods: ``post_pr_comment`` and ``set_commit_status``.
+the two core methods: ``post_pull_request_comment`` and ``set_commit_status``.
 """
 
 from __future__ import annotations
@@ -10,7 +10,7 @@ import enum
 from abc import ABC, abstractmethod
 from typing import NewType, NoReturn
 
-from phi_scan.ci._detect import PRContext
+from phi_scan.ci._detect import PullRequestContext
 from phi_scan.exceptions import CIIntegrationError
 from phi_scan.models import ScanResult
 
@@ -52,7 +52,9 @@ class BaseCIAdapter(ABC):
     """
 
     @abstractmethod
-    def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
+    def post_pull_request_comment(
+        self, comment_body: SanitisedCommentBody, pull_request_context: PullRequestContext
+    ) -> None:
         """Post a comment on the PR/MR associated with this build.
 
         ``comment_body`` is typed as ``SanitisedCommentBody`` to enforce
@@ -62,19 +64,21 @@ class BaseCIAdapter(ABC):
 
         Args:
             comment_body: Pre-sanitised Markdown comment text.
-            pr_context: Platform context extracted from environment variables.
+            pull_request_context: Platform context extracted from environment variables.
 
         Raises:
             CIIntegrationError: On any HTTP or auth failure.
         """
 
     @abstractmethod
-    def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+    def set_commit_status(
+        self, scan_result: ScanResult, pull_request_context: PullRequestContext
+    ) -> None:
         """Report pass/fail status on the commit that triggered the build.
 
         Args:
             scan_result: The completed scan result.
-            pr_context: Platform context extracted from environment variables.
+            pull_request_context: Platform context extracted from environment variables.
 
         Raises:
             CIIntegrationError: On any HTTP or auth failure.
@@ -113,22 +117,26 @@ class BaseCIAdapter(ABC):
             )
         )
 
-    def upload_sarif_report(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+    def upload_sarif_report(
+        self, scan_result: ScanResult, pull_request_context: PullRequestContext
+    ) -> None:
         """Upload SARIF to the platform's code scanning API."""
         self._abort_unsupported_operation(UnsupportedOperation.SARIF_UPLOAD)
 
-    def annotate_code_findings(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+    def annotate_code_findings(
+        self, scan_result: ScanResult, pull_request_context: PullRequestContext
+    ) -> None:
         """Post inline code annotations to the platform."""
         self._abort_unsupported_operation(UnsupportedOperation.CODE_ANNOTATIONS)
 
     def create_work_item_from_findings(
-        self, scan_result: ScanResult, pr_context: PRContext
+        self, scan_result: ScanResult, pull_request_context: PullRequestContext
     ) -> None:
         """Create a work item or ticket from scan findings."""
         self._abort_unsupported_operation(UnsupportedOperation.WORK_ITEM_CREATION)
 
     def import_findings_to_security_hub(
-        self, scan_result: ScanResult, pr_context: PRContext
+        self, scan_result: ScanResult, pull_request_context: PullRequestContext
     ) -> None:
         """Import findings into AWS Security Hub."""
         self._abort_unsupported_operation(UnsupportedOperation.SECURITY_HUB_IMPORT)

--- a/phi_scan/ci/_base.py
+++ b/phi_scan/ci/_base.py
@@ -107,3 +107,7 @@ class BaseCIAdapter(ABC):
     def create_work_item(self, scan_result: ScanResult, pr_context: PRContext) -> None:
         """Create a work item or ticket from scan findings."""
         self._raise_unsupported_operation_error("work item creation")
+
+    def import_to_security_hub(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+        """Import findings into AWS Security Hub."""
+        self._raise_unsupported_operation_error("Security Hub import")

--- a/phi_scan/ci/_base.py
+++ b/phi_scan/ci/_base.py
@@ -75,11 +75,14 @@ class BaseCIAdapter(ABC):
         """Whether this platform supports AWS Security Hub import."""
         return False
 
-    def upload_sarif(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        """Upload SARIF to the platform's code scanning API."""
+    def _raise_unsupported(self, operation: str) -> None:
         raise CIIntegrationError(
             _UNSUPPORTED_OPERATION_MESSAGE.format(
                 adapter_name=type(self).__name__,
-                operation="SARIF upload",
+                operation=operation,
             )
         )
+
+    def upload_sarif(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+        """Upload SARIF to the platform's code scanning API."""
+        self._raise_unsupported("SARIF upload")

--- a/phi_scan/ci/_base.py
+++ b/phi_scan/ci/_base.py
@@ -51,6 +51,11 @@ class BaseCIAdapter(ABC):
         """
 
     @property
+    def supports_commit_status(self) -> bool:
+        """Whether this platform supports setting commit status directly."""
+        return True
+
+    @property
     def supports_sarif_upload(self) -> bool:
         """Whether this platform supports native SARIF ingestion."""
         return False

--- a/phi_scan/ci/_base.py
+++ b/phi_scan/ci/_base.py
@@ -100,7 +100,7 @@ class BaseCIAdapter(ABC):
         """Whether this platform supports AWS Security Hub import."""
         return False
 
-    def _raise_unsupported_operation_error(self, operation_name: UnsupportedOperation) -> NoReturn:
+    def _abort_unsupported_operation(self, operation_name: UnsupportedOperation) -> NoReturn:
         raise CIIntegrationError(
             _UNSUPPORTED_OPERATION_MESSAGE.format(
                 adapter_name=type(self).__name__,
@@ -110,16 +110,16 @@ class BaseCIAdapter(ABC):
 
     def upload_sarif(self, scan_result: ScanResult, pr_context: PRContext) -> None:
         """Upload SARIF to the platform's code scanning API."""
-        self._raise_unsupported_operation_error(UnsupportedOperation.SARIF_UPLOAD)
+        self._abort_unsupported_operation(UnsupportedOperation.SARIF_UPLOAD)
 
     def annotate_code(self, scan_result: ScanResult, pr_context: PRContext) -> None:
         """Post inline code annotations to the platform."""
-        self._raise_unsupported_operation_error(UnsupportedOperation.CODE_ANNOTATIONS)
+        self._abort_unsupported_operation(UnsupportedOperation.CODE_ANNOTATIONS)
 
     def create_work_item(self, scan_result: ScanResult, pr_context: PRContext) -> None:
         """Create a work item or ticket from scan findings."""
-        self._raise_unsupported_operation_error(UnsupportedOperation.WORK_ITEM_CREATION)
+        self._abort_unsupported_operation(UnsupportedOperation.WORK_ITEM_CREATION)
 
     def import_to_security_hub(self, scan_result: ScanResult, pr_context: PRContext) -> None:
         """Import findings into AWS Security Hub."""
-        self._raise_unsupported_operation_error(UnsupportedOperation.SECURITY_HUB_IMPORT)
+        self._abort_unsupported_operation(UnsupportedOperation.SECURITY_HUB_IMPORT)

--- a/phi_scan/ci/_base.py
+++ b/phi_scan/ci/_base.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import enum
 from abc import ABC, abstractmethod
-from typing import NewType
+from typing import NewType, NoReturn
 
 from phi_scan.ci._detect import PRContext
 from phi_scan.exceptions import CIIntegrationError
@@ -100,7 +100,7 @@ class BaseCIAdapter(ABC):
         """Whether this platform supports AWS Security Hub import."""
         return False
 
-    def _raise_unsupported_operation_error(self, operation_name: UnsupportedOperation) -> None:
+    def _raise_unsupported_operation_error(self, operation_name: UnsupportedOperation) -> NoReturn:
         raise CIIntegrationError(
             _UNSUPPORTED_OPERATION_MESSAGE.format(
                 adapter_name=type(self).__name__,

--- a/phi_scan/ci/_base.py
+++ b/phi_scan/ci/_base.py
@@ -1,0 +1,80 @@
+"""Base adapter class for CI/CD platform integrations.
+
+All per-platform adapters inherit from ``BaseCIAdapter`` and implement
+the two core methods: ``post_pr_comment`` and ``set_commit_status``.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from phi_scan.ci._detect import PRContext
+from phi_scan.exceptions import CIIntegrationError
+from phi_scan.models import ScanResult
+
+__all__ = [
+    "BaseCIAdapter",
+]
+
+_UNSUPPORTED_OPERATION_MESSAGE: str = "{adapter_name} does not support {operation}"
+
+
+class BaseCIAdapter(ABC):
+    """Abstract base class for per-platform CI/CD adapters.
+
+    Each adapter encapsulates the platform-specific logic for posting
+    PR comments and setting commit statuses.
+    """
+
+    @abstractmethod
+    def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
+        """Post a comment on the PR/MR associated with this build.
+
+        Args:
+            comment_body: Markdown comment text.
+            pr_context: Platform context extracted from environment variables.
+
+        Raises:
+            CIIntegrationError: On any HTTP or auth failure.
+        """
+
+    @abstractmethod
+    def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+        """Report pass/fail status on the commit that triggered the build.
+
+        Args:
+            scan_result: The completed scan result.
+            pr_context: Platform context extracted from environment variables.
+
+        Raises:
+            CIIntegrationError: On any HTTP or auth failure.
+        """
+
+    @property
+    def supports_sarif_upload(self) -> bool:
+        """Whether this platform supports native SARIF ingestion."""
+        return False
+
+    @property
+    def supports_code_insights(self) -> bool:
+        """Whether this platform supports inline code annotations."""
+        return False
+
+    @property
+    def supports_work_item_creation(self) -> bool:
+        """Whether this platform supports creating work items from findings."""
+        return False
+
+    @property
+    def supports_security_hub(self) -> bool:
+        """Whether this platform supports AWS Security Hub import."""
+        return False
+
+    def upload_sarif(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+        """Upload SARIF to the platform's code scanning API."""
+        raise CIIntegrationError(
+            _UNSUPPORTED_OPERATION_MESSAGE.format(
+                adapter_name=type(self).__name__,
+                operation="SARIF upload",
+            )
+        )

--- a/phi_scan/ci/_base.py
+++ b/phi_scan/ci/_base.py
@@ -30,8 +30,14 @@ class BaseCIAdapter(ABC):
     def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
         """Post a comment on the PR/MR associated with this build.
 
+        **PHI-safety contract:** ``comment_body`` is sent to an external
+        API.  Callers must ensure it contains only hashed references and
+        redacted metadata — never raw PHI values, code snippets, or
+        matched strings.  The formatting functions in ``ci_integration``
+        enforce this; bypass them only with an explicit safety audit.
+
         Args:
-            comment_body: Markdown comment text.
+            comment_body: Pre-sanitised Markdown comment text.
             pr_context: Platform context extracted from environment variables.
 
         Raises:
@@ -51,27 +57,27 @@ class BaseCIAdapter(ABC):
         """
 
     @property
-    def supports_commit_status(self) -> bool:
+    def can_post_commit_status(self) -> bool:
         """Whether this platform supports setting commit status directly."""
         return True
 
     @property
-    def supports_sarif_upload(self) -> bool:
+    def can_upload_sarif(self) -> bool:
         """Whether this platform supports native SARIF ingestion."""
         return False
 
     @property
-    def supports_code_insights(self) -> bool:
+    def can_annotate_code(self) -> bool:
         """Whether this platform supports inline code annotations."""
         return False
 
     @property
-    def supports_work_item_creation(self) -> bool:
+    def can_create_work_item(self) -> bool:
         """Whether this platform supports creating work items from findings."""
         return False
 
     @property
-    def supports_security_hub(self) -> bool:
+    def can_import_to_security_hub(self) -> bool:
         """Whether this platform supports AWS Security Hub import."""
         return False
 

--- a/phi_scan/ci/_base.py
+++ b/phi_scan/ci/_base.py
@@ -86,3 +86,11 @@ class BaseCIAdapter(ABC):
     def upload_sarif(self, scan_result: ScanResult, pr_context: PRContext) -> None:
         """Upload SARIF to the platform's code scanning API."""
         self._raise_unsupported("SARIF upload")
+
+    def upload_code_insights(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+        """Post inline code annotations to the platform."""
+        self._raise_unsupported("code insights")
+
+    def create_work_item(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+        """Create a work item or ticket from scan findings."""
+        self._raise_unsupported("work item creation")

--- a/phi_scan/ci/_base.py
+++ b/phi_scan/ci/_base.py
@@ -7,16 +7,24 @@ the two core methods: ``post_pr_comment`` and ``set_commit_status``.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import NewType
 
 from phi_scan.ci._detect import PRContext
 from phi_scan.exceptions import CIIntegrationError
 from phi_scan.models import ScanResult
 
+SanitisedCommentBody = NewType("SanitisedCommentBody", str)
+"""A comment string verified to contain only hashed references and
+redacted metadata — never raw PHI values, code snippets, or matched
+strings.  Created by ``build_comment_body`` in ``ci_integration``.
+"""
+
 __all__ = [
     "BaseCIAdapter",
+    "SanitisedCommentBody",
 ]
 
-_UNSUPPORTED_OPERATION_MESSAGE: str = "{adapter_name} does not support {operation}"
+_UNSUPPORTED_OPERATION_MESSAGE: str = "{adapter_name} does not support {operation_name}"
 
 
 class BaseCIAdapter(ABC):
@@ -27,14 +35,13 @@ class BaseCIAdapter(ABC):
     """
 
     @abstractmethod
-    def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
+    def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
         """Post a comment on the PR/MR associated with this build.
 
-        **PHI-safety contract:** ``comment_body`` is sent to an external
-        API.  Callers must ensure it contains only hashed references and
-        redacted metadata — never raw PHI values, code snippets, or
-        matched strings.  The formatting functions in ``ci_integration``
-        enforce this; bypass them only with an explicit safety audit.
+        ``comment_body`` is typed as ``SanitisedCommentBody`` to enforce
+        at the type level that only pre-sanitised content (hashed
+        references, redacted metadata) reaches an external API.  Use
+        ``build_comment_body`` in ``ci_integration`` to create one.
 
         Args:
             comment_body: Pre-sanitised Markdown comment text.
@@ -81,22 +88,22 @@ class BaseCIAdapter(ABC):
         """Whether this platform supports AWS Security Hub import."""
         return False
 
-    def _raise_unsupported(self, operation: str) -> None:
+    def _raise_unsupported_operation_error(self, operation_name: str) -> None:
         raise CIIntegrationError(
             _UNSUPPORTED_OPERATION_MESSAGE.format(
                 adapter_name=type(self).__name__,
-                operation=operation,
+                operation_name=operation_name,
             )
         )
 
     def upload_sarif(self, scan_result: ScanResult, pr_context: PRContext) -> None:
         """Upload SARIF to the platform's code scanning API."""
-        self._raise_unsupported("SARIF upload")
+        self._raise_unsupported_operation_error("SARIF upload")
 
-    def upload_code_insights(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+    def annotate_code(self, scan_result: ScanResult, pr_context: PRContext) -> None:
         """Post inline code annotations to the platform."""
-        self._raise_unsupported("code insights")
+        self._raise_unsupported_operation_error("code annotations")
 
     def create_work_item(self, scan_result: ScanResult, pr_context: PRContext) -> None:
         """Create a work item or ticket from scan findings."""
-        self._raise_unsupported("work item creation")
+        self._raise_unsupported_operation_error("work item creation")

--- a/phi_scan/ci/_base.py
+++ b/phi_scan/ci/_base.py
@@ -6,12 +6,24 @@ the two core methods: ``post_pr_comment`` and ``set_commit_status``.
 
 from __future__ import annotations
 
+import enum
 from abc import ABC, abstractmethod
 from typing import NewType
 
 from phi_scan.ci._detect import PRContext
 from phi_scan.exceptions import CIIntegrationError
 from phi_scan.models import ScanResult
+
+
+class UnsupportedOperation(enum.StrEnum):
+    """Named operations that an adapter may not support."""
+
+    COMMIT_STATUS = "commit status"
+    SARIF_UPLOAD = "SARIF upload"
+    CODE_ANNOTATIONS = "code annotations"
+    WORK_ITEM_CREATION = "work item creation"
+    SECURITY_HUB_IMPORT = "Security Hub import"
+
 
 SanitisedCommentBody = NewType("SanitisedCommentBody", str)
 """A comment string verified to contain only hashed references and
@@ -88,7 +100,7 @@ class BaseCIAdapter(ABC):
         """Whether this platform supports AWS Security Hub import."""
         return False
 
-    def _raise_unsupported_operation_error(self, operation_name: str) -> None:
+    def _raise_unsupported_operation_error(self, operation_name: UnsupportedOperation) -> None:
         raise CIIntegrationError(
             _UNSUPPORTED_OPERATION_MESSAGE.format(
                 adapter_name=type(self).__name__,
@@ -98,16 +110,16 @@ class BaseCIAdapter(ABC):
 
     def upload_sarif(self, scan_result: ScanResult, pr_context: PRContext) -> None:
         """Upload SARIF to the platform's code scanning API."""
-        self._raise_unsupported_operation_error("SARIF upload")
+        self._raise_unsupported_operation_error(UnsupportedOperation.SARIF_UPLOAD)
 
     def annotate_code(self, scan_result: ScanResult, pr_context: PRContext) -> None:
         """Post inline code annotations to the platform."""
-        self._raise_unsupported_operation_error("code annotations")
+        self._raise_unsupported_operation_error(UnsupportedOperation.CODE_ANNOTATIONS)
 
     def create_work_item(self, scan_result: ScanResult, pr_context: PRContext) -> None:
         """Create a work item or ticket from scan findings."""
-        self._raise_unsupported_operation_error("work item creation")
+        self._raise_unsupported_operation_error(UnsupportedOperation.WORK_ITEM_CREATION)
 
     def import_to_security_hub(self, scan_result: ScanResult, pr_context: PRContext) -> None:
         """Import findings into AWS Security Hub."""
-        self._raise_unsupported_operation_error("Security Hub import")
+        self._raise_unsupported_operation_error(UnsupportedOperation.SECURITY_HUB_IMPORT)

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -167,12 +167,17 @@ def read_env_variable(name: str) -> str | None:
     return env_value if env_value else None
 
 
+def _extract_github_pr_number(ref: str) -> str | None:
+    if ref.startswith(_GITHUB_PR_REF_PREFIX):
+        return ref.split("/")[_GITHUB_PR_REF_NUMBER_INDEX]
+    return None
+
+
 def _build_github_context() -> PRContext:
     pr_number = read_env_variable(_ENV_PR_NUMBER)
     if not pr_number:
         ref = read_env_variable(_ENV_GITHUB_REF) or ""
-        if ref.startswith(_GITHUB_PR_REF_PREFIX):
-            pr_number = ref.split("/")[_GITHUB_PR_REF_NUMBER_INDEX]
+        pr_number = _extract_github_pr_number(ref)
     return PRContext(
         platform=CIPlatform.GITHUB_ACTIONS,
         pr_number=pr_number,
@@ -221,15 +226,19 @@ def _build_azure_context() -> PRContext:
     )
 
 
+def _extract_pr_number_from_url(pr_url: str) -> str | None:
+    if not pr_url:
+        return None
+    url_segments = pr_url.rstrip("/").split("/")
+    if not url_segments:
+        return None
+    pr_number_candidate = url_segments[-1]
+    return pr_number_candidate if pr_number_candidate.isdigit() else None
+
+
 def _build_circleci_context() -> PRContext:
     pr_url = read_env_variable(_ENV_CIRCLE_PULL_REQUEST) or ""
-    pr_number: str | None = None
-    if pr_url:
-        url_segments = pr_url.rstrip("/").split("/")
-        if url_segments:
-            candidate = url_segments[-1]
-            if candidate.isdigit():
-                pr_number = candidate
+    pr_number = _extract_pr_number_from_url(pr_url)
     return PRContext(
         platform=CIPlatform.CIRCLECI,
         pr_number=pr_number,

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -79,6 +79,7 @@ _GITHUB_PR_REF_NUMBER_INDEX: int = 2
 
 # CodeBuild webhook trigger prefix for PR detection (e.g. "pr/42")
 _CODEBUILD_PR_TRIGGER_PREFIX: str = "pr/"
+_URL_LAST_SEGMENT_INDEX: int = -1
 
 # Sentinel values for CI platform detection env vars
 _CI_ENV_SENTINEL_TRUE: str = "true"
@@ -155,14 +156,14 @@ def detect_platform() -> CIPlatform:
 
 def fetch_environment_variable(name: str) -> str | None:
     """Return the environment variable value, or None if unset or empty."""
-    env_value = os.environ.get(name, "").strip()
-    return env_value if env_value else None
+    raw_env_string = os.environ.get(name, "").strip()
+    return raw_env_string if raw_env_string else None
 
 
-def _extract_github_pr_number(ref: str) -> str | None:
-    if not ref.startswith(_GITHUB_PR_REF_PREFIX):
+def _extract_github_pr_number(github_ref: str) -> str | None:
+    if not github_ref.startswith(_GITHUB_PR_REF_PREFIX):
         return None
-    ref_segments = ref.split("/")
+    ref_segments = github_ref.split("/")
     if len(ref_segments) <= _GITHUB_PR_REF_NUMBER_INDEX:
         return None
     return ref_segments[_GITHUB_PR_REF_NUMBER_INDEX]
@@ -172,8 +173,8 @@ def _resolve_github_pr_number() -> str | None:
     explicit_pr_number = fetch_environment_variable(_ENV_PR_NUMBER)
     if explicit_pr_number:
         return explicit_pr_number
-    ref = fetch_environment_variable(_ENV_GITHUB_REF) or ""
-    return _extract_github_pr_number(ref)
+    github_ref = fetch_environment_variable(_ENV_GITHUB_REF) or ""
+    return _extract_github_pr_number(github_ref)
 
 
 def _build_github_context() -> PRContext:
@@ -203,10 +204,10 @@ def _build_gitlab_context() -> PRContext:
     )
 
 
-def _append_trailing_slash(uri: str) -> str:
-    if uri and not uri.endswith("/"):
-        return uri + "/"
-    return uri
+def _append_trailing_slash(server_url: str) -> str:
+    if server_url and not server_url.endswith("/"):
+        return server_url + "/"
+    return server_url
 
 
 def _build_azure_context() -> PRContext:
@@ -233,7 +234,7 @@ def _extract_pr_number_from_url(pr_url: str) -> str | None:
     url_segments = pr_url.rstrip("/").split("/")
     if not url_segments:
         return None
-    pr_number_candidate = url_segments[-1]
+    pr_number_candidate = url_segments[_URL_LAST_SEGMENT_INDEX]
     return pr_number_candidate if pr_number_candidate.isdigit() else None
 
 

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -200,15 +200,15 @@ def _build_gitlab_context() -> PRContext:
     )
 
 
-def _append_trailing_slash(server_url: str) -> str:
-    if server_url and not server_url.endswith("/"):
-        return server_url + "/"
-    return server_url
+def _normalise_collection_url(collection_url: str) -> str:
+    if collection_url and not collection_url.endswith("/"):
+        return collection_url + "/"
+    return collection_url
 
 
 def _build_azure_context() -> PRContext:
-    unformatted_uri = fetch_environment_variable(_ENV_SYSTEM_TEAMFOUNDATIONCOLLECTIONURI) or ""
-    collection_uri = _append_trailing_slash(unformatted_uri)
+    raw_collection_url = fetch_environment_variable(_ENV_SYSTEM_TEAMFOUNDATIONCOLLECTIONURI) or ""
+    collection_uri = _normalise_collection_url(raw_collection_url)
     return PRContext(
         platform=CIPlatform.AZURE_DEVOPS,
         pr_number=fetch_environment_variable(_ENV_SYSTEM_PULLREQUEST_PULLREQUESTID),

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -1,7 +1,7 @@
 """CI/CD platform detection and PR context extraction.
 
 Auto-detects the running CI/CD platform from environment variables and
-extracts PR/MR context into a platform-neutral ``PRContext`` dataclass.
+extracts PR/MR context into a platform-neutral ``PullRequestContext`` dataclass.
 """
 
 from __future__ import annotations
@@ -15,9 +15,9 @@ from phi_scan.ci._env import fetch_environment_variable
 
 __all__ = [
     "CIPlatform",
-    "PRContext",
+    "PullRequestContext",
     "detect_platform",
-    "get_pr_context",
+    "get_pull_request_context",
 ]
 
 # ---------------------------------------------------------------------------
@@ -108,7 +108,7 @@ class CIPlatform(enum.Enum):
 
 
 @dataclass(frozen=True)
-class PRContext:
+class PullRequestContext:
     """Platform-neutral PR/MR context extracted from environment variables.
 
     Top-level fields that are unavailable on the current platform are ``None``.
@@ -116,7 +116,7 @@ class PRContext:
     """
 
     platform: CIPlatform
-    pr_number: str | None
+    pull_request_number: str | None
     repository: str | None
     sha: str | None
     branch: str | None
@@ -157,7 +157,7 @@ def detect_platform() -> CIPlatform:
 # ---------------------------------------------------------------------------
 
 
-def _extract_github_pr_number(github_ref: str) -> str | None:
+def _extract_github_pull_request_number(github_ref: str) -> str | None:
     if not github_ref.startswith(_GITHUB_PR_REF_PREFIX):
         return None
     ref_segments = github_ref.split("/")
@@ -166,18 +166,18 @@ def _extract_github_pr_number(github_ref: str) -> str | None:
     return ref_segments[_GITHUB_REF_PR_NUMBER_SEGMENT_INDEX]
 
 
-def _resolve_github_pr_number() -> str | None:
-    explicit_pr_number = fetch_environment_variable(_ENV_PR_NUMBER)
-    if explicit_pr_number:
-        return explicit_pr_number
+def _resolve_github_pull_request_number() -> str | None:
+    explicit_pull_request_number = fetch_environment_variable(_ENV_PR_NUMBER)
+    if explicit_pull_request_number:
+        return explicit_pull_request_number
     github_ref = fetch_environment_variable(_ENV_GITHUB_REF) or ""
-    return _extract_github_pr_number(github_ref)
+    return _extract_github_pull_request_number(github_ref)
 
 
-def _build_github_context() -> PRContext:
-    return PRContext(
+def _build_github_context() -> PullRequestContext:
+    return PullRequestContext(
         platform=CIPlatform.GITHUB_ACTIONS,
-        pr_number=_resolve_github_pr_number(),
+        pull_request_number=_resolve_github_pull_request_number(),
         repository=fetch_environment_variable(_ENV_GITHUB_REPOSITORY),
         sha=fetch_environment_variable(_ENV_GITHUB_SHA),
         branch=fetch_environment_variable(_ENV_GITHUB_REF),
@@ -185,10 +185,10 @@ def _build_github_context() -> PRContext:
     )
 
 
-def _build_gitlab_context() -> PRContext:
-    return PRContext(
+def _build_gitlab_context() -> PullRequestContext:
+    return PullRequestContext(
         platform=CIPlatform.GITLAB_CI,
-        pr_number=fetch_environment_variable(_ENV_CI_MERGE_REQUEST_IID),
+        pull_request_number=fetch_environment_variable(_ENV_CI_MERGE_REQUEST_IID),
         repository=fetch_environment_variable(_ENV_CI_PROJECT_ID),
         sha=fetch_environment_variable(_ENV_CI_COMMIT_SHA),
         branch=fetch_environment_variable(_ENV_CI_COMMIT_REF_NAME),
@@ -207,12 +207,12 @@ def _normalise_collection_url(collection_url: str) -> str:
     return collection_url
 
 
-def _build_azure_context() -> PRContext:
+def _build_azure_context() -> PullRequestContext:
     raw_collection_url = fetch_environment_variable(_ENV_SYSTEM_TEAMFOUNDATIONCOLLECTIONURI) or ""
     collection_uri = _normalise_collection_url(raw_collection_url)
-    return PRContext(
+    return PullRequestContext(
         platform=CIPlatform.AZURE_DEVOPS,
-        pr_number=fetch_environment_variable(_ENV_SYSTEM_PULLREQUEST_PULLREQUESTID),
+        pull_request_number=fetch_environment_variable(_ENV_SYSTEM_PULLREQUEST_PULLREQUESTID),
         repository=fetch_environment_variable(_ENV_BUILD_REPOSITORY_ID),
         sha=fetch_environment_variable(_ENV_BUILD_SOURCEVERSION),
         branch=None,
@@ -225,34 +225,34 @@ def _build_azure_context() -> PRContext:
     )
 
 
-def _extract_pr_number_from_url(pr_url: str) -> str | None:
-    if not pr_url:
+def _extract_pull_request_number_from_url(pull_request_url: str) -> str | None:
+    if not pull_request_url:
         return None
-    url_segments = pr_url.rstrip("/").split("/")
+    url_segments = pull_request_url.rstrip("/").split("/")
     if not url_segments:
         return None
     last_url_segment = url_segments[-1]
     return last_url_segment if last_url_segment.isdigit() else None
 
 
-def _build_circleci_context() -> PRContext:
-    circle_pr_url = fetch_environment_variable(_ENV_CIRCLE_PULL_REQUEST) or ""
-    pr_number = _extract_pr_number_from_url(circle_pr_url)
-    return PRContext(
+def _build_circleci_context() -> PullRequestContext:
+    circle_pull_request_url = fetch_environment_variable(_ENV_CIRCLE_PULL_REQUEST) or ""
+    pull_request_number = _extract_pull_request_number_from_url(circle_pull_request_url)
+    return PullRequestContext(
         platform=CIPlatform.CIRCLECI,
-        pr_number=pr_number,
+        pull_request_number=pull_request_number,
         repository=None,
         sha=fetch_environment_variable(_ENV_CIRCLE_SHA1),
         branch=fetch_environment_variable(_ENV_CIRCLE_BRANCH),
         base_branch=None,
-        extras={"circle_pull_request_url": circle_pr_url},
+        extras={"circle_pull_request_url": circle_pull_request_url},
     )
 
 
-def _build_bitbucket_context() -> PRContext:
-    return PRContext(
+def _build_bitbucket_context() -> PullRequestContext:
+    return PullRequestContext(
         platform=CIPlatform.BITBUCKET,
-        pr_number=fetch_environment_variable(_ENV_BITBUCKET_PR_ID),
+        pull_request_number=fetch_environment_variable(_ENV_BITBUCKET_PR_ID),
         repository=fetch_environment_variable(_ENV_BITBUCKET_REPO_SLUG),
         sha=fetch_environment_variable(_ENV_BITBUCKET_COMMIT),
         branch=None,
@@ -263,18 +263,18 @@ def _build_bitbucket_context() -> PRContext:
     )
 
 
-def _extract_codebuild_pr_number(webhook_trigger: str) -> str | None:
+def _extract_codebuild_pull_request_number(webhook_trigger: str) -> str | None:
     if not webhook_trigger.startswith(_CODEBUILD_PR_TRIGGER_PREFIX):
         return None
     return webhook_trigger.removeprefix(_CODEBUILD_PR_TRIGGER_PREFIX) or None
 
 
-def _build_codebuild_context() -> PRContext:
+def _build_codebuild_context() -> PullRequestContext:
     webhook_trigger = fetch_environment_variable(_ENV_CODEBUILD_WEBHOOK_TRIGGER) or ""
-    pr_number = _extract_codebuild_pr_number(webhook_trigger)
-    return PRContext(
+    pull_request_number = _extract_codebuild_pull_request_number(webhook_trigger)
+    return PullRequestContext(
         platform=CIPlatform.CODEBUILD,
-        pr_number=pr_number,
+        pull_request_number=pull_request_number,
         repository=None,
         sha=fetch_environment_variable(_ENV_CODEBUILD_SOURCE_VERSION),
         branch=None,
@@ -282,10 +282,10 @@ def _build_codebuild_context() -> PRContext:
     )
 
 
-def _build_jenkins_context() -> PRContext:
-    return PRContext(
+def _build_jenkins_context() -> PullRequestContext:
+    return PullRequestContext(
         platform=CIPlatform.JENKINS,
-        pr_number=fetch_environment_variable(_ENV_CHANGE_ID),
+        pull_request_number=fetch_environment_variable(_ENV_CHANGE_ID),
         repository=None,
         sha=None,
         branch=None,
@@ -294,10 +294,10 @@ def _build_jenkins_context() -> PRContext:
     )
 
 
-def _build_unknown_context() -> PRContext:
-    return PRContext(
+def _build_unknown_context() -> PullRequestContext:
+    return PullRequestContext(
         platform=CIPlatform.UNKNOWN,
-        pr_number=None,
+        pull_request_number=None,
         repository=None,
         sha=None,
         branch=None,
@@ -305,7 +305,7 @@ def _build_unknown_context() -> PRContext:
     )
 
 
-_PLATFORM_CONTEXT_BUILDERS: dict[CIPlatform, Callable[[], PRContext]] = {
+_PLATFORM_CONTEXT_BUILDERS: dict[CIPlatform, Callable[[], PullRequestContext]] = {
     CIPlatform.GITHUB_ACTIONS: _build_github_context,
     CIPlatform.GITLAB_CI: _build_gitlab_context,
     CIPlatform.AZURE_DEVOPS: _build_azure_context,
@@ -317,8 +317,8 @@ _PLATFORM_CONTEXT_BUILDERS: dict[CIPlatform, Callable[[], PRContext]] = {
 }
 
 
-def get_pr_context() -> PRContext:
-    """Build a ``PRContext`` from the current environment.
+def get_pull_request_context() -> PullRequestContext:
+    """Build a ``PullRequestContext`` from the current environment.
 
     Reads platform-specific environment variables to extract the PR number,
     repository, commit SHA, and branch.

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -81,7 +81,6 @@ _GITHUB_PR_REF_NUMBER_INDEX: int = 2
 
 # CodeBuild webhook trigger prefix for PR detection (e.g. "pr/42")
 _CODEBUILD_PR_TRIGGER_PREFIX: str = "pr/"
-_URL_LAST_SEGMENT_INDEX: int = -1
 _URL_PATH_SEPARATOR: str = "/"
 
 # Sentinel values for CI platform detection env vars
@@ -231,7 +230,7 @@ def _extract_pr_number_from_url(pr_url: str) -> str | None:
     url_segments = pr_url.rstrip("/").split("/")
     if not url_segments:
         return None
-    pr_number_candidate = url_segments[_URL_LAST_SEGMENT_INDEX]
+    pr_number_candidate = url_segments[-1]
     return pr_number_candidate if pr_number_candidate.isdigit() else None
 
 

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -77,7 +77,7 @@ _GITLAB_DEFAULT_SERVER_URL: str = "https://gitlab.com"
 
 # GitHub ref prefix for PR detection (e.g. "refs/pull/42/merge")
 _GITHUB_PR_REF_PREFIX: str = "refs/pull/"
-_GITHUB_PR_REF_NUMBER_INDEX: int = 2
+_GITHUB_REF_PR_NUMBER_SEGMENT_INDEX: int = 2
 
 # CodeBuild webhook trigger prefix for PR detection (e.g. "pr/42")
 _CODEBUILD_PR_TRIGGER_PREFIX: str = "pr/"
@@ -160,9 +160,9 @@ def _extract_github_pr_number(github_ref: str) -> str | None:
     if not github_ref.startswith(_GITHUB_PR_REF_PREFIX):
         return None
     ref_segments = github_ref.split("/")
-    if len(ref_segments) <= _GITHUB_PR_REF_NUMBER_INDEX:
+    if len(ref_segments) <= _GITHUB_REF_PR_NUMBER_SEGMENT_INDEX:
         return None
-    return ref_segments[_GITHUB_PR_REF_NUMBER_INDEX]
+    return ref_segments[_GITHUB_REF_PR_NUMBER_SEGMENT_INDEX]
 
 
 def _resolve_github_pr_number() -> str | None:

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -264,11 +264,15 @@ def _build_bitbucket_context() -> PRContext:
     )
 
 
+def _extract_codebuild_pr_number(webhook_trigger: str) -> str | None:
+    if not webhook_trigger.startswith(_CODEBUILD_PR_TRIGGER_PREFIX):
+        return None
+    return webhook_trigger.removeprefix(_CODEBUILD_PR_TRIGGER_PREFIX) or None
+
+
 def _build_codebuild_context() -> PRContext:
     webhook_trigger = fetch_environment_variable(_ENV_CODEBUILD_WEBHOOK_TRIGGER) or ""
-    pr_number: str | None = None
-    if webhook_trigger.startswith(_CODEBUILD_PR_TRIGGER_PREFIX):
-        pr_number = webhook_trigger[len(_CODEBUILD_PR_TRIGGER_PREFIX) :]
+    pr_number = _extract_codebuild_pr_number(webhook_trigger)
     return PRContext(
         platform=CIPlatform.CODEBUILD,
         pr_number=pr_number,

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -197,15 +197,15 @@ def _build_gitlab_context() -> PRContext:
     )
 
 
-def _normalize_trailing_slash(uri: str) -> str:
+def _append_trailing_slash(uri: str) -> str:
     if uri and not uri.endswith("/"):
         return uri + "/"
     return uri
 
 
 def _build_azure_context() -> PRContext:
-    raw_uri = read_env_variable(_ENV_SYSTEM_TEAMFOUNDATIONCOLLECTIONURI) or ""
-    collection_uri = _normalize_trailing_slash(raw_uri)
+    unformatted_uri = read_env_variable(_ENV_SYSTEM_TEAMFOUNDATIONCOLLECTIONURI) or ""
+    collection_uri = _append_trailing_slash(unformatted_uri)
     return PRContext(
         platform=CIPlatform.AZURE_DEVOPS,
         pr_number=read_env_variable(_ENV_SYSTEM_PULLREQUEST_PULLREQUESTID),
@@ -225,9 +225,9 @@ def _build_circleci_context() -> PRContext:
     pr_url = read_env_variable(_ENV_CIRCLE_PULL_REQUEST) or ""
     pr_number: str | None = None
     if pr_url:
-        parts = pr_url.rstrip("/").split("/")
-        if parts:
-            candidate = parts[-1]
+        url_segments = pr_url.rstrip("/").split("/")
+        if url_segments:
+            candidate = url_segments[-1]
             if candidate.isdigit():
                 pr_number = candidate
     return PRContext(

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -16,7 +16,7 @@ __all__ = [
     "PRContext",
     "detect_platform",
     "get_pr_context",
-    "read_env_variable",
+    "fetch_env_variable",
 ]
 
 # ---------------------------------------------------------------------------
@@ -81,6 +81,10 @@ _GITHUB_PR_REF_NUMBER_INDEX: int = 2
 # CodeBuild webhook trigger prefix for PR detection (e.g. "pr/42")
 _CODEBUILD_PR_TRIGGER_PREFIX: str = "pr/"
 
+# Sentinel values for CI platform detection env vars
+_ENV_SENTINEL_TRUE_LOWERCASE: str = "true"
+_ENV_SENTINEL_TRUE_TITLECASE: str = "True"
+
 
 # ---------------------------------------------------------------------------
 # Public types
@@ -128,13 +132,13 @@ def detect_platform() -> CIPlatform:
     Checks well-known platform sentinel variables in order of specificity.
     Returns ``CIPlatform.UNKNOWN`` when none of the known sentinels are set.
     """
-    if os.environ.get(_ENV_GITHUB_ACTIONS) == "true":
+    if os.environ.get(_ENV_GITHUB_ACTIONS) == _ENV_SENTINEL_TRUE_LOWERCASE:
         return CIPlatform.GITHUB_ACTIONS
-    if os.environ.get(_ENV_GITLAB_CI) == "true":
+    if os.environ.get(_ENV_GITLAB_CI) == _ENV_SENTINEL_TRUE_LOWERCASE:
         return CIPlatform.GITLAB_CI
-    if os.environ.get(_ENV_TF_BUILD) == "True":
+    if os.environ.get(_ENV_TF_BUILD) == _ENV_SENTINEL_TRUE_TITLECASE:
         return CIPlatform.AZURE_DEVOPS
-    if os.environ.get(_ENV_CIRCLECI) == "true":
+    if os.environ.get(_ENV_CIRCLECI) == _ENV_SENTINEL_TRUE_LOWERCASE:
         return CIPlatform.CIRCLECI
     if os.environ.get(_ENV_BITBUCKET_BUILD_NUMBER):
         return CIPlatform.BITBUCKET
@@ -161,29 +165,32 @@ def get_pr_context() -> PRContext:
 # ---------------------------------------------------------------------------
 
 
-def read_env_variable(name: str) -> str | None:
+def fetch_env_variable(name: str) -> str | None:
     """Return the environment variable value, or None if unset or empty."""
     env_value = os.environ.get(name, "").strip()
     return env_value if env_value else None
 
 
 def _extract_github_pr_number(ref: str) -> str | None:
-    if ref.startswith(_GITHUB_PR_REF_PREFIX):
-        return ref.split("/")[_GITHUB_PR_REF_NUMBER_INDEX]
-    return None
+    if not ref.startswith(_GITHUB_PR_REF_PREFIX):
+        return None
+    ref_segments = ref.split("/")
+    if len(ref_segments) <= _GITHUB_PR_REF_NUMBER_INDEX:
+        return None
+    return ref_segments[_GITHUB_PR_REF_NUMBER_INDEX]
 
 
 def _build_github_context() -> PRContext:
-    pr_number = read_env_variable(_ENV_PR_NUMBER)
+    pr_number = fetch_env_variable(_ENV_PR_NUMBER)
     if not pr_number:
-        ref = read_env_variable(_ENV_GITHUB_REF) or ""
+        ref = fetch_env_variable(_ENV_GITHUB_REF) or ""
         pr_number = _extract_github_pr_number(ref)
     return PRContext(
         platform=CIPlatform.GITHUB_ACTIONS,
         pr_number=pr_number,
-        repository=read_env_variable(_ENV_GITHUB_REPOSITORY),
-        sha=read_env_variable(_ENV_GITHUB_SHA),
-        branch=read_env_variable(_ENV_GITHUB_REF),
+        repository=fetch_env_variable(_ENV_GITHUB_REPOSITORY),
+        sha=fetch_env_variable(_ENV_GITHUB_SHA),
+        branch=fetch_env_variable(_ENV_GITHUB_REF),
         base_branch=None,
     )
 
@@ -191,13 +198,13 @@ def _build_github_context() -> PRContext:
 def _build_gitlab_context() -> PRContext:
     return PRContext(
         platform=CIPlatform.GITLAB_CI,
-        pr_number=read_env_variable(_ENV_CI_MERGE_REQUEST_IID),
-        repository=read_env_variable(_ENV_CI_PROJECT_ID),
-        sha=read_env_variable(_ENV_CI_COMMIT_SHA),
-        branch=read_env_variable(_ENV_CI_COMMIT_REF_NAME),
+        pr_number=fetch_env_variable(_ENV_CI_MERGE_REQUEST_IID),
+        repository=fetch_env_variable(_ENV_CI_PROJECT_ID),
+        sha=fetch_env_variable(_ENV_CI_COMMIT_SHA),
+        branch=fetch_env_variable(_ENV_CI_COMMIT_REF_NAME),
         base_branch=None,
         extras={
-            "ci_server_url": read_env_variable(_ENV_CI_SERVER_URL) or _GITLAB_DEFAULT_SERVER_URL,
+            "ci_server_url": fetch_env_variable(_ENV_CI_SERVER_URL) or _GITLAB_DEFAULT_SERVER_URL,
         },
     )
 
@@ -209,19 +216,19 @@ def _append_trailing_slash(uri: str) -> str:
 
 
 def _build_azure_context() -> PRContext:
-    unformatted_uri = read_env_variable(_ENV_SYSTEM_TEAMFOUNDATIONCOLLECTIONURI) or ""
+    unformatted_uri = fetch_env_variable(_ENV_SYSTEM_TEAMFOUNDATIONCOLLECTIONURI) or ""
     collection_uri = _append_trailing_slash(unformatted_uri)
     return PRContext(
         platform=CIPlatform.AZURE_DEVOPS,
-        pr_number=read_env_variable(_ENV_SYSTEM_PULLREQUEST_PULLREQUESTID),
-        repository=read_env_variable(_ENV_BUILD_REPOSITORY_ID),
-        sha=read_env_variable(_ENV_BUILD_SOURCEVERSION),
+        pr_number=fetch_env_variable(_ENV_SYSTEM_PULLREQUEST_PULLREQUESTID),
+        repository=fetch_env_variable(_ENV_BUILD_REPOSITORY_ID),
+        sha=fetch_env_variable(_ENV_BUILD_SOURCEVERSION),
         branch=None,
         base_branch=None,
         extras={
             "collection_uri": collection_uri,
-            "team_project": read_env_variable(_ENV_SYSTEM_TEAMPROJECT) or "",
-            "build_id": read_env_variable(_ENV_BUILD_BUILDID) or "",
+            "team_project": fetch_env_variable(_ENV_SYSTEM_TEAMPROJECT) or "",
+            "build_id": fetch_env_variable(_ENV_BUILD_BUILDID) or "",
         },
     )
 
@@ -237,14 +244,14 @@ def _extract_pr_number_from_url(pr_url: str) -> str | None:
 
 
 def _build_circleci_context() -> PRContext:
-    pr_url = read_env_variable(_ENV_CIRCLE_PULL_REQUEST) or ""
+    pr_url = fetch_env_variable(_ENV_CIRCLE_PULL_REQUEST) or ""
     pr_number = _extract_pr_number_from_url(pr_url)
     return PRContext(
         platform=CIPlatform.CIRCLECI,
         pr_number=pr_number,
         repository=None,
-        sha=read_env_variable(_ENV_CIRCLE_SHA1),
-        branch=read_env_variable(_ENV_CIRCLE_BRANCH),
+        sha=fetch_env_variable(_ENV_CIRCLE_SHA1),
+        branch=fetch_env_variable(_ENV_CIRCLE_BRANCH),
         base_branch=None,
         extras={"circle_pull_request_url": pr_url},
     )
@@ -253,20 +260,20 @@ def _build_circleci_context() -> PRContext:
 def _build_bitbucket_context() -> PRContext:
     return PRContext(
         platform=CIPlatform.BITBUCKET,
-        pr_number=read_env_variable(_ENV_BITBUCKET_PR_ID),
-        repository=read_env_variable(_ENV_BITBUCKET_REPO_SLUG),
-        sha=read_env_variable(_ENV_BITBUCKET_COMMIT),
+        pr_number=fetch_env_variable(_ENV_BITBUCKET_PR_ID),
+        repository=fetch_env_variable(_ENV_BITBUCKET_REPO_SLUG),
+        sha=fetch_env_variable(_ENV_BITBUCKET_COMMIT),
         branch=None,
         base_branch=None,
         extras={
-            "workspace": read_env_variable(_ENV_BITBUCKET_WORKSPACE) or "",
-            "repo_slug": read_env_variable(_ENV_BITBUCKET_REPO_SLUG) or "",
+            "workspace": fetch_env_variable(_ENV_BITBUCKET_WORKSPACE) or "",
+            "repo_slug": fetch_env_variable(_ENV_BITBUCKET_REPO_SLUG) or "",
         },
     )
 
 
 def _build_codebuild_context() -> PRContext:
-    trigger = read_env_variable(_ENV_CODEBUILD_WEBHOOK_TRIGGER) or ""
+    trigger = fetch_env_variable(_ENV_CODEBUILD_WEBHOOK_TRIGGER) or ""
     pr_number: str | None = None
     if trigger.startswith(_CODEBUILD_PR_TRIGGER_PREFIX):
         pr_number = trigger[len(_CODEBUILD_PR_TRIGGER_PREFIX) :]
@@ -274,21 +281,21 @@ def _build_codebuild_context() -> PRContext:
         platform=CIPlatform.CODEBUILD,
         pr_number=pr_number,
         repository=None,
-        sha=read_env_variable(_ENV_CODEBUILD_SOURCE_VERSION),
+        sha=fetch_env_variable(_ENV_CODEBUILD_SOURCE_VERSION),
         branch=None,
-        base_branch=read_env_variable(_ENV_CODEBUILD_WEBHOOK_BASE_REF),
+        base_branch=fetch_env_variable(_ENV_CODEBUILD_WEBHOOK_BASE_REF),
     )
 
 
 def _build_jenkins_context() -> PRContext:
     return PRContext(
         platform=CIPlatform.JENKINS,
-        pr_number=read_env_variable(_ENV_CHANGE_ID),
+        pr_number=fetch_env_variable(_ENV_CHANGE_ID),
         repository=None,
         sha=None,
         branch=None,
         base_branch=None,
-        extras={"change_url": read_env_variable(_ENV_CHANGE_URL) or ""},
+        extras={"change_url": fetch_env_variable(_ENV_CHANGE_URL) or ""},
     )
 
 

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import enum
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
+from types import MappingProxyType
 
 from phi_scan.ci._env import fetch_environment_variable
 
@@ -113,6 +114,8 @@ class PullRequestContext:
 
     Top-level fields that are unavailable on the current platform are ``None``.
     Values inside ``extras`` are always strings (empty string when absent).
+    The ``extras`` mapping is frozen via ``MappingProxyType`` to prevent
+    mutation of shared context objects between adapter calls.
     """
 
     platform: CIPlatform
@@ -121,7 +124,11 @@ class PullRequestContext:
     sha: str | None
     branch: str | None
     base_branch: str | None
-    extras: dict[str, str] = field(default_factory=dict)
+    extras: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.extras, MappingProxyType):
+            object.__setattr__(self, "extras", MappingProxyType(dict(self.extras)))
 
 
 # ---------------------------------------------------------------------------

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -16,6 +16,7 @@ __all__ = [
     "PRContext",
     "detect_platform",
     "get_pr_context",
+    "read_env_variable",
 ]
 
 # ---------------------------------------------------------------------------
@@ -73,6 +74,13 @@ _ENV_CODEBUILD_WEBHOOK_BASE_REF: str = "CODEBUILD_WEBHOOK_BASE_REF"
 # GitLab default
 _GITLAB_DEFAULT_SERVER_URL: str = "https://gitlab.com"
 
+# GitHub ref prefix for PR detection (e.g. "refs/pull/42/merge")
+_GITHUB_PR_REF_PREFIX: str = "refs/pull/"
+_GITHUB_PR_REF_NUMBER_INDEX: int = 2
+
+# CodeBuild webhook trigger prefix for PR detection (e.g. "pr/42")
+_CODEBUILD_PR_TRIGGER_PREFIX: str = "pr/"
+
 
 # ---------------------------------------------------------------------------
 # Public types
@@ -120,21 +128,19 @@ def detect_platform() -> CIPlatform:
     Checks well-known platform sentinel variables in order of specificity.
     Returns ``CIPlatform.UNKNOWN`` when none of the known sentinels are set.
     """
-    env_get = os.environ.get
-
-    if env_get(_ENV_GITHUB_ACTIONS) == "true":
+    if os.environ.get(_ENV_GITHUB_ACTIONS) == "true":
         return CIPlatform.GITHUB_ACTIONS
-    if env_get(_ENV_GITLAB_CI) == "true":
+    if os.environ.get(_ENV_GITLAB_CI) == "true":
         return CIPlatform.GITLAB_CI
-    if env_get(_ENV_TF_BUILD) == "True":
+    if os.environ.get(_ENV_TF_BUILD) == "True":
         return CIPlatform.AZURE_DEVOPS
-    if env_get(_ENV_CIRCLECI) == "true":
+    if os.environ.get(_ENV_CIRCLECI) == "true":
         return CIPlatform.CIRCLECI
-    if env_get(_ENV_BITBUCKET_BUILD_NUMBER):
+    if os.environ.get(_ENV_BITBUCKET_BUILD_NUMBER):
         return CIPlatform.BITBUCKET
-    if env_get(_ENV_CODEBUILD_BUILD_ID):
+    if os.environ.get(_ENV_CODEBUILD_BUILD_ID):
         return CIPlatform.CODEBUILD
-    if env_get(_ENV_JENKINS_URL):
+    if os.environ.get(_ENV_JENKINS_URL):
         return CIPlatform.JENKINS
     return CIPlatform.UNKNOWN
 
@@ -155,18 +161,21 @@ def get_pr_context() -> PRContext:
 # ---------------------------------------------------------------------------
 
 
-def _env(name: str) -> str | None:
+def read_env_variable(name: str) -> str | None:
     """Return the environment variable value, or None if unset or empty."""
     env_value = os.environ.get(name, "").strip()
     return env_value if env_value else None
+
+
+_env = read_env_variable
 
 
 def _build_github_context() -> PRContext:
     pr_number = _env(_ENV_PR_NUMBER)
     if not pr_number:
         ref = _env(_ENV_GITHUB_REF) or ""
-        if ref.startswith("refs/pull/"):
-            pr_number = ref.split("/")[2]
+        if ref.startswith(_GITHUB_PR_REF_PREFIX):
+            pr_number = ref.split("/")[_GITHUB_PR_REF_NUMBER_INDEX]
     return PRContext(
         platform=CIPlatform.GITHUB_ACTIONS,
         pr_number=pr_number,
@@ -191,10 +200,14 @@ def _build_gitlab_context() -> PRContext:
     )
 
 
+def _normalize_trailing_slash(uri: str) -> str:
+    if uri and not uri.endswith("/"):
+        return uri + "/"
+    return uri
+
+
 def _build_azure_context() -> PRContext:
-    collection_uri = _env(_ENV_SYSTEM_TEAMFOUNDATIONCOLLECTIONURI) or ""
-    if collection_uri and not collection_uri.endswith("/"):
-        collection_uri += "/"
+    collection_uri = _normalize_trailing_slash(_env(_ENV_SYSTEM_TEAMFOUNDATIONCOLLECTIONURI) or "")
     return PRContext(
         platform=CIPlatform.AZURE_DEVOPS,
         pr_number=_env(_ENV_SYSTEM_PULLREQUEST_PULLREQUESTID),
@@ -248,8 +261,8 @@ def _build_bitbucket_context() -> PRContext:
 def _build_codebuild_context() -> PRContext:
     trigger = _env(_ENV_CODEBUILD_WEBHOOK_TRIGGER) or ""
     pr_number: str | None = None
-    if trigger.startswith("pr/"):
-        pr_number = trigger[3:]
+    if trigger.startswith(_CODEBUILD_PR_TRIGGER_PREFIX):
+        pr_number = trigger[len(_CODEBUILD_PR_TRIGGER_PREFIX) :]
     return PRContext(
         platform=CIPlatform.CODEBUILD,
         pr_number=pr_number,

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -230,8 +230,8 @@ def _extract_pr_number_from_url(pr_url: str) -> str | None:
     url_segments = pr_url.rstrip("/").split("/")
     if not url_segments:
         return None
-    pr_number_candidate = url_segments[-1]
-    return pr_number_candidate if pr_number_candidate.isdigit() else None
+    last_url_segment = url_segments[-1]
+    return last_url_segment if last_url_segment.isdigit() else None
 
 
 def _build_circleci_context() -> PRContext:
@@ -312,6 +312,7 @@ _PLATFORM_CONTEXT_BUILDERS: dict[CIPlatform, Callable[[], PRContext]] = {
     CIPlatform.BITBUCKET: _build_bitbucket_context,
     CIPlatform.CODEBUILD: _build_codebuild_context,
     CIPlatform.JENKINS: _build_jenkins_context,
+    CIPlatform.UNKNOWN: _build_unknown_context,
 }
 
 
@@ -322,5 +323,5 @@ def get_pr_context() -> PRContext:
     repository, commit SHA, and branch.
     """
     platform = detect_platform()
-    builder = _PLATFORM_CONTEXT_BUILDERS.get(platform, _build_unknown_context)
+    builder = _PLATFORM_CONTEXT_BUILDERS[platform]
     return builder()

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -15,7 +15,6 @@ __all__ = [
     "CIPlatform",
     "PRContext",
     "detect_platform",
-    "fetch_environment_variable",
     "get_pr_context",
 ]
 
@@ -239,8 +238,8 @@ def _extract_pr_number_from_url(pr_url: str) -> str | None:
 
 
 def _build_circleci_context() -> PRContext:
-    pr_url = fetch_environment_variable(_ENV_CIRCLE_PULL_REQUEST) or ""
-    pr_number = _extract_pr_number_from_url(pr_url)
+    circle_pr_url = fetch_environment_variable(_ENV_CIRCLE_PULL_REQUEST) or ""
+    pr_number = _extract_pr_number_from_url(circle_pr_url)
     return PRContext(
         platform=CIPlatform.CIRCLECI,
         pr_number=pr_number,
@@ -248,7 +247,7 @@ def _build_circleci_context() -> PRContext:
         sha=fetch_environment_variable(_ENV_CIRCLE_SHA1),
         branch=fetch_environment_variable(_ENV_CIRCLE_BRANCH),
         base_branch=None,
-        extras={"circle_pull_request_url": pr_url},
+        extras={"circle_pull_request_url": circle_pr_url},
     )
 
 
@@ -268,10 +267,10 @@ def _build_bitbucket_context() -> PRContext:
 
 
 def _build_codebuild_context() -> PRContext:
-    trigger = fetch_environment_variable(_ENV_CODEBUILD_WEBHOOK_TRIGGER) or ""
+    webhook_trigger = fetch_environment_variable(_ENV_CODEBUILD_WEBHOOK_TRIGGER) or ""
     pr_number: str | None = None
-    if trigger.startswith(_CODEBUILD_PR_TRIGGER_PREFIX):
-        pr_number = trigger[len(_CODEBUILD_PR_TRIGGER_PREFIX) :]
+    if webhook_trigger.startswith(_CODEBUILD_PR_TRIGGER_PREFIX):
+        pr_number = webhook_trigger[len(_CODEBUILD_PR_TRIGGER_PREFIX) :]
     return PRContext(
         platform=CIPlatform.CODEBUILD,
         pr_number=pr_number,

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -167,21 +167,18 @@ def read_env_variable(name: str) -> str | None:
     return env_value if env_value else None
 
 
-_env = read_env_variable
-
-
 def _build_github_context() -> PRContext:
-    pr_number = _env(_ENV_PR_NUMBER)
+    pr_number = read_env_variable(_ENV_PR_NUMBER)
     if not pr_number:
-        ref = _env(_ENV_GITHUB_REF) or ""
+        ref = read_env_variable(_ENV_GITHUB_REF) or ""
         if ref.startswith(_GITHUB_PR_REF_PREFIX):
             pr_number = ref.split("/")[_GITHUB_PR_REF_NUMBER_INDEX]
     return PRContext(
         platform=CIPlatform.GITHUB_ACTIONS,
         pr_number=pr_number,
-        repository=_env(_ENV_GITHUB_REPOSITORY),
-        sha=_env(_ENV_GITHUB_SHA),
-        branch=_env(_ENV_GITHUB_REF),
+        repository=read_env_variable(_ENV_GITHUB_REPOSITORY),
+        sha=read_env_variable(_ENV_GITHUB_SHA),
+        branch=read_env_variable(_ENV_GITHUB_REF),
         base_branch=None,
     )
 
@@ -189,13 +186,13 @@ def _build_github_context() -> PRContext:
 def _build_gitlab_context() -> PRContext:
     return PRContext(
         platform=CIPlatform.GITLAB_CI,
-        pr_number=_env(_ENV_CI_MERGE_REQUEST_IID),
-        repository=_env(_ENV_CI_PROJECT_ID),
-        sha=_env(_ENV_CI_COMMIT_SHA),
-        branch=_env(_ENV_CI_COMMIT_REF_NAME),
+        pr_number=read_env_variable(_ENV_CI_MERGE_REQUEST_IID),
+        repository=read_env_variable(_ENV_CI_PROJECT_ID),
+        sha=read_env_variable(_ENV_CI_COMMIT_SHA),
+        branch=read_env_variable(_ENV_CI_COMMIT_REF_NAME),
         base_branch=None,
         extras={
-            "ci_server_url": _env(_ENV_CI_SERVER_URL) or _GITLAB_DEFAULT_SERVER_URL,
+            "ci_server_url": read_env_variable(_ENV_CI_SERVER_URL) or _GITLAB_DEFAULT_SERVER_URL,
         },
     )
 
@@ -207,24 +204,25 @@ def _normalize_trailing_slash(uri: str) -> str:
 
 
 def _build_azure_context() -> PRContext:
-    collection_uri = _normalize_trailing_slash(_env(_ENV_SYSTEM_TEAMFOUNDATIONCOLLECTIONURI) or "")
+    raw_uri = read_env_variable(_ENV_SYSTEM_TEAMFOUNDATIONCOLLECTIONURI) or ""
+    collection_uri = _normalize_trailing_slash(raw_uri)
     return PRContext(
         platform=CIPlatform.AZURE_DEVOPS,
-        pr_number=_env(_ENV_SYSTEM_PULLREQUEST_PULLREQUESTID),
-        repository=_env(_ENV_BUILD_REPOSITORY_ID),
-        sha=_env(_ENV_BUILD_SOURCEVERSION),
+        pr_number=read_env_variable(_ENV_SYSTEM_PULLREQUEST_PULLREQUESTID),
+        repository=read_env_variable(_ENV_BUILD_REPOSITORY_ID),
+        sha=read_env_variable(_ENV_BUILD_SOURCEVERSION),
         branch=None,
         base_branch=None,
         extras={
             "collection_uri": collection_uri,
-            "team_project": _env(_ENV_SYSTEM_TEAMPROJECT) or "",
-            "build_id": _env(_ENV_BUILD_BUILDID) or "",
+            "team_project": read_env_variable(_ENV_SYSTEM_TEAMPROJECT) or "",
+            "build_id": read_env_variable(_ENV_BUILD_BUILDID) or "",
         },
     )
 
 
 def _build_circleci_context() -> PRContext:
-    pr_url = _env(_ENV_CIRCLE_PULL_REQUEST) or ""
+    pr_url = read_env_variable(_ENV_CIRCLE_PULL_REQUEST) or ""
     pr_number: str | None = None
     if pr_url:
         parts = pr_url.rstrip("/").split("/")
@@ -236,8 +234,8 @@ def _build_circleci_context() -> PRContext:
         platform=CIPlatform.CIRCLECI,
         pr_number=pr_number,
         repository=None,
-        sha=_env(_ENV_CIRCLE_SHA1),
-        branch=_env(_ENV_CIRCLE_BRANCH),
+        sha=read_env_variable(_ENV_CIRCLE_SHA1),
+        branch=read_env_variable(_ENV_CIRCLE_BRANCH),
         base_branch=None,
         extras={"circle_pull_request_url": pr_url},
     )
@@ -246,20 +244,20 @@ def _build_circleci_context() -> PRContext:
 def _build_bitbucket_context() -> PRContext:
     return PRContext(
         platform=CIPlatform.BITBUCKET,
-        pr_number=_env(_ENV_BITBUCKET_PR_ID),
-        repository=_env(_ENV_BITBUCKET_REPO_SLUG),
-        sha=_env(_ENV_BITBUCKET_COMMIT),
+        pr_number=read_env_variable(_ENV_BITBUCKET_PR_ID),
+        repository=read_env_variable(_ENV_BITBUCKET_REPO_SLUG),
+        sha=read_env_variable(_ENV_BITBUCKET_COMMIT),
         branch=None,
         base_branch=None,
         extras={
-            "workspace": _env(_ENV_BITBUCKET_WORKSPACE) or "",
-            "repo_slug": _env(_ENV_BITBUCKET_REPO_SLUG) or "",
+            "workspace": read_env_variable(_ENV_BITBUCKET_WORKSPACE) or "",
+            "repo_slug": read_env_variable(_ENV_BITBUCKET_REPO_SLUG) or "",
         },
     )
 
 
 def _build_codebuild_context() -> PRContext:
-    trigger = _env(_ENV_CODEBUILD_WEBHOOK_TRIGGER) or ""
+    trigger = read_env_variable(_ENV_CODEBUILD_WEBHOOK_TRIGGER) or ""
     pr_number: str | None = None
     if trigger.startswith(_CODEBUILD_PR_TRIGGER_PREFIX):
         pr_number = trigger[len(_CODEBUILD_PR_TRIGGER_PREFIX) :]
@@ -267,21 +265,21 @@ def _build_codebuild_context() -> PRContext:
         platform=CIPlatform.CODEBUILD,
         pr_number=pr_number,
         repository=None,
-        sha=_env(_ENV_CODEBUILD_SOURCE_VERSION),
+        sha=read_env_variable(_ENV_CODEBUILD_SOURCE_VERSION),
         branch=None,
-        base_branch=_env(_ENV_CODEBUILD_WEBHOOK_BASE_REF),
+        base_branch=read_env_variable(_ENV_CODEBUILD_WEBHOOK_BASE_REF),
     )
 
 
 def _build_jenkins_context() -> PRContext:
     return PRContext(
         platform=CIPlatform.JENKINS,
-        pr_number=_env(_ENV_CHANGE_ID),
+        pr_number=read_env_variable(_ENV_CHANGE_ID),
         repository=None,
         sha=None,
         branch=None,
         base_branch=None,
-        extras={"change_url": _env(_ENV_CHANGE_URL) or ""},
+        extras={"change_url": read_env_variable(_ENV_CHANGE_URL) or ""},
     )
 
 

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -82,6 +82,7 @@ _GITHUB_PR_REF_NUMBER_INDEX: int = 2
 # CodeBuild webhook trigger prefix for PR detection (e.g. "pr/42")
 _CODEBUILD_PR_TRIGGER_PREFIX: str = "pr/"
 _URL_LAST_SEGMENT_INDEX: int = -1
+_URL_PATH_SEPARATOR: str = "/"
 
 # Sentinel values for CI platform detection env vars
 _CI_ENV_SENTINEL_TRUE: str = "true"
@@ -201,8 +202,8 @@ def _build_gitlab_context() -> PRContext:
 
 
 def _normalise_collection_url(collection_url: str) -> str:
-    if collection_url and not collection_url.endswith("/"):
-        return collection_url + "/"
+    if collection_url and not collection_url.endswith(_URL_PATH_SEPARATOR):
+        return collection_url + _URL_PATH_SEPARATOR
     return collection_url
 
 

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -16,7 +16,7 @@ __all__ = [
     "PRContext",
     "detect_platform",
     "get_pr_context",
-    "fetch_env_variable",
+    "fetch_environment_variable",
 ]
 
 # ---------------------------------------------------------------------------
@@ -149,23 +149,12 @@ def detect_platform() -> CIPlatform:
     return CIPlatform.UNKNOWN
 
 
-def get_pr_context() -> PRContext:
-    """Build a ``PRContext`` from the current environment.
-
-    Reads platform-specific environment variables to extract the PR number,
-    repository, commit SHA, and branch.
-    """
-    platform = detect_platform()
-    builder = _PLATFORM_CONTEXT_BUILDERS.get(platform, _build_unknown_context)
-    return builder()
-
-
 # ---------------------------------------------------------------------------
 # Context builders — one per platform
 # ---------------------------------------------------------------------------
 
 
-def fetch_env_variable(name: str) -> str | None:
+def fetch_environment_variable(name: str) -> str | None:
     """Return the environment variable value, or None if unset or empty."""
     env_value = os.environ.get(name, "").strip()
     return env_value if env_value else None
@@ -181,16 +170,16 @@ def _extract_github_pr_number(ref: str) -> str | None:
 
 
 def _build_github_context() -> PRContext:
-    pr_number = fetch_env_variable(_ENV_PR_NUMBER)
+    pr_number = fetch_environment_variable(_ENV_PR_NUMBER)
     if not pr_number:
-        ref = fetch_env_variable(_ENV_GITHUB_REF) or ""
+        ref = fetch_environment_variable(_ENV_GITHUB_REF) or ""
         pr_number = _extract_github_pr_number(ref)
     return PRContext(
         platform=CIPlatform.GITHUB_ACTIONS,
         pr_number=pr_number,
-        repository=fetch_env_variable(_ENV_GITHUB_REPOSITORY),
-        sha=fetch_env_variable(_ENV_GITHUB_SHA),
-        branch=fetch_env_variable(_ENV_GITHUB_REF),
+        repository=fetch_environment_variable(_ENV_GITHUB_REPOSITORY),
+        sha=fetch_environment_variable(_ENV_GITHUB_SHA),
+        branch=fetch_environment_variable(_ENV_GITHUB_REF),
         base_branch=None,
     )
 
@@ -198,13 +187,15 @@ def _build_github_context() -> PRContext:
 def _build_gitlab_context() -> PRContext:
     return PRContext(
         platform=CIPlatform.GITLAB_CI,
-        pr_number=fetch_env_variable(_ENV_CI_MERGE_REQUEST_IID),
-        repository=fetch_env_variable(_ENV_CI_PROJECT_ID),
-        sha=fetch_env_variable(_ENV_CI_COMMIT_SHA),
-        branch=fetch_env_variable(_ENV_CI_COMMIT_REF_NAME),
+        pr_number=fetch_environment_variable(_ENV_CI_MERGE_REQUEST_IID),
+        repository=fetch_environment_variable(_ENV_CI_PROJECT_ID),
+        sha=fetch_environment_variable(_ENV_CI_COMMIT_SHA),
+        branch=fetch_environment_variable(_ENV_CI_COMMIT_REF_NAME),
         base_branch=None,
         extras={
-            "ci_server_url": fetch_env_variable(_ENV_CI_SERVER_URL) or _GITLAB_DEFAULT_SERVER_URL,
+            "ci_server_url": (
+                fetch_environment_variable(_ENV_CI_SERVER_URL) or _GITLAB_DEFAULT_SERVER_URL
+            ),
         },
     )
 
@@ -216,19 +207,19 @@ def _append_trailing_slash(uri: str) -> str:
 
 
 def _build_azure_context() -> PRContext:
-    unformatted_uri = fetch_env_variable(_ENV_SYSTEM_TEAMFOUNDATIONCOLLECTIONURI) or ""
+    unformatted_uri = fetch_environment_variable(_ENV_SYSTEM_TEAMFOUNDATIONCOLLECTIONURI) or ""
     collection_uri = _append_trailing_slash(unformatted_uri)
     return PRContext(
         platform=CIPlatform.AZURE_DEVOPS,
-        pr_number=fetch_env_variable(_ENV_SYSTEM_PULLREQUEST_PULLREQUESTID),
-        repository=fetch_env_variable(_ENV_BUILD_REPOSITORY_ID),
-        sha=fetch_env_variable(_ENV_BUILD_SOURCEVERSION),
+        pr_number=fetch_environment_variable(_ENV_SYSTEM_PULLREQUEST_PULLREQUESTID),
+        repository=fetch_environment_variable(_ENV_BUILD_REPOSITORY_ID),
+        sha=fetch_environment_variable(_ENV_BUILD_SOURCEVERSION),
         branch=None,
         base_branch=None,
         extras={
             "collection_uri": collection_uri,
-            "team_project": fetch_env_variable(_ENV_SYSTEM_TEAMPROJECT) or "",
-            "build_id": fetch_env_variable(_ENV_BUILD_BUILDID) or "",
+            "team_project": fetch_environment_variable(_ENV_SYSTEM_TEAMPROJECT) or "",
+            "build_id": fetch_environment_variable(_ENV_BUILD_BUILDID) or "",
         },
     )
 
@@ -244,14 +235,14 @@ def _extract_pr_number_from_url(pr_url: str) -> str | None:
 
 
 def _build_circleci_context() -> PRContext:
-    pr_url = fetch_env_variable(_ENV_CIRCLE_PULL_REQUEST) or ""
+    pr_url = fetch_environment_variable(_ENV_CIRCLE_PULL_REQUEST) or ""
     pr_number = _extract_pr_number_from_url(pr_url)
     return PRContext(
         platform=CIPlatform.CIRCLECI,
         pr_number=pr_number,
         repository=None,
-        sha=fetch_env_variable(_ENV_CIRCLE_SHA1),
-        branch=fetch_env_variable(_ENV_CIRCLE_BRANCH),
+        sha=fetch_environment_variable(_ENV_CIRCLE_SHA1),
+        branch=fetch_environment_variable(_ENV_CIRCLE_BRANCH),
         base_branch=None,
         extras={"circle_pull_request_url": pr_url},
     )
@@ -260,20 +251,20 @@ def _build_circleci_context() -> PRContext:
 def _build_bitbucket_context() -> PRContext:
     return PRContext(
         platform=CIPlatform.BITBUCKET,
-        pr_number=fetch_env_variable(_ENV_BITBUCKET_PR_ID),
-        repository=fetch_env_variable(_ENV_BITBUCKET_REPO_SLUG),
-        sha=fetch_env_variable(_ENV_BITBUCKET_COMMIT),
+        pr_number=fetch_environment_variable(_ENV_BITBUCKET_PR_ID),
+        repository=fetch_environment_variable(_ENV_BITBUCKET_REPO_SLUG),
+        sha=fetch_environment_variable(_ENV_BITBUCKET_COMMIT),
         branch=None,
         base_branch=None,
         extras={
-            "workspace": fetch_env_variable(_ENV_BITBUCKET_WORKSPACE) or "",
-            "repo_slug": fetch_env_variable(_ENV_BITBUCKET_REPO_SLUG) or "",
+            "workspace": fetch_environment_variable(_ENV_BITBUCKET_WORKSPACE) or "",
+            "repo_slug": fetch_environment_variable(_ENV_BITBUCKET_REPO_SLUG) or "",
         },
     )
 
 
 def _build_codebuild_context() -> PRContext:
-    trigger = fetch_env_variable(_ENV_CODEBUILD_WEBHOOK_TRIGGER) or ""
+    trigger = fetch_environment_variable(_ENV_CODEBUILD_WEBHOOK_TRIGGER) or ""
     pr_number: str | None = None
     if trigger.startswith(_CODEBUILD_PR_TRIGGER_PREFIX):
         pr_number = trigger[len(_CODEBUILD_PR_TRIGGER_PREFIX) :]
@@ -281,21 +272,21 @@ def _build_codebuild_context() -> PRContext:
         platform=CIPlatform.CODEBUILD,
         pr_number=pr_number,
         repository=None,
-        sha=fetch_env_variable(_ENV_CODEBUILD_SOURCE_VERSION),
+        sha=fetch_environment_variable(_ENV_CODEBUILD_SOURCE_VERSION),
         branch=None,
-        base_branch=fetch_env_variable(_ENV_CODEBUILD_WEBHOOK_BASE_REF),
+        base_branch=fetch_environment_variable(_ENV_CODEBUILD_WEBHOOK_BASE_REF),
     )
 
 
 def _build_jenkins_context() -> PRContext:
     return PRContext(
         platform=CIPlatform.JENKINS,
-        pr_number=fetch_env_variable(_ENV_CHANGE_ID),
+        pr_number=fetch_environment_variable(_ENV_CHANGE_ID),
         repository=None,
         sha=None,
         branch=None,
         base_branch=None,
-        extras={"change_url": fetch_env_variable(_ENV_CHANGE_URL) or ""},
+        extras={"change_url": fetch_environment_variable(_ENV_CHANGE_URL) or ""},
     )
 
 
@@ -319,3 +310,14 @@ _PLATFORM_CONTEXT_BUILDERS: dict[CIPlatform, Callable[[], PRContext]] = {
     CIPlatform.CODEBUILD: _build_codebuild_context,
     CIPlatform.JENKINS: _build_jenkins_context,
 }
+
+
+def get_pr_context() -> PRContext:
+    """Build a ``PRContext`` from the current environment.
+
+    Reads platform-specific environment variables to extract the PR number,
+    repository, commit SHA, and branch.
+    """
+    platform = detect_platform()
+    builder = _PLATFORM_CONTEXT_BUILDERS.get(platform, _build_unknown_context)
+    return builder()

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -84,6 +84,7 @@ _CODEBUILD_PR_TRIGGER_PREFIX: str = "pr/"
 _URL_PATH_SEPARATOR: str = "/"
 
 # Sentinel values for CI platform detection env vars
+# Azure DevOps uses "True" (capital T) while all other platforms use "true"
 _CI_ENV_SENTINEL_TRUE: str = "true"
 _AZURE_ENV_SENTINEL_TRUE: str = "True"
 

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -15,6 +15,7 @@ __all__ = [
     "CIPlatform",
     "PRContext",
     "detect_platform",
+    "fetch_environment_variable",
     "get_pr_context",
 ]
 
@@ -168,14 +169,18 @@ def _extract_github_pr_number(ref: str) -> str | None:
     return ref_segments[_GITHUB_PR_REF_NUMBER_INDEX]
 
 
+def _resolve_github_pr_number() -> str | None:
+    explicit_pr_number = fetch_environment_variable(_ENV_PR_NUMBER)
+    if explicit_pr_number:
+        return explicit_pr_number
+    ref = fetch_environment_variable(_ENV_GITHUB_REF) or ""
+    return _extract_github_pr_number(ref)
+
+
 def _build_github_context() -> PRContext:
-    pr_number = fetch_environment_variable(_ENV_PR_NUMBER)
-    if not pr_number:
-        ref = fetch_environment_variable(_ENV_GITHUB_REF) or ""
-        pr_number = _extract_github_pr_number(ref)
     return PRContext(
         platform=CIPlatform.GITHUB_ACTIONS,
-        pr_number=pr_number,
+        pr_number=_resolve_github_pr_number(),
         repository=fetch_environment_variable(_ENV_GITHUB_REPOSITORY),
         sha=fetch_environment_variable(_ENV_GITHUB_SHA),
         branch=fetch_environment_variable(_ENV_GITHUB_REF),

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -16,7 +16,6 @@ __all__ = [
     "PRContext",
     "detect_platform",
     "get_pr_context",
-    "fetch_environment_variable",
 ]
 
 # ---------------------------------------------------------------------------
@@ -82,8 +81,8 @@ _GITHUB_PR_REF_NUMBER_INDEX: int = 2
 _CODEBUILD_PR_TRIGGER_PREFIX: str = "pr/"
 
 # Sentinel values for CI platform detection env vars
-_ENV_SENTINEL_TRUE_LOWERCASE: str = "true"
-_ENV_SENTINEL_TRUE_TITLECASE: str = "True"
+_CI_ENV_SENTINEL_TRUE: str = "true"
+_AZURE_ENV_SENTINEL_TRUE: str = "True"
 
 
 # ---------------------------------------------------------------------------
@@ -108,8 +107,8 @@ class CIPlatform(enum.Enum):
 class PRContext:
     """Platform-neutral PR/MR context extracted from environment variables.
 
-    Fields that are not available on the current platform are ``None``.
-    The CLI passes this object to ``post_pr_comment`` and ``set_commit_status``.
+    Top-level fields that are unavailable on the current platform are ``None``.
+    Values inside ``extras`` are always strings (empty string when absent).
     """
 
     platform: CIPlatform
@@ -132,13 +131,13 @@ def detect_platform() -> CIPlatform:
     Checks well-known platform sentinel variables in order of specificity.
     Returns ``CIPlatform.UNKNOWN`` when none of the known sentinels are set.
     """
-    if os.environ.get(_ENV_GITHUB_ACTIONS) == _ENV_SENTINEL_TRUE_LOWERCASE:
+    if os.environ.get(_ENV_GITHUB_ACTIONS) == _CI_ENV_SENTINEL_TRUE:
         return CIPlatform.GITHUB_ACTIONS
-    if os.environ.get(_ENV_GITLAB_CI) == _ENV_SENTINEL_TRUE_LOWERCASE:
+    if os.environ.get(_ENV_GITLAB_CI) == _CI_ENV_SENTINEL_TRUE:
         return CIPlatform.GITLAB_CI
-    if os.environ.get(_ENV_TF_BUILD) == _ENV_SENTINEL_TRUE_TITLECASE:
+    if os.environ.get(_ENV_TF_BUILD) == _AZURE_ENV_SENTINEL_TRUE:
         return CIPlatform.AZURE_DEVOPS
-    if os.environ.get(_ENV_CIRCLECI) == _ENV_SENTINEL_TRUE_LOWERCASE:
+    if os.environ.get(_ENV_CIRCLECI) == _CI_ENV_SENTINEL_TRUE:
         return CIPlatform.CIRCLECI
     if os.environ.get(_ENV_BITBUCKET_BUILD_NUMBER):
         return CIPlatform.BITBUCKET

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -11,6 +11,8 @@ import os
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
+from phi_scan.ci._env import fetch_environment_variable
+
 __all__ = [
     "CIPlatform",
     "PRContext",
@@ -154,12 +156,6 @@ def detect_platform() -> CIPlatform:
 # ---------------------------------------------------------------------------
 
 
-def fetch_environment_variable(name: str) -> str | None:
-    """Return the environment variable value, or None if unset or empty."""
-    raw_env_string = os.environ.get(name, "").strip()
-    return raw_env_string if raw_env_string else None
-
-
 def _extract_github_pr_number(github_ref: str) -> str | None:
     if not github_ref.startswith(_GITHUB_PR_REF_PREFIX):
         return None
@@ -253,16 +249,17 @@ def _build_circleci_context() -> PRContext:
 
 
 def _build_bitbucket_context() -> PRContext:
+    repo_slug = fetch_environment_variable(_ENV_BITBUCKET_REPO_SLUG)
     return PRContext(
         platform=CIPlatform.BITBUCKET,
         pr_number=fetch_environment_variable(_ENV_BITBUCKET_PR_ID),
-        repository=fetch_environment_variable(_ENV_BITBUCKET_REPO_SLUG),
+        repository=repo_slug,
         sha=fetch_environment_variable(_ENV_BITBUCKET_COMMIT),
         branch=None,
         base_branch=None,
         extras={
             "workspace": fetch_environment_variable(_ENV_BITBUCKET_WORKSPACE) or "",
-            "repo_slug": fetch_environment_variable(_ENV_BITBUCKET_REPO_SLUG) or "",
+            "repo_slug": repo_slug or "",
         },
     )
 

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -249,17 +249,15 @@ def _build_circleci_context() -> PRContext:
 
 
 def _build_bitbucket_context() -> PRContext:
-    repo_slug = fetch_environment_variable(_ENV_BITBUCKET_REPO_SLUG)
     return PRContext(
         platform=CIPlatform.BITBUCKET,
         pr_number=fetch_environment_variable(_ENV_BITBUCKET_PR_ID),
-        repository=repo_slug,
+        repository=fetch_environment_variable(_ENV_BITBUCKET_REPO_SLUG),
         sha=fetch_environment_variable(_ENV_BITBUCKET_COMMIT),
         branch=None,
         base_branch=None,
         extras={
             "workspace": fetch_environment_variable(_ENV_BITBUCKET_WORKSPACE) or "",
-            "repo_slug": repo_slug or "",
         },
     )
 

--- a/phi_scan/ci/_detect.py
+++ b/phi_scan/ci/_detect.py
@@ -1,0 +1,294 @@
+"""CI/CD platform detection and PR context extraction.
+
+Auto-detects the running CI/CD platform from environment variables and
+extracts PR/MR context into a platform-neutral ``PRContext`` dataclass.
+"""
+
+from __future__ import annotations
+
+import enum
+import os
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+__all__ = [
+    "CIPlatform",
+    "PRContext",
+    "detect_platform",
+    "get_pr_context",
+]
+
+# ---------------------------------------------------------------------------
+# Environment variable names — one block per platform
+# ---------------------------------------------------------------------------
+
+# GitHub Actions
+_ENV_GITHUB_ACTIONS: str = "GITHUB_ACTIONS"
+_ENV_GITHUB_REPOSITORY: str = "GITHUB_REPOSITORY"
+_ENV_GITHUB_SHA: str = "GITHUB_SHA"
+_ENV_GITHUB_REF: str = "GITHUB_REF"
+_ENV_PR_NUMBER: str = "PR_NUMBER"
+
+# GitLab CI
+_ENV_GITLAB_CI: str = "GITLAB_CI"
+_ENV_CI_PROJECT_ID: str = "CI_PROJECT_ID"
+_ENV_CI_MERGE_REQUEST_IID: str = "CI_MERGE_REQUEST_IID"
+_ENV_CI_SERVER_URL: str = "CI_SERVER_URL"
+_ENV_CI_COMMIT_SHA: str = "CI_COMMIT_SHA"
+_ENV_CI_COMMIT_REF_NAME: str = "CI_COMMIT_REF_NAME"
+
+# Jenkins
+_ENV_JENKINS_URL: str = "JENKINS_URL"
+_ENV_CHANGE_ID: str = "CHANGE_ID"
+_ENV_CHANGE_URL: str = "CHANGE_URL"
+
+# Azure DevOps
+_ENV_TF_BUILD: str = "TF_BUILD"
+_ENV_SYSTEM_TEAMFOUNDATIONCOLLECTIONURI: str = "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI"
+_ENV_SYSTEM_TEAMPROJECT: str = "SYSTEM_TEAMPROJECT"
+_ENV_BUILD_REPOSITORY_ID: str = "BUILD_REPOSITORY_ID"
+_ENV_SYSTEM_PULLREQUEST_PULLREQUESTID: str = "SYSTEM_PULLREQUEST_PULLREQUESTID"
+_ENV_BUILD_BUILDID: str = "BUILD_BUILDID"
+_ENV_BUILD_SOURCEVERSION: str = "BUILD_SOURCEVERSION"
+
+# CircleCI
+_ENV_CIRCLECI: str = "CIRCLECI"
+_ENV_CIRCLE_PULL_REQUEST: str = "CIRCLE_PULL_REQUEST"
+_ENV_CIRCLE_SHA1: str = "CIRCLE_SHA1"
+_ENV_CIRCLE_BRANCH: str = "CIRCLE_BRANCH"
+
+# Bitbucket Pipelines
+_ENV_BITBUCKET_BUILD_NUMBER: str = "BITBUCKET_BUILD_NUMBER"
+_ENV_BITBUCKET_PR_ID: str = "BITBUCKET_PR_ID"
+_ENV_BITBUCKET_REPO_SLUG: str = "BITBUCKET_REPO_SLUG"
+_ENV_BITBUCKET_WORKSPACE: str = "BITBUCKET_WORKSPACE"
+_ENV_BITBUCKET_COMMIT: str = "BITBUCKET_COMMIT"
+
+# AWS CodeBuild
+_ENV_CODEBUILD_BUILD_ID: str = "CODEBUILD_BUILD_ID"
+_ENV_CODEBUILD_WEBHOOK_TRIGGER: str = "CODEBUILD_WEBHOOK_TRIGGER"
+_ENV_CODEBUILD_SOURCE_VERSION: str = "CODEBUILD_SOURCE_VERSION"
+_ENV_CODEBUILD_WEBHOOK_BASE_REF: str = "CODEBUILD_WEBHOOK_BASE_REF"
+
+# GitLab default
+_GITLAB_DEFAULT_SERVER_URL: str = "https://gitlab.com"
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+class CIPlatform(enum.Enum):
+    """Enumeration of supported CI/CD platforms."""
+
+    GITHUB_ACTIONS = "github_actions"
+    GITLAB_CI = "gitlab_ci"
+    JENKINS = "jenkins"
+    AZURE_DEVOPS = "azure_devops"
+    CIRCLECI = "circleci"
+    BITBUCKET = "bitbucket"
+    CODEBUILD = "codebuild"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class PRContext:
+    """Platform-neutral PR/MR context extracted from environment variables.
+
+    Fields that are not available on the current platform are ``None``.
+    The CLI passes this object to ``post_pr_comment`` and ``set_commit_status``.
+    """
+
+    platform: CIPlatform
+    pr_number: str | None
+    repository: str | None
+    sha: str | None
+    branch: str | None
+    base_branch: str | None
+    extras: dict[str, str] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Platform detection
+# ---------------------------------------------------------------------------
+
+
+def detect_platform() -> CIPlatform:
+    """Detect the currently running CI/CD platform from environment variables.
+
+    Checks well-known platform sentinel variables in order of specificity.
+    Returns ``CIPlatform.UNKNOWN`` when none of the known sentinels are set.
+    """
+    env_get = os.environ.get
+
+    if env_get(_ENV_GITHUB_ACTIONS) == "true":
+        return CIPlatform.GITHUB_ACTIONS
+    if env_get(_ENV_GITLAB_CI) == "true":
+        return CIPlatform.GITLAB_CI
+    if env_get(_ENV_TF_BUILD) == "True":
+        return CIPlatform.AZURE_DEVOPS
+    if env_get(_ENV_CIRCLECI) == "true":
+        return CIPlatform.CIRCLECI
+    if env_get(_ENV_BITBUCKET_BUILD_NUMBER):
+        return CIPlatform.BITBUCKET
+    if env_get(_ENV_CODEBUILD_BUILD_ID):
+        return CIPlatform.CODEBUILD
+    if env_get(_ENV_JENKINS_URL):
+        return CIPlatform.JENKINS
+    return CIPlatform.UNKNOWN
+
+
+def get_pr_context() -> PRContext:
+    """Build a ``PRContext`` from the current environment.
+
+    Reads platform-specific environment variables to extract the PR number,
+    repository, commit SHA, and branch.
+    """
+    platform = detect_platform()
+    builder = _PLATFORM_CONTEXT_BUILDERS.get(platform, _build_unknown_context)
+    return builder()
+
+
+# ---------------------------------------------------------------------------
+# Context builders — one per platform
+# ---------------------------------------------------------------------------
+
+
+def _env(name: str) -> str | None:
+    """Return the environment variable value, or None if unset or empty."""
+    env_value = os.environ.get(name, "").strip()
+    return env_value if env_value else None
+
+
+def _build_github_context() -> PRContext:
+    pr_number = _env(_ENV_PR_NUMBER)
+    if not pr_number:
+        ref = _env(_ENV_GITHUB_REF) or ""
+        if ref.startswith("refs/pull/"):
+            pr_number = ref.split("/")[2]
+    return PRContext(
+        platform=CIPlatform.GITHUB_ACTIONS,
+        pr_number=pr_number,
+        repository=_env(_ENV_GITHUB_REPOSITORY),
+        sha=_env(_ENV_GITHUB_SHA),
+        branch=_env(_ENV_GITHUB_REF),
+        base_branch=None,
+    )
+
+
+def _build_gitlab_context() -> PRContext:
+    return PRContext(
+        platform=CIPlatform.GITLAB_CI,
+        pr_number=_env(_ENV_CI_MERGE_REQUEST_IID),
+        repository=_env(_ENV_CI_PROJECT_ID),
+        sha=_env(_ENV_CI_COMMIT_SHA),
+        branch=_env(_ENV_CI_COMMIT_REF_NAME),
+        base_branch=None,
+        extras={
+            "ci_server_url": _env(_ENV_CI_SERVER_URL) or _GITLAB_DEFAULT_SERVER_URL,
+        },
+    )
+
+
+def _build_azure_context() -> PRContext:
+    collection_uri = _env(_ENV_SYSTEM_TEAMFOUNDATIONCOLLECTIONURI) or ""
+    if collection_uri and not collection_uri.endswith("/"):
+        collection_uri += "/"
+    return PRContext(
+        platform=CIPlatform.AZURE_DEVOPS,
+        pr_number=_env(_ENV_SYSTEM_PULLREQUEST_PULLREQUESTID),
+        repository=_env(_ENV_BUILD_REPOSITORY_ID),
+        sha=_env(_ENV_BUILD_SOURCEVERSION),
+        branch=None,
+        base_branch=None,
+        extras={
+            "collection_uri": collection_uri,
+            "team_project": _env(_ENV_SYSTEM_TEAMPROJECT) or "",
+            "build_id": _env(_ENV_BUILD_BUILDID) or "",
+        },
+    )
+
+
+def _build_circleci_context() -> PRContext:
+    pr_url = _env(_ENV_CIRCLE_PULL_REQUEST) or ""
+    pr_number: str | None = None
+    if pr_url:
+        parts = pr_url.rstrip("/").split("/")
+        if parts:
+            candidate = parts[-1]
+            if candidate.isdigit():
+                pr_number = candidate
+    return PRContext(
+        platform=CIPlatform.CIRCLECI,
+        pr_number=pr_number,
+        repository=None,
+        sha=_env(_ENV_CIRCLE_SHA1),
+        branch=_env(_ENV_CIRCLE_BRANCH),
+        base_branch=None,
+        extras={"circle_pull_request_url": pr_url},
+    )
+
+
+def _build_bitbucket_context() -> PRContext:
+    return PRContext(
+        platform=CIPlatform.BITBUCKET,
+        pr_number=_env(_ENV_BITBUCKET_PR_ID),
+        repository=_env(_ENV_BITBUCKET_REPO_SLUG),
+        sha=_env(_ENV_BITBUCKET_COMMIT),
+        branch=None,
+        base_branch=None,
+        extras={
+            "workspace": _env(_ENV_BITBUCKET_WORKSPACE) or "",
+            "repo_slug": _env(_ENV_BITBUCKET_REPO_SLUG) or "",
+        },
+    )
+
+
+def _build_codebuild_context() -> PRContext:
+    trigger = _env(_ENV_CODEBUILD_WEBHOOK_TRIGGER) or ""
+    pr_number: str | None = None
+    if trigger.startswith("pr/"):
+        pr_number = trigger[3:]
+    return PRContext(
+        platform=CIPlatform.CODEBUILD,
+        pr_number=pr_number,
+        repository=None,
+        sha=_env(_ENV_CODEBUILD_SOURCE_VERSION),
+        branch=None,
+        base_branch=_env(_ENV_CODEBUILD_WEBHOOK_BASE_REF),
+    )
+
+
+def _build_jenkins_context() -> PRContext:
+    return PRContext(
+        platform=CIPlatform.JENKINS,
+        pr_number=_env(_ENV_CHANGE_ID),
+        repository=None,
+        sha=None,
+        branch=None,
+        base_branch=None,
+        extras={"change_url": _env(_ENV_CHANGE_URL) or ""},
+    )
+
+
+def _build_unknown_context() -> PRContext:
+    return PRContext(
+        platform=CIPlatform.UNKNOWN,
+        pr_number=None,
+        repository=None,
+        sha=None,
+        branch=None,
+        base_branch=None,
+    )
+
+
+_PLATFORM_CONTEXT_BUILDERS: dict[CIPlatform, Callable[[], PRContext]] = {
+    CIPlatform.GITHUB_ACTIONS: _build_github_context,
+    CIPlatform.GITLAB_CI: _build_gitlab_context,
+    CIPlatform.AZURE_DEVOPS: _build_azure_context,
+    CIPlatform.CIRCLECI: _build_circleci_context,
+    CIPlatform.BITBUCKET: _build_bitbucket_context,
+    CIPlatform.CODEBUILD: _build_codebuild_context,
+    CIPlatform.JENKINS: _build_jenkins_context,
+}

--- a/phi_scan/ci/_env.py
+++ b/phi_scan/ci/_env.py
@@ -11,7 +11,7 @@ import os
 _ENV_DEFAULT_EMPTY: str = ""
 
 
-def fetch_environment_variable(name: str) -> str | None:
+def fetch_environment_variable(variable_name: str) -> str | None:
     """Return the environment variable value, or None if unset or empty."""
-    raw_env_string = os.environ.get(name, _ENV_DEFAULT_EMPTY).strip()
+    raw_env_string = os.environ.get(variable_name, _ENV_DEFAULT_EMPTY).strip()
     return raw_env_string if raw_env_string else None

--- a/phi_scan/ci/_env.py
+++ b/phi_scan/ci/_env.py
@@ -13,5 +13,5 @@ _UNSET_VARIABLE_FALLBACK: str = ""
 
 def fetch_environment_variable(variable_name: str) -> str | None:
     """Return the environment variable value, or None if unset or empty."""
-    raw_env_string = os.environ.get(variable_name, _UNSET_VARIABLE_FALLBACK).strip()
-    return raw_env_string if raw_env_string else None
+    stripped_variable_value = os.environ.get(variable_name, _UNSET_VARIABLE_FALLBACK).strip()
+    return stripped_variable_value if stripped_variable_value else None

--- a/phi_scan/ci/_env.py
+++ b/phi_scan/ci/_env.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 
 import os
 
-_ENV_DEFAULT_EMPTY: str = ""
+_UNSET_VARIABLE_FALLBACK: str = ""
 
 
 def fetch_environment_variable(variable_name: str) -> str | None:
     """Return the environment variable value, or None if unset or empty."""
-    raw_env_string = os.environ.get(variable_name, _ENV_DEFAULT_EMPTY).strip()
+    raw_env_string = os.environ.get(variable_name, _UNSET_VARIABLE_FALLBACK).strip()
     return raw_env_string if raw_env_string else None

--- a/phi_scan/ci/_env.py
+++ b/phi_scan/ci/_env.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 
 import os
 
+_ENV_DEFAULT_EMPTY: str = ""
+
 
 def fetch_environment_variable(name: str) -> str | None:
     """Return the environment variable value, or None if unset or empty."""
-    raw_env_string = os.environ.get(name, "").strip()
+    raw_env_string = os.environ.get(name, _ENV_DEFAULT_EMPTY).strip()
     return raw_env_string if raw_env_string else None

--- a/phi_scan/ci/_env.py
+++ b/phi_scan/ci/_env.py
@@ -13,5 +13,4 @@ _UNSET_VARIABLE_FALLBACK: str = ""
 
 def fetch_environment_variable(variable_name: str) -> str | None:
     """Return the environment variable value, or None if unset or empty."""
-    stripped_variable_value = os.environ.get(variable_name, _UNSET_VARIABLE_FALLBACK).strip()
-    return stripped_variable_value if stripped_variable_value else None
+    return os.environ.get(variable_name, _UNSET_VARIABLE_FALLBACK).strip() or None

--- a/phi_scan/ci/_env.py
+++ b/phi_scan/ci/_env.py
@@ -1,0 +1,15 @@
+"""Environment variable access for CI/CD adapters.
+
+Provides a safe accessor that returns ``None`` for unset or empty
+variables, used by both platform detection and adapter auth lookups.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def fetch_environment_variable(name: str) -> str | None:
+    """Return the environment variable value, or None if unset or empty."""
+    raw_env_string = os.environ.get(name, "").strip()
+    return raw_env_string if raw_env_string else None

--- a/phi_scan/ci/_env.py
+++ b/phi_scan/ci/_env.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 
 import os
 
-_UNSET_VARIABLE_FALLBACK: str = ""
-
 
 def fetch_environment_variable(variable_name: str) -> str | None:
     """Return the environment variable value, or None if unset or empty."""
-    return os.environ.get(variable_name, _UNSET_VARIABLE_FALLBACK).strip() or None
+    return os.environ.get(variable_name, "").strip() or None

--- a/phi_scan/ci/_transport.py
+++ b/phi_scan/ci/_transport.py
@@ -34,6 +34,8 @@ __all__ = [
 ]
 
 _HTTP_TIMEOUT_SECONDS: float = 15.0
+_HTTP_STATUS_ERROR_TEMPLATE: str = "{operation} failed (HTTP {status_code})"
+_NETWORK_ERROR_TEMPLATE: str = "{operation} request failed (network error)"
 
 
 class HttpMethod(enum.StrEnum):
@@ -117,10 +119,13 @@ def execute_http_request(request_config: HttpRequestConfig) -> httpx.Response:
         response.raise_for_status()
     except httpx.HTTPStatusError as status_error:
         raise CIIntegrationError(
-            f"{request_config.operation_label} failed (HTTP {status_error.response.status_code})"
+            _HTTP_STATUS_ERROR_TEMPLATE.format(
+                operation=request_config.operation_label,
+                status_code=status_error.response.status_code,
+            )
         ) from status_error
     except httpx.RequestError as request_error:
         raise CIIntegrationError(
-            f"{request_config.operation_label} request failed (network error)"
+            _NETWORK_ERROR_TEMPLATE.format(operation=request_config.operation_label)
         ) from request_error
     return response

--- a/phi_scan/ci/_transport.py
+++ b/phi_scan/ci/_transport.py
@@ -121,6 +121,6 @@ def execute_http_request(request_config: HttpRequestConfig) -> httpx.Response:
         ) from status_error
     except httpx.RequestError as request_error:
         raise CIIntegrationError(
-            f"{request_config.operation_label} request failed: {type(request_error).__name__}"
+            f"{request_config.operation_label} request failed (network error)"
         ) from request_error
     return response

--- a/phi_scan/ci/_transport.py
+++ b/phi_scan/ci/_transport.py
@@ -5,7 +5,9 @@ across all platform adapters goes through a single code path with
 consistent error wrapping, timeout handling, and PHI-safety guarantees.
 
 Security contract:
-  - Error messages include only the HTTP status code and reason phrase.
+  - Error messages include only the numeric HTTP status code.
+  - Reason phrases are excluded — proxies and WAFs can echo request
+    fragments in non-standard reason phrases.
   - Response bodies are never included in error messages — API error
     responses for comment endpoints could echo back request content
     containing finding metadata.
@@ -93,9 +95,7 @@ def execute_http_request(request_config: HttpRequestConfig) -> httpx.Response:
         response.raise_for_status()
     except httpx.HTTPStatusError as status_error:
         raise CIIntegrationError(
-            f"{request_config.operation_label} failed "
-            f"(HTTP {status_error.response.status_code} "
-            f"{status_error.response.reason_phrase})"
+            f"{request_config.operation_label} failed (HTTP {status_error.response.status_code})"
         ) from status_error
     except httpx.RequestError as request_error:
         raise CIIntegrationError(

--- a/phi_scan/ci/_transport.py
+++ b/phi_scan/ci/_transport.py
@@ -9,6 +9,9 @@ Security contract:
   - Response bodies are never included in error messages — API error
     responses for comment endpoints could echo back request content
     containing finding metadata.
+  - ``operation_label`` propagates into exception messages and logs.
+    Callers must use static string literals only — never interpolate
+    PR content, file paths, or finding metadata into the label.
 """
 
 from __future__ import annotations
@@ -43,6 +46,10 @@ class HttpRequestConfig:
 
     Bundles all variable parts of the request so that
     ``execute_http_request`` can centralise the try/except scaffolding.
+
+    ``operation_label`` appears in error messages and logs — use only
+    static string literals (e.g. ``"GitHub commit status"``), never
+    interpolated PR content, file paths, or finding metadata.
     """
 
     method: HttpMethod

--- a/phi_scan/ci/_transport.py
+++ b/phi_scan/ci/_transport.py
@@ -55,17 +55,17 @@ class HttpRequestConfig:
     timeout_seconds: float = _HTTP_TIMEOUT_SECONDS
 
 
-def _build_request_keyword_arguments(request_config: HttpRequestConfig) -> dict[str, Any]:
-    request_keyword_arguments: dict[str, Any] = {"timeout": request_config.timeout_seconds}
+def _assemble_request_options(request_config: HttpRequestConfig) -> dict[str, Any]:
+    options: dict[str, Any] = {"timeout": request_config.timeout_seconds}
     if request_config.headers is not None:
-        request_keyword_arguments["headers"] = request_config.headers
+        options["headers"] = request_config.headers
     if request_config.json_body is not None:
-        request_keyword_arguments["json"] = request_config.json_body
+        options["json"] = request_config.json_body
     if request_config.binary_body is not None:
-        request_keyword_arguments["content"] = request_config.binary_body
+        options["content"] = request_config.binary_body
     if request_config.auth is not None:
-        request_keyword_arguments["auth"] = request_config.auth
-    return request_keyword_arguments
+        options["auth"] = request_config.auth
+    return options
 
 
 def execute_http_request(request_config: HttpRequestConfig) -> httpx.Response:
@@ -80,11 +80,9 @@ def execute_http_request(request_config: HttpRequestConfig) -> httpx.Response:
     Raises:
         CIIntegrationError: On HTTP 4xx/5xx or any network error.
     """
-    request_keyword_arguments = _build_request_keyword_arguments(request_config)
+    options = _assemble_request_options(request_config)
     try:
-        response = httpx.request(
-            request_config.method, request_config.url, **request_keyword_arguments
-        )
+        response = httpx.request(request_config.method, request_config.url, **options)
         response.raise_for_status()
     except httpx.HTTPStatusError as status_error:
         raise CIIntegrationError(
@@ -94,6 +92,6 @@ def execute_http_request(request_config: HttpRequestConfig) -> httpx.Response:
         ) from status_error
     except httpx.RequestError as request_error:
         raise CIIntegrationError(
-            f"{request_config.operation_label} request failed: {request_error}"
+            f"{request_config.operation_label} request failed: {type(request_error).__name__}"
         ) from request_error
     return response

--- a/phi_scan/ci/_transport.py
+++ b/phi_scan/ci/_transport.py
@@ -12,8 +12,8 @@ Security contract:
     responses for comment endpoints could echo back request content
     containing finding metadata.
   - ``operation_label`` propagates into exception messages and logs.
-    Callers must use static string literals only — never interpolate
-    PR content, file paths, or finding metadata into the label.
+    It is typed as ``OperationLabel`` (a ``StrEnum``) so only pre-defined
+    static labels are accepted — no dynamic content can leak into errors.
 """
 
 from __future__ import annotations
@@ -29,6 +29,7 @@ from phi_scan.exceptions import CIIntegrationError
 __all__ = [
     "HttpMethod",
     "HttpRequestConfig",
+    "OperationLabel",
     "execute_http_request",
 ]
 
@@ -42,6 +43,28 @@ class HttpMethod(enum.StrEnum):
     PUT = "PUT"
 
 
+class OperationLabel(enum.StrEnum):
+    """Labels for outbound CI/CD HTTP operations.
+
+    Each member is a static string that appears in error messages and logs.
+    Using an enum enforces the security contract: callers cannot interpolate
+    PR content, file paths, or finding metadata into error messages.
+    """
+
+    GITHUB_COMMIT_STATUS = "GitHub commit status"
+    GITHUB_SARIF_UPLOAD = "GitHub SARIF upload"
+    GITLAB_MR_COMMENT = "GitLab MR comment"
+    GITLAB_COMMIT_STATUS = "GitLab commit status"
+    AZURE_PR_COMMENT = "Azure DevOps PR comment"
+    AZURE_BUILD_TAG = "Azure DevOps build tag"
+    AZURE_PR_STATUS = "Azure DevOps PR status"
+    AZURE_WORK_ITEM = "Azure Boards work item"
+    BITBUCKET_PR_COMMENT = "Bitbucket PR comment"
+    BITBUCKET_COMMIT_STATUS = "Bitbucket commit status"
+    BITBUCKET_CODE_INSIGHTS_REPORT = "Bitbucket Code Insights report"
+    BITBUCKET_CODE_INSIGHTS_ANNOTATIONS = "Bitbucket Code Insights annotations"
+
+
 @dataclass(frozen=True)
 class HttpRequestConfig:
     """Parameters for a single outbound HTTP request.
@@ -49,14 +72,13 @@ class HttpRequestConfig:
     Bundles all variable parts of the request so that
     ``execute_http_request`` can centralise the try/except scaffolding.
 
-    ``operation_label`` appears in error messages and logs — use only
-    static string literals (e.g. ``"GitHub commit status"``), never
-    interpolated PR content, file paths, or finding metadata.
+    ``operation_label`` appears in error messages and logs — typed as
+    ``OperationLabel`` to enforce that only static labels are used.
     """
 
     method: HttpMethod
     url: str
-    operation_label: str
+    operation_label: OperationLabel
     headers: dict[str, str] | None = None
     json_body: dict[str, Any] | list[Any] | None = None
     binary_body: bytes | None = None

--- a/phi_scan/ci/_transport.py
+++ b/phi_scan/ci/_transport.py
@@ -56,16 +56,16 @@ class HttpRequestConfig:
 
 
 def _assemble_request_options(request_config: HttpRequestConfig) -> dict[str, Any]:
-    options: dict[str, Any] = {"timeout": request_config.timeout_seconds}
+    request_options: dict[str, Any] = {"timeout": request_config.timeout_seconds}
     if request_config.headers is not None:
-        options["headers"] = request_config.headers
+        request_options["headers"] = request_config.headers
     if request_config.json_body is not None:
-        options["json"] = request_config.json_body
+        request_options["json"] = request_config.json_body
     if request_config.binary_body is not None:
-        options["content"] = request_config.binary_body
+        request_options["content"] = request_config.binary_body
     if request_config.auth is not None:
-        options["auth"] = request_config.auth
-    return options
+        request_options["auth"] = request_config.auth
+    return request_options
 
 
 def execute_http_request(request_config: HttpRequestConfig) -> httpx.Response:
@@ -80,9 +80,9 @@ def execute_http_request(request_config: HttpRequestConfig) -> httpx.Response:
     Raises:
         CIIntegrationError: On HTTP 4xx/5xx or any network error.
     """
-    options = _assemble_request_options(request_config)
+    request_options = _assemble_request_options(request_config)
     try:
-        response = httpx.request(request_config.method, request_config.url, **options)
+        response = httpx.request(request_config.method, request_config.url, **request_options)
         response.raise_for_status()
     except httpx.HTTPStatusError as status_error:
         raise CIIntegrationError(

--- a/phi_scan/ci/_transport.py
+++ b/phi_scan/ci/_transport.py
@@ -60,7 +60,7 @@ class HttpRequestConfig:
     headers: dict[str, str] | None = None
     json_body: dict[str, Any] | list[Any] | None = None
     binary_body: bytes | None = None
-    auth: tuple[str, str] | None = None
+    basic_auth_credentials: tuple[str, str] | None = None
     timeout_seconds: float = _HTTP_TIMEOUT_SECONDS
 
 
@@ -72,8 +72,8 @@ def _assemble_request_options(request_config: HttpRequestConfig) -> dict[str, An
         request_options["json"] = request_config.json_body
     if request_config.binary_body is not None:
         request_options["content"] = request_config.binary_body
-    if request_config.auth is not None:
-        request_options["auth"] = request_config.auth
+    if request_config.basic_auth_credentials is not None:
+        request_options["auth"] = request_config.basic_auth_credentials
     return request_options
 
 

--- a/phi_scan/ci/_transport.py
+++ b/phi_scan/ci/_transport.py
@@ -1,0 +1,99 @@
+"""Shared HTTP transport for CI/CD platform adapters.
+
+Centralises the request/error pattern so that every outbound HTTP call
+across all platform adapters goes through a single code path with
+consistent error wrapping, timeout handling, and PHI-safety guarantees.
+
+Security contract:
+  - Error messages include only the HTTP status code and reason phrase.
+  - Response bodies are never included in error messages — API error
+    responses for comment endpoints could echo back request content
+    containing finding metadata.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from phi_scan.exceptions import CIIntegrationError
+
+__all__ = [
+    "HttpMethod",
+    "HttpRequestConfig",
+    "execute_http_request",
+]
+
+_HTTP_TIMEOUT_SECONDS: float = 15.0
+
+
+class HttpMethod(enum.StrEnum):
+    """HTTP methods used by CI/CD platform API calls."""
+
+    POST = "POST"
+    PUT = "PUT"
+
+
+@dataclass(frozen=True)
+class HttpRequestConfig:
+    """Parameters for a single outbound HTTP request.
+
+    Bundles all variable parts of the request so that
+    ``execute_http_request`` can centralise the try/except scaffolding.
+    """
+
+    method: HttpMethod
+    url: str
+    operation_label: str
+    headers: dict[str, str] | None = None
+    json_body: dict[str, Any] | list[Any] | None = None
+    binary_body: bytes | None = None
+    auth: tuple[str, str] | None = None
+    timeout_seconds: float = _HTTP_TIMEOUT_SECONDS
+
+
+def _build_request_keyword_arguments(request_config: HttpRequestConfig) -> dict[str, Any]:
+    request_keyword_arguments: dict[str, Any] = {"timeout": request_config.timeout_seconds}
+    if request_config.headers is not None:
+        request_keyword_arguments["headers"] = request_config.headers
+    if request_config.json_body is not None:
+        request_keyword_arguments["json"] = request_config.json_body
+    if request_config.binary_body is not None:
+        request_keyword_arguments["content"] = request_config.binary_body
+    if request_config.auth is not None:
+        request_keyword_arguments["auth"] = request_config.auth
+    return request_keyword_arguments
+
+
+def execute_http_request(request_config: HttpRequestConfig) -> httpx.Response:
+    """Execute one HTTP request and translate httpx errors to CIIntegrationError.
+
+    Args:
+        request_config: All parameters for the HTTP call.
+
+    Returns:
+        The successful ``httpx.Response``.
+
+    Raises:
+        CIIntegrationError: On HTTP 4xx/5xx or any network error.
+    """
+    request_keyword_arguments = _build_request_keyword_arguments(request_config)
+    try:
+        response = httpx.request(
+            request_config.method, request_config.url, **request_keyword_arguments
+        )
+        response.raise_for_status()
+    except httpx.HTTPStatusError as status_error:
+        raise CIIntegrationError(
+            f"{request_config.operation_label} failed "
+            f"(HTTP {status_error.response.status_code} "
+            f"{status_error.response.reason_phrase})"
+        ) from status_error
+    except httpx.RequestError as request_error:
+        raise CIIntegrationError(
+            f"{request_config.operation_label} request failed: {request_error}"
+        ) from request_error
+    return response

--- a/phi_scan/ci/azure.py
+++ b/phi_scan/ci/azure.py
@@ -36,6 +36,18 @@ _AZURE_COMMENT_TYPE_TEXT: int = 1
 _AZURE_THREAD_STATUS_ACTIVE: str = "active"
 
 
+def _build_pr_threads_url(
+    collection_uri: str, team_project: str, repo_id: str | None, pr_id: str | None
+) -> str:
+    return _AZURE_PR_THREADS_PATH.format(
+        collection_uri=collection_uri,
+        team_project=team_project,
+        repo_id=repo_id,
+        pr_id=pr_id,
+        api_version=_AZURE_API_VERSION,
+    )
+
+
 def _build_azure_thread_payload(comment_body: str) -> dict[str, Any]:
     return {
         "comments": [
@@ -67,7 +79,7 @@ class AzureAdapter(BaseCIAdapter):
         team_project = pr_context.extras.get("team_project", "")
 
         if not all((pr_id, repo_id, collection_uri, team_project)):
-            _LOG.debug("Azure DevOps: missing PR context — skipping comment")
+            _LOG.warning("Azure DevOps: missing PR context — skipping comment")
             return
 
         token = fetch_environment_variable(_ENV_SYSTEM_ACCESSTOKEN)
@@ -78,13 +90,7 @@ class AzureAdapter(BaseCIAdapter):
             )
             return
 
-        url = _AZURE_PR_THREADS_PATH.format(
-            collection_uri=collection_uri,
-            team_project=team_project,
-            repo_id=repo_id,
-            pr_id=pr_id,
-            api_version=_AZURE_API_VERSION,
-        )
+        url = _build_pr_threads_url(collection_uri, team_project, repo_id, pr_id)
         execute_http_request(
             HttpRequestConfig(
                 method=HttpMethod.POST,

--- a/phi_scan/ci/azure.py
+++ b/phi_scan/ci/azure.py
@@ -36,14 +36,12 @@ _AZURE_COMMENT_TYPE_TEXT: int = 1
 _AZURE_THREAD_STATUS_ACTIVE: str = "active"
 
 
-def _build_pr_threads_url(
-    collection_uri: str, team_project: str, repo_id: str | None, pr_id: str | None
-) -> str:
+def _build_pr_threads_url(pr_context: PRContext) -> str:
     return _AZURE_PR_THREADS_PATH.format(
-        collection_uri=collection_uri,
-        team_project=team_project,
-        repo_id=repo_id,
-        pr_id=pr_id,
+        collection_uri=pr_context.extras.get("collection_uri", ""),
+        team_project=pr_context.extras.get("team_project", ""),
+        repo_id=pr_context.repository,
+        pr_id=pr_context.pr_number,
         api_version=_AZURE_API_VERSION,
     )
 
@@ -90,7 +88,7 @@ class AzureAdapter(BaseCIAdapter):
             )
             return
 
-        url = _build_pr_threads_url(collection_uri, team_project, repo_id, pr_id)
+        url = _build_pr_threads_url(pr_context)
         execute_http_request(
             HttpRequestConfig(
                 method=HttpMethod.POST,

--- a/phi_scan/ci/azure.py
+++ b/phi_scan/ci/azure.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 
 from phi_scan.ci._base import BaseCIAdapter
-from phi_scan.ci._detect import PRContext, read_env_variable
+from phi_scan.ci._detect import PRContext, fetch_env_variable
 from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
 from phi_scan.models import ScanResult
 
@@ -50,7 +50,7 @@ class AzureAdapter(BaseCIAdapter):
             _LOG.debug("Azure DevOps: missing PR context — skipping comment")
             return
 
-        token = read_env_variable(_ENV_SYSTEM_ACCESSTOKEN)
+        token = fetch_env_variable(_ENV_SYSTEM_ACCESSTOKEN)
         if not token:
             _LOG.warning(
                 "Azure DevOps: SYSTEM_ACCESSTOKEN not set — "
@@ -89,4 +89,4 @@ class AzureAdapter(BaseCIAdapter):
         _LOG.debug("Azure DevOps: PR thread comment posted to PR #%s", pr_id)
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        _LOG.debug("Azure DevOps: commit status not supported via adapter")
+        self._raise_unsupported("commit status")

--- a/phi_scan/ci/azure.py
+++ b/phi_scan/ci/azure.py
@@ -78,7 +78,7 @@ class AzureAdapter(BaseCIAdapter):
         return False
 
     @property
-    def can_create_work_item(self) -> bool:
+    def can_create_work_item_from_findings(self) -> bool:
         return True
 
     def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:

--- a/phi_scan/ci/azure.py
+++ b/phi_scan/ci/azure.py
@@ -19,6 +19,7 @@ from phi_scan.ci._transport import (
     OperationLabel,
     execute_http_request,
 )
+from phi_scan.exceptions import CIIntegrationError
 from phi_scan.models import ScanResult
 
 _LOG: logging.Logger = logging.getLogger(__name__)
@@ -88,16 +89,13 @@ class AzureAdapter(BaseCIAdapter):
         team_project = pr_context.extras.get("team_project", "")
 
         if not all((pr_id, repo_id, collection_uri, team_project)):
-            _LOG.warning("Azure DevOps: missing PR context — skipping comment")
-            return
+            raise CIIntegrationError(
+                "Azure DevOps: missing PR context fields required for PR comment"
+            )
 
         system_access_token = fetch_environment_variable(_ENV_SYSTEM_ACCESSTOKEN)
         if not system_access_token:
-            _LOG.warning(
-                "Azure DevOps: SYSTEM_ACCESSTOKEN not set — "
-                "enable 'Allow scripts to access the OAuth token' in pipeline settings"
-            )
-            return
+            raise CIIntegrationError("Azure DevOps: SYSTEM_ACCESSTOKEN not set")
 
         url = _build_pr_threads_url(pr_context)
         execute_http_request(

--- a/phi_scan/ci/azure.py
+++ b/phi_scan/ci/azure.py
@@ -11,7 +11,7 @@ import logging
 from typing import Any
 
 from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody, UnsupportedOperation
-from phi_scan.ci._detect import PRContext
+from phi_scan.ci._detect import PullRequestContext
 from phi_scan.ci._env import fetch_environment_variable
 from phi_scan.ci._transport import (
     HttpMethod,
@@ -29,7 +29,7 @@ _ENV_SYSTEM_ACCESSTOKEN: str = "SYSTEM_ACCESSTOKEN"
 _AZURE_API_VERSION: str = "7.1"
 _AZURE_PR_THREADS_PATH: str = (
     "{collection_uri}{team_project}/_apis/git/repositories/{repo_id}"
-    "/pullRequests/{pr_id}/threads?api-version={api_version}"
+    "/pullRequests/{pull_request_identifier}/threads?api-version={api_version}"
 )
 
 _AZURE_COMMENT_PARENT_ID_ROOT: int = 0
@@ -47,12 +47,12 @@ class _AzureThreadStatus(enum.StrEnum):
     ACTIVE = "active"
 
 
-def _build_pr_threads_url(pr_context: PRContext) -> str:
+def _build_pr_threads_url(pull_request_context: PullRequestContext) -> str:
     return _AZURE_PR_THREADS_PATH.format(
-        collection_uri=pr_context.extras.get("collection_uri", ""),
-        team_project=pr_context.extras.get("team_project", ""),
-        repo_id=pr_context.repository,
-        pr_id=pr_context.pr_number,
+        collection_uri=pull_request_context.extras.get("collection_uri", ""),
+        team_project=pull_request_context.extras.get("team_project", ""),
+        repo_id=pull_request_context.repository,
+        pull_request_identifier=pull_request_context.pull_request_number,
         api_version=_AZURE_API_VERSION,
     )
 
@@ -81,13 +81,15 @@ class AzureAdapter(BaseCIAdapter):
     def can_create_work_item_from_findings(self) -> bool:
         return True
 
-    def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
-        pr_id = pr_context.pr_number
-        repo_id = pr_context.repository
-        collection_uri = pr_context.extras.get("collection_uri", "")
-        team_project = pr_context.extras.get("team_project", "")
+    def post_pull_request_comment(
+        self, comment_body: SanitisedCommentBody, pull_request_context: PullRequestContext
+    ) -> None:
+        pull_request_identifier = pull_request_context.pull_request_number
+        repo_id = pull_request_context.repository
+        collection_uri = pull_request_context.extras.get("collection_uri", "")
+        team_project = pull_request_context.extras.get("team_project", "")
 
-        if not pr_id or not repo_id:
+        if not pull_request_identifier or not repo_id:
             raise CIIntegrationError("Azure DevOps: missing PR ID or repository ID")
         if not collection_uri or not team_project:
             raise CIIntegrationError("Azure DevOps: missing collection URI or team project")
@@ -96,7 +98,7 @@ class AzureAdapter(BaseCIAdapter):
         if not system_access_token:
             raise CIIntegrationError("Azure DevOps: SYSTEM_ACCESSTOKEN not set")
 
-        url = _build_pr_threads_url(pr_context)
+        url = _build_pr_threads_url(pull_request_context)
         execute_http_request(
             HttpRequestConfig(
                 method=HttpMethod.POST,
@@ -106,7 +108,9 @@ class AzureAdapter(BaseCIAdapter):
                 basic_auth_credentials=("", system_access_token),
             )
         )
-        _LOG.debug("Azure DevOps: PR thread comment posted to PR #%s", pr_id)
+        _LOG.debug("Azure DevOps: PR thread comment posted to PR #%s", pull_request_identifier)
 
-    def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+    def set_commit_status(
+        self, scan_result: ScanResult, pull_request_context: PullRequestContext
+    ) -> None:
         self._abort_unsupported_operation(UnsupportedOperation.COMMIT_STATUS)

--- a/phi_scan/ci/azure.py
+++ b/phi_scan/ci/azure.py
@@ -24,6 +24,9 @@ _AZURE_PR_THREADS_PATH: str = (
 )
 
 _COMMIT_STATUS_CONTEXT: str = "phi-scan"
+_AZURE_COMMENT_PARENT_ID_ROOT: int = 0
+_AZURE_COMMENT_TYPE_TEXT: int = 1
+_AZURE_THREAD_STATUS_ACTIVE: str = "active"
 
 
 class AzureAdapter(BaseCIAdapter):
@@ -63,8 +66,14 @@ class AzureAdapter(BaseCIAdapter):
             api_version=_AZURE_API_VERSION,
         )
         payload = {
-            "comments": [{"parentCommentId": 0, "content": comment_body, "commentType": 1}],
-            "status": "active",
+            "comments": [
+                {
+                    "parentCommentId": _AZURE_COMMENT_PARENT_ID_ROOT,
+                    "content": comment_body,
+                    "commentType": _AZURE_COMMENT_TYPE_TEXT,
+                }
+            ],
+            "status": _AZURE_THREAD_STATUS_ACTIVE,
         }
 
         execute_http_request(

--- a/phi_scan/ci/azure.py
+++ b/phi_scan/ci/azure.py
@@ -32,7 +32,7 @@ _AZURE_PR_THREADS_PATH: str = (
 
 _COMMIT_STATUS_CONTEXT: str = "phi-scan"
 _AZURE_COMMENT_PARENT_ID_ROOT: int = 0
-_AZURE_COMMENT_TYPE_TEXT: int = 1
+_AZURE_COMMENT_TYPE_TEXT: int = 1  # Azure DevOps commentType: 1 = text (see REST API docs)
 _AZURE_THREAD_STATUS_ACTIVE: str = "active"
 
 
@@ -80,8 +80,8 @@ class AzureAdapter(BaseCIAdapter):
             _LOG.warning("Azure DevOps: missing PR context — skipping comment")
             return
 
-        token = fetch_environment_variable(_ENV_SYSTEM_ACCESSTOKEN)
-        if not token:
+        system_access_token = fetch_environment_variable(_ENV_SYSTEM_ACCESSTOKEN)
+        if not system_access_token:
             _LOG.warning(
                 "Azure DevOps: SYSTEM_ACCESSTOKEN not set — "
                 "enable 'Allow scripts to access the OAuth token' in pipeline settings"
@@ -95,7 +95,7 @@ class AzureAdapter(BaseCIAdapter):
                 url=url,
                 operation_label=OperationLabel.AZURE_PR_COMMENT,
                 json_body=_build_azure_thread_payload(comment_body),
-                basic_auth_credentials=("", token),
+                basic_auth_credentials=("", system_access_token),
             )
         )
         _LOG.debug("Azure DevOps: PR thread comment posted to PR #%s", pr_id)

--- a/phi_scan/ci/azure.py
+++ b/phi_scan/ci/azure.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from phi_scan.ci._base import BaseCIAdapter
+from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody
 from phi_scan.ci._detect import PRContext
 from phi_scan.ci._env import fetch_environment_variable
 from phi_scan.ci._transport import (
@@ -60,7 +60,7 @@ class AzureAdapter(BaseCIAdapter):
     def can_create_work_item(self) -> bool:
         return True
 
-    def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
+    def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
         pr_id = pr_context.pr_number
         repo_id = pr_context.repository
         collection_uri = pr_context.extras.get("collection_uri", "")
@@ -97,4 +97,4 @@ class AzureAdapter(BaseCIAdapter):
         _LOG.debug("Azure DevOps: PR thread comment posted to PR #%s", pr_id)
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        self._raise_unsupported("commit status")
+        self._raise_unsupported_operation_error("commit status")

--- a/phi_scan/ci/azure.py
+++ b/phi_scan/ci/azure.py
@@ -11,10 +11,9 @@ follow-up PR.
 from __future__ import annotations
 
 import logging
-import os
 
 from phi_scan.ci._base import BaseCIAdapter
-from phi_scan.ci._detect import PRContext
+from phi_scan.ci._detect import PRContext, read_env_variable
 from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
 from phi_scan.models import ScanResult
 
@@ -29,11 +28,6 @@ _AZURE_PR_THREADS_PATH: str = (
 )
 
 _COMMIT_STATUS_CONTEXT: str = "phi-scan"
-
-
-def _env(name: str) -> str | None:
-    env_value = os.environ.get(name, "").strip()
-    return env_value if env_value else None
 
 
 class AzureAdapter(BaseCIAdapter):
@@ -53,7 +47,7 @@ class AzureAdapter(BaseCIAdapter):
             _LOG.debug("Azure DevOps: missing PR context — skipping comment")
             return
 
-        token = _env(_ENV_SYSTEM_ACCESSTOKEN)
+        token = read_env_variable(_ENV_SYSTEM_ACCESSTOKEN)
         if not token:
             _LOG.warning(
                 "Azure DevOps: SYSTEM_ACCESSTOKEN not set — "

--- a/phi_scan/ci/azure.py
+++ b/phi_scan/ci/azure.py
@@ -7,9 +7,10 @@ Uses ``SYSTEM_ACCESSTOKEN`` for authentication.
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from phi_scan.ci._base import BaseCIAdapter
-from phi_scan.ci._detect import PRContext, fetch_env_variable
+from phi_scan.ci._detect import PRContext, fetch_environment_variable
 from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
 from phi_scan.models import ScanResult
 
@@ -27,6 +28,19 @@ _COMMIT_STATUS_CONTEXT: str = "phi-scan"
 _AZURE_COMMENT_PARENT_ID_ROOT: int = 0
 _AZURE_COMMENT_TYPE_TEXT: int = 1
 _AZURE_THREAD_STATUS_ACTIVE: str = "active"
+
+
+def _build_azure_thread_payload(comment_body: str) -> dict[str, Any]:
+    return {
+        "comments": [
+            {
+                "parentCommentId": _AZURE_COMMENT_PARENT_ID_ROOT,
+                "content": comment_body,
+                "commentType": _AZURE_COMMENT_TYPE_TEXT,
+            }
+        ],
+        "status": _AZURE_THREAD_STATUS_ACTIVE,
+    }
 
 
 class AzureAdapter(BaseCIAdapter):
@@ -50,7 +64,7 @@ class AzureAdapter(BaseCIAdapter):
             _LOG.debug("Azure DevOps: missing PR context — skipping comment")
             return
 
-        token = fetch_env_variable(_ENV_SYSTEM_ACCESSTOKEN)
+        token = fetch_environment_variable(_ENV_SYSTEM_ACCESSTOKEN)
         if not token:
             _LOG.warning(
                 "Azure DevOps: SYSTEM_ACCESSTOKEN not set — "
@@ -65,27 +79,15 @@ class AzureAdapter(BaseCIAdapter):
             pr_id=pr_id,
             api_version=_AZURE_API_VERSION,
         )
-        payload = {
-            "comments": [
-                {
-                    "parentCommentId": _AZURE_COMMENT_PARENT_ID_ROOT,
-                    "content": comment_body,
-                    "commentType": _AZURE_COMMENT_TYPE_TEXT,
-                }
-            ],
-            "status": _AZURE_THREAD_STATUS_ACTIVE,
-        }
-
         execute_http_request(
             HttpRequestConfig(
                 method=HttpMethod.POST,
                 url=url,
                 operation_label="Azure DevOps PR comment",
-                json_body=payload,
-                auth=("", token),
+                json_body=_build_azure_thread_payload(comment_body),
+                basic_auth_credentials=("", token),
             )
         )
-
         _LOG.debug("Azure DevOps: PR thread comment posted to PR #%s", pr_id)
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:

--- a/phi_scan/ci/azure.py
+++ b/phi_scan/ci/azure.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody
+from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody, UnsupportedOperation
 from phi_scan.ci._detect import PRContext
 from phi_scan.ci._env import fetch_environment_variable
 from phi_scan.ci._transport import (
@@ -101,4 +101,4 @@ class AzureAdapter(BaseCIAdapter):
         _LOG.debug("Azure DevOps: PR thread comment posted to PR #%s", pr_id)
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        self._raise_unsupported_operation_error("commit status")
+        self._raise_unsupported_operation_error(UnsupportedOperation.COMMIT_STATUS)

--- a/phi_scan/ci/azure.py
+++ b/phi_scan/ci/azure.py
@@ -10,7 +10,8 @@ import logging
 from typing import Any
 
 from phi_scan.ci._base import BaseCIAdapter
-from phi_scan.ci._detect import PRContext, fetch_environment_variable
+from phi_scan.ci._detect import PRContext
+from phi_scan.ci._env import fetch_environment_variable
 from phi_scan.ci._transport import (
     HttpMethod,
     HttpRequestConfig,
@@ -52,11 +53,11 @@ class AzureAdapter(BaseCIAdapter):
     """Azure DevOps adapter using the Azure DevOps REST API."""
 
     @property
-    def supports_commit_status(self) -> bool:
+    def can_post_commit_status(self) -> bool:
         return False
 
     @property
-    def supports_work_item_creation(self) -> bool:
+    def can_create_work_item(self) -> bool:
         return True
 
     def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:

--- a/phi_scan/ci/azure.py
+++ b/phi_scan/ci/azure.py
@@ -88,10 +88,10 @@ class AzureAdapter(BaseCIAdapter):
         collection_uri = pr_context.extras.get("collection_uri", "")
         team_project = pr_context.extras.get("team_project", "")
 
-        if not all((pr_id, repo_id, collection_uri, team_project)):
-            raise CIIntegrationError(
-                "Azure DevOps: missing PR context fields required for PR comment"
-            )
+        if not pr_id or not repo_id:
+            raise CIIntegrationError("Azure DevOps: missing PR ID or repository ID")
+        if not collection_uri or not team_project:
+            raise CIIntegrationError("Azure DevOps: missing collection URI or team project")
 
         system_access_token = fetch_environment_variable(_ENV_SYSTEM_ACCESSTOKEN)
         if not system_access_token:
@@ -110,4 +110,4 @@ class AzureAdapter(BaseCIAdapter):
         _LOG.debug("Azure DevOps: PR thread comment posted to PR #%s", pr_id)
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        self._raise_unsupported_operation_error(UnsupportedOperation.COMMIT_STATUS)
+        self._abort_unsupported_operation(UnsupportedOperation.COMMIT_STATUS)

--- a/phi_scan/ci/azure.py
+++ b/phi_scan/ci/azure.py
@@ -1,0 +1,95 @@
+"""Azure DevOps CI adapter.
+
+Posts PR thread comments via the Azure DevOps REST API.
+Uses ``SYSTEM_ACCESSTOKEN`` for authentication.
+
+Note: Azure-specific extras (build tags, PR statuses, Boards work items)
+remain in ``ci_integration.py`` for now and will be migrated in a
+follow-up PR.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from phi_scan.ci._base import BaseCIAdapter
+from phi_scan.ci._detect import PRContext
+from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
+from phi_scan.models import ScanResult
+
+_LOG: logging.Logger = logging.getLogger(__name__)
+
+_ENV_SYSTEM_ACCESSTOKEN: str = "SYSTEM_ACCESSTOKEN"
+
+_AZURE_API_VERSION: str = "7.1"
+_AZURE_PR_THREADS_PATH: str = (
+    "{collection_uri}{team_project}/_apis/git/repositories/{repo_id}"
+    "/pullRequests/{pr_id}/threads?api-version={api_version}"
+)
+
+_COMMIT_STATUS_CONTEXT: str = "phi-scan"
+
+
+def _env(name: str) -> str | None:
+    env_value = os.environ.get(name, "").strip()
+    return env_value if env_value else None
+
+
+class AzureAdapter(BaseCIAdapter):
+    """Azure DevOps adapter using the Azure DevOps REST API."""
+
+    @property
+    def supports_work_item_creation(self) -> bool:
+        return True
+
+    def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
+        pr_id = pr_context.pr_number
+        repo_id = pr_context.repository
+        collection_uri = pr_context.extras.get("collection_uri", "")
+        team_project = pr_context.extras.get("team_project", "")
+
+        if not all([pr_id, repo_id, collection_uri, team_project]):
+            _LOG.debug("Azure DevOps: missing PR context — skipping comment")
+            return
+
+        token = _env(_ENV_SYSTEM_ACCESSTOKEN)
+        if not token:
+            _LOG.warning(
+                "Azure DevOps: SYSTEM_ACCESSTOKEN not set — "
+                "enable 'Allow scripts to access the OAuth token' in pipeline settings"
+            )
+            return
+
+        url = _AZURE_PR_THREADS_PATH.format(
+            collection_uri=collection_uri,
+            team_project=team_project,
+            repo_id=repo_id,
+            pr_id=pr_id,
+            api_version=_AZURE_API_VERSION,
+        )
+        payload = {
+            "comments": [{"parentCommentId": 0, "content": comment_body, "commentType": 1}],
+            "status": "active",
+        }
+
+        execute_http_request(
+            HttpRequestConfig(
+                method=HttpMethod.POST,
+                url=url,
+                operation_label="Azure DevOps PR comment",
+                json_body=payload,
+                auth=("", token),
+            )
+        )
+
+        _LOG.debug("Azure DevOps: PR thread comment posted to PR #%s", pr_id)
+
+    def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+        """Azure DevOps does not have a standalone commit status API.
+
+        Commit status is handled via ``set_azure_pr_status`` (a platform-
+        specific extra) which remains in ``ci_integration.py`` for now.
+        This method is a no-op; the CLI calls the extra directly.
+        """
+        _LOG.debug("Azure DevOps: commit status handled via set_azure_pr_status extra")

--- a/phi_scan/ci/azure.py
+++ b/phi_scan/ci/azure.py
@@ -2,10 +2,6 @@
 
 Posts PR thread comments via the Azure DevOps REST API.
 Uses ``SYSTEM_ACCESSTOKEN`` for authentication.
-
-Note: Azure-specific extras (build tags, PR statuses, Boards work items)
-remain in ``ci_integration.py`` for now and will be migrated in a
-follow-up PR.
 """
 
 from __future__ import annotations
@@ -32,6 +28,10 @@ _COMMIT_STATUS_CONTEXT: str = "phi-scan"
 
 class AzureAdapter(BaseCIAdapter):
     """Azure DevOps adapter using the Azure DevOps REST API."""
+
+    @property
+    def supports_commit_status(self) -> bool:
+        return False
 
     @property
     def supports_work_item_creation(self) -> bool:
@@ -80,10 +80,4 @@ class AzureAdapter(BaseCIAdapter):
         _LOG.debug("Azure DevOps: PR thread comment posted to PR #%s", pr_id)
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        """Azure DevOps does not have a standalone commit status API.
-
-        Commit status is handled via ``set_azure_pr_status`` (a platform-
-        specific extra) which remains in ``ci_integration.py`` for now.
-        This method is a no-op; the CLI calls the extra directly.
-        """
-        _LOG.debug("Azure DevOps: commit status handled via set_azure_pr_status extra")
+        _LOG.debug("Azure DevOps: commit status not supported via adapter")

--- a/phi_scan/ci/azure.py
+++ b/phi_scan/ci/azure.py
@@ -11,7 +11,12 @@ from typing import Any
 
 from phi_scan.ci._base import BaseCIAdapter
 from phi_scan.ci._detect import PRContext, fetch_environment_variable
-from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
+from phi_scan.ci._transport import (
+    HttpMethod,
+    HttpRequestConfig,
+    OperationLabel,
+    execute_http_request,
+)
 from phi_scan.models import ScanResult
 
 _LOG: logging.Logger = logging.getLogger(__name__)
@@ -60,7 +65,7 @@ class AzureAdapter(BaseCIAdapter):
         collection_uri = pr_context.extras.get("collection_uri", "")
         team_project = pr_context.extras.get("team_project", "")
 
-        if not all([pr_id, repo_id, collection_uri, team_project]):
+        if not all((pr_id, repo_id, collection_uri, team_project)):
             _LOG.debug("Azure DevOps: missing PR context — skipping comment")
             return
 
@@ -83,7 +88,7 @@ class AzureAdapter(BaseCIAdapter):
             HttpRequestConfig(
                 method=HttpMethod.POST,
                 url=url,
-                operation_label="Azure DevOps PR comment",
+                operation_label=OperationLabel.AZURE_PR_COMMENT,
                 json_body=_build_azure_thread_payload(comment_body),
                 basic_auth_credentials=("", token),
             )

--- a/phi_scan/ci/azure.py
+++ b/phi_scan/ci/azure.py
@@ -32,7 +32,6 @@ _AZURE_PR_THREADS_PATH: str = (
     "/pullRequests/{pr_id}/threads?api-version={api_version}"
 )
 
-_COMMIT_STATUS_CONTEXT: str = "phi-scan"
 _AZURE_COMMENT_PARENT_ID_ROOT: int = 0
 
 

--- a/phi_scan/ci/azure.py
+++ b/phi_scan/ci/azure.py
@@ -6,6 +6,7 @@ Uses ``SYSTEM_ACCESSTOKEN`` for authentication.
 
 from __future__ import annotations
 
+import enum
 import logging
 from typing import Any
 
@@ -32,8 +33,18 @@ _AZURE_PR_THREADS_PATH: str = (
 
 _COMMIT_STATUS_CONTEXT: str = "phi-scan"
 _AZURE_COMMENT_PARENT_ID_ROOT: int = 0
-_AZURE_COMMENT_TYPE_TEXT: int = 1  # Azure DevOps commentType: 1 = text (see REST API docs)
-_AZURE_THREAD_STATUS_ACTIVE: str = "active"
+
+
+class _AzureCommentType(enum.IntEnum):
+    """Azure DevOps PR thread comment types (REST API)."""
+
+    TEXT = 1
+
+
+class _AzureThreadStatus(enum.StrEnum):
+    """Azure DevOps PR thread statuses (REST API)."""
+
+    ACTIVE = "active"
 
 
 def _build_pr_threads_url(pr_context: PRContext) -> str:
@@ -52,10 +63,10 @@ def _build_azure_thread_payload(comment_body: str) -> dict[str, Any]:
             {
                 "parentCommentId": _AZURE_COMMENT_PARENT_ID_ROOT,
                 "content": comment_body,
-                "commentType": _AZURE_COMMENT_TYPE_TEXT,
+                "commentType": _AzureCommentType.TEXT,
             }
         ],
-        "status": _AZURE_THREAD_STATUS_ACTIVE,
+        "status": _AzureThreadStatus.ACTIVE,
     }
 
 

--- a/phi_scan/ci/bitbucket.py
+++ b/phi_scan/ci/bitbucket.py
@@ -84,8 +84,8 @@ class BitbucketAdapter(BaseCIAdapter):
             _LOG.warning("Bitbucket: missing PR context — skipping comment")
             return
 
-        token = fetch_environment_variable(_ENV_BITBUCKET_TOKEN)
-        if not token:
+        bitbucket_token = fetch_environment_variable(_ENV_BITBUCKET_TOKEN)
+        if not bitbucket_token:
             _LOG.warning("Bitbucket: BITBUCKET_TOKEN not set — skipping comment")
             return
 
@@ -99,7 +99,7 @@ class BitbucketAdapter(BaseCIAdapter):
                 method=HttpMethod.POST,
                 url=url,
                 operation_label=OperationLabel.BITBUCKET_PR_COMMENT,
-                headers=_build_auth_headers(token),
+                headers=_build_auth_headers(bitbucket_token),
                 json_body={
                     _BITBUCKET_COMMENT_CONTENT_KEY: {_BITBUCKET_COMMENT_RAW_KEY: comment_body},
                 },
@@ -115,8 +115,8 @@ class BitbucketAdapter(BaseCIAdapter):
             _LOG.warning("Bitbucket: missing context — skipping commit status")
             return
 
-        token = fetch_environment_variable(_ENV_BITBUCKET_TOKEN)
-        if not token:
+        bitbucket_token = fetch_environment_variable(_ENV_BITBUCKET_TOKEN)
+        if not bitbucket_token:
             _LOG.warning("Bitbucket: BITBUCKET_TOKEN not set — skipping commit status")
             return
 
@@ -130,7 +130,7 @@ class BitbucketAdapter(BaseCIAdapter):
                 method=HttpMethod.POST,
                 url=url,
                 operation_label=OperationLabel.BITBUCKET_COMMIT_STATUS,
-                headers=_build_auth_headers(token),
+                headers=_build_auth_headers(bitbucket_token),
                 json_body=_build_commit_status_payload(scan_result),
             )
         )

--- a/phi_scan/ci/bitbucket.py
+++ b/phi_scan/ci/bitbucket.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 
 from phi_scan.ci._base import BaseCIAdapter
-from phi_scan.ci._detect import PRContext, read_env_variable
+from phi_scan.ci._detect import PRContext, fetch_env_variable
 from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
 from phi_scan.models import ScanResult
 
@@ -52,7 +52,7 @@ class BitbucketAdapter(BaseCIAdapter):
             _LOG.debug("Bitbucket: missing PR context — skipping comment")
             return
 
-        token = read_env_variable(_ENV_BITBUCKET_TOKEN)
+        token = fetch_env_variable(_ENV_BITBUCKET_TOKEN)
         if not token:
             _LOG.warning("Bitbucket: BITBUCKET_TOKEN not set — skipping comment")
             return
@@ -85,12 +85,14 @@ class BitbucketAdapter(BaseCIAdapter):
             _LOG.debug("Bitbucket: missing context — skipping commit status")
             return
 
-        token = read_env_variable(_ENV_BITBUCKET_TOKEN)
+        token = fetch_env_variable(_ENV_BITBUCKET_TOKEN)
         if not token:
             _LOG.warning("Bitbucket: BITBUCKET_TOKEN not set — skipping commit status")
             return
 
-        state = _BITBUCKET_STATUS_SUCCESSFUL if scan_result.is_clean else _BITBUCKET_STATUS_FAILED
+        commit_build_state = (
+            _BITBUCKET_STATUS_SUCCESSFUL if scan_result.is_clean else _BITBUCKET_STATUS_FAILED
+        )
         url = _BITBUCKET_API_BASE_URL + _BITBUCKET_COMMIT_STATUS_PATH.format(
             workspace=workspace,
             repo_slug=repo_slug,
@@ -98,7 +100,7 @@ class BitbucketAdapter(BaseCIAdapter):
         )
         payload = {
             "key": _COMMIT_STATUS_CONTEXT,
-            "state": state,
+            "state": commit_build_state,
             "name": _COMMIT_STATUS_CONTEXT,
             "description": (
                 _COMMIT_STATUS_DESCRIPTION_CLEAN
@@ -117,4 +119,5 @@ class BitbucketAdapter(BaseCIAdapter):
             )
         )
 
-        _LOG.debug("Bitbucket: commit status set to %s for %s", state, sha[:_SHA_LOG_PREFIX_LENGTH])
+        sha_prefix = sha[:_SHA_LOG_PREFIX_LENGTH]
+        _LOG.debug("Bitbucket: commit status set to %s for %s", commit_build_state, sha_prefix)

--- a/phi_scan/ci/bitbucket.py
+++ b/phi_scan/ci/bitbucket.py
@@ -31,6 +31,8 @@ _BITBUCKET_COMMENT_RAW_KEY: str = "raw"
 _COMMIT_STATUS_CONTEXT: str = "phi-scan"
 _COMMIT_STATUS_DESCRIPTION_CLEAN: str = "No PHI/PII violations found"
 _COMMIT_STATUS_DESCRIPTION_VIOLATIONS: str = "{count} PHI/PII violation(s) found"
+_BITBUCKET_STATUS_SUCCESSFUL: str = "SUCCESSFUL"
+_BITBUCKET_STATUS_FAILED: str = "FAILED"
 _SHA_LOG_PREFIX_LENGTH: int = 8
 
 
@@ -88,7 +90,7 @@ class BitbucketAdapter(BaseCIAdapter):
             _LOG.warning("Bitbucket: BITBUCKET_TOKEN not set — skipping commit status")
             return
 
-        state = "SUCCESSFUL" if scan_result.is_clean else "FAILED"
+        state = _BITBUCKET_STATUS_SUCCESSFUL if scan_result.is_clean else _BITBUCKET_STATUS_FAILED
         url = _BITBUCKET_API_BASE_URL + _BITBUCKET_COMMIT_STATUS_PATH.format(
             workspace=workspace,
             repo_slug=repo_slug,

--- a/phi_scan/ci/bitbucket.py
+++ b/phi_scan/ci/bitbucket.py
@@ -10,7 +10,7 @@ import logging
 from typing import Any
 
 from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody
-from phi_scan.ci._detect import PRContext
+from phi_scan.ci._detect import PullRequestContext
 from phi_scan.ci._env import fetch_environment_variable
 from phi_scan.ci._transport import (
     HttpMethod,
@@ -26,7 +26,7 @@ _ENV_BITBUCKET_TOKEN: str = "BITBUCKET_TOKEN"
 
 _BITBUCKET_API_BASE_URL: str = "https://api.bitbucket.org/2.0"
 _BITBUCKET_PR_COMMENTS_PATH: str = (
-    "/repositories/{workspace}/{repo_slug}/pullrequests/{pr_id}/comments"
+    "/repositories/{workspace}/{repo_slug}/pullrequests/{pull_request_identifier}/comments"
 )
 _BITBUCKET_COMMIT_STATUS_PATH: str = (
     "/repositories/{workspace}/{repo_slug}/commit/{commit}/statuses/build"
@@ -75,12 +75,14 @@ class BitbucketAdapter(BaseCIAdapter):
     def can_annotate_code_findings(self) -> bool:
         return True
 
-    def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
-        pr_id = pr_context.pr_number
-        workspace = pr_context.extras.get("workspace", "")
-        repo_slug = pr_context.repository or ""
+    def post_pull_request_comment(
+        self, comment_body: SanitisedCommentBody, pull_request_context: PullRequestContext
+    ) -> None:
+        pull_request_identifier = pull_request_context.pull_request_number
+        workspace = pull_request_context.extras.get("workspace", "")
+        repo_slug = pull_request_context.repository or ""
 
-        if not all((pr_id, workspace, repo_slug)):
+        if not all((pull_request_identifier, workspace, repo_slug)):
             _LOG.warning("Bitbucket: missing PR context — skipping comment")
             return
 
@@ -92,7 +94,7 @@ class BitbucketAdapter(BaseCIAdapter):
         url = _BITBUCKET_API_BASE_URL + _BITBUCKET_PR_COMMENTS_PATH.format(
             workspace=workspace,
             repo_slug=repo_slug,
-            pr_id=pr_id,
+            pull_request_identifier=pull_request_identifier,
         )
         execute_http_request(
             HttpRequestConfig(
@@ -105,12 +107,14 @@ class BitbucketAdapter(BaseCIAdapter):
                 },
             )
         )
-        _LOG.debug("Bitbucket: PR comment posted to PR #%s", pr_id)
+        _LOG.debug("Bitbucket: PR comment posted to PR #%s", pull_request_identifier)
 
-    def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        sha = pr_context.sha
-        workspace = pr_context.extras.get("workspace", "")
-        repo_slug = pr_context.repository or ""
+    def set_commit_status(
+        self, scan_result: ScanResult, pull_request_context: PullRequestContext
+    ) -> None:
+        sha = pull_request_context.sha
+        workspace = pull_request_context.extras.get("workspace", "")
+        repo_slug = pull_request_context.repository or ""
         if not sha or not workspace or not repo_slug:
             _LOG.warning("Bitbucket: missing context — skipping commit status")
             return

--- a/phi_scan/ci/bitbucket.py
+++ b/phi_scan/ci/bitbucket.py
@@ -72,7 +72,7 @@ class BitbucketAdapter(BaseCIAdapter):
     """Bitbucket Cloud adapter using the Bitbucket REST API."""
 
     @property
-    def can_annotate_code(self) -> bool:
+    def can_annotate_code_findings(self) -> bool:
         return True
 
     def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:

--- a/phi_scan/ci/bitbucket.py
+++ b/phi_scan/ci/bitbucket.py
@@ -81,7 +81,7 @@ class BitbucketAdapter(BaseCIAdapter):
         repo_slug = pr_context.extras.get("repo_slug", "")
 
         if not all((pr_id, workspace, repo_slug)):
-            _LOG.debug("Bitbucket: missing PR context — skipping comment")
+            _LOG.warning("Bitbucket: missing PR context — skipping comment")
             return
 
         token = fetch_environment_variable(_ENV_BITBUCKET_TOKEN)
@@ -112,7 +112,7 @@ class BitbucketAdapter(BaseCIAdapter):
         workspace = pr_context.extras.get("workspace", "")
         repo_slug = pr_context.extras.get("repo_slug", "")
         if not sha or not workspace or not repo_slug:
-            _LOG.debug("Bitbucket: missing context — skipping commit status")
+            _LOG.warning("Bitbucket: missing context — skipping commit status")
             return
 
         token = fetch_environment_variable(_ENV_BITBUCKET_TOKEN)

--- a/phi_scan/ci/bitbucket.py
+++ b/phi_scan/ci/bitbucket.py
@@ -10,7 +10,8 @@ import logging
 from typing import Any
 
 from phi_scan.ci._base import BaseCIAdapter
-from phi_scan.ci._detect import PRContext, fetch_environment_variable
+from phi_scan.ci._detect import PRContext
+from phi_scan.ci._env import fetch_environment_variable
 from phi_scan.ci._transport import (
     HttpMethod,
     HttpRequestConfig,
@@ -71,7 +72,7 @@ class BitbucketAdapter(BaseCIAdapter):
     """Bitbucket Cloud adapter using the Bitbucket REST API."""
 
     @property
-    def supports_code_insights(self) -> bool:
+    def can_annotate_code(self) -> bool:
         return True
 
     def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:

--- a/phi_scan/ci/bitbucket.py
+++ b/phi_scan/ci/bitbucket.py
@@ -1,0 +1,126 @@
+"""Bitbucket Pipelines CI adapter.
+
+Posts PR comments and sets commit build statuses via the Bitbucket
+Cloud REST API. Uses ``BITBUCKET_TOKEN`` for authentication.
+
+Note: Bitbucket Code Insights (report + annotations) remains in
+``ci_integration.py`` for now and will be migrated in a follow-up PR.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from phi_scan.ci._base import BaseCIAdapter
+from phi_scan.ci._detect import PRContext
+from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
+from phi_scan.models import ScanResult
+
+_LOG: logging.Logger = logging.getLogger(__name__)
+
+_ENV_BITBUCKET_TOKEN: str = "BITBUCKET_TOKEN"
+
+_BITBUCKET_API_BASE_URL: str = "https://api.bitbucket.org/2.0"
+_BITBUCKET_PR_COMMENTS_PATH: str = (
+    "/repositories/{workspace}/{repo_slug}/pullrequests/{pr_id}/comments"
+)
+_BITBUCKET_COMMIT_STATUS_PATH: str = (
+    "/repositories/{workspace}/{repo_slug}/commit/{commit}/statuses/build"
+)
+
+_JSON_CONTENT_TYPE: str = "application/json"
+_BITBUCKET_COMMENT_CONTENT_KEY: str = "content"
+_BITBUCKET_COMMENT_RAW_KEY: str = "raw"
+_COMMIT_STATUS_CONTEXT: str = "phi-scan"
+_COMMIT_STATUS_DESCRIPTION_CLEAN: str = "No PHI/PII violations found"
+_COMMIT_STATUS_DESCRIPTION_VIOLATIONS: str = "{count} PHI/PII violation(s) found"
+
+
+def _env(name: str) -> str | None:
+    env_value = os.environ.get(name, "").strip()
+    return env_value if env_value else None
+
+
+class BitbucketAdapter(BaseCIAdapter):
+    """Bitbucket Cloud adapter using the Bitbucket REST API."""
+
+    @property
+    def supports_code_insights(self) -> bool:
+        return True
+
+    def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
+        pr_id = pr_context.pr_number
+        workspace = pr_context.extras.get("workspace", "")
+        repo_slug = pr_context.extras.get("repo_slug", "")
+
+        if not all([pr_id, workspace, repo_slug]):
+            _LOG.debug("Bitbucket: missing PR context — skipping comment")
+            return
+
+        token = _env(_ENV_BITBUCKET_TOKEN)
+        if not token:
+            _LOG.warning("Bitbucket: BITBUCKET_TOKEN not set — skipping comment")
+            return
+
+        url = _BITBUCKET_API_BASE_URL + _BITBUCKET_PR_COMMENTS_PATH.format(
+            workspace=workspace,
+            repo_slug=repo_slug,
+            pr_id=pr_id,
+        )
+
+        execute_http_request(
+            HttpRequestConfig(
+                method=HttpMethod.POST,
+                url=url,
+                operation_label="Bitbucket PR comment",
+                headers={"Authorization": f"Bearer {token}", "Content-Type": _JSON_CONTENT_TYPE},
+                json_body={
+                    _BITBUCKET_COMMENT_CONTENT_KEY: {_BITBUCKET_COMMENT_RAW_KEY: comment_body},
+                },
+            )
+        )
+
+        _LOG.debug("Bitbucket: PR comment posted to PR #%s", pr_id)
+
+    def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+        sha = pr_context.sha
+        workspace = pr_context.extras.get("workspace", "")
+        repo_slug = pr_context.extras.get("repo_slug", "")
+        if not sha or not workspace or not repo_slug:
+            _LOG.debug("Bitbucket: missing context — skipping commit status")
+            return
+
+        token = _env(_ENV_BITBUCKET_TOKEN)
+        if not token:
+            _LOG.warning("Bitbucket: BITBUCKET_TOKEN not set — skipping commit status")
+            return
+
+        state = "SUCCESSFUL" if scan_result.is_clean else "FAILED"
+        url = _BITBUCKET_API_BASE_URL + _BITBUCKET_COMMIT_STATUS_PATH.format(
+            workspace=workspace,
+            repo_slug=repo_slug,
+            commit=sha,
+        )
+        payload = {
+            "key": _COMMIT_STATUS_CONTEXT,
+            "state": state,
+            "name": "phi-scan",
+            "description": (
+                _COMMIT_STATUS_DESCRIPTION_CLEAN
+                if scan_result.is_clean
+                else _COMMIT_STATUS_DESCRIPTION_VIOLATIONS.format(count=len(scan_result.findings))
+            ),
+        }
+
+        execute_http_request(
+            HttpRequestConfig(
+                method=HttpMethod.POST,
+                url=url,
+                operation_label="Bitbucket commit status",
+                headers={"Authorization": f"Bearer {token}", "Content-Type": _JSON_CONTENT_TYPE},
+                json_body=payload,
+            )
+        )
+
+        _LOG.debug("Bitbucket: commit status set to %s for %s", state, sha[:8])

--- a/phi_scan/ci/bitbucket.py
+++ b/phi_scan/ci/bitbucket.py
@@ -7,9 +7,10 @@ Cloud REST API. Uses ``BITBUCKET_TOKEN`` for authentication.
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from phi_scan.ci._base import BaseCIAdapter
-from phi_scan.ci._detect import PRContext, fetch_env_variable
+from phi_scan.ci._detect import PRContext, fetch_environment_variable
 from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
 from phi_scan.models import ScanResult
 
@@ -25,6 +26,8 @@ _BITBUCKET_COMMIT_STATUS_PATH: str = (
     "/repositories/{workspace}/{repo_slug}/commit/{commit}/statuses/build"
 )
 
+_HTTP_HEADER_AUTHORIZATION: str = "Authorization"
+_HTTP_HEADER_CONTENT_TYPE: str = "Content-Type"
 _JSON_CONTENT_TYPE: str = "application/json"
 _BITBUCKET_COMMENT_CONTENT_KEY: str = "content"
 _BITBUCKET_COMMENT_RAW_KEY: str = "raw"
@@ -34,6 +37,29 @@ _COMMIT_STATUS_DESCRIPTION_VIOLATIONS: str = "{count} PHI/PII violation(s) found
 _BITBUCKET_STATUS_SUCCESSFUL: str = "SUCCESSFUL"
 _BITBUCKET_STATUS_FAILED: str = "FAILED"
 _SHA_LOG_PREFIX_LENGTH: int = 8
+
+
+def _build_auth_headers(token: str) -> dict[str, str]:
+    return {
+        _HTTP_HEADER_AUTHORIZATION: f"Bearer {token}",
+        _HTTP_HEADER_CONTENT_TYPE: _JSON_CONTENT_TYPE,
+    }
+
+
+def _build_commit_status_payload(scan_result: ScanResult) -> dict[str, Any]:
+    commit_build_state = (
+        _BITBUCKET_STATUS_SUCCESSFUL if scan_result.is_clean else _BITBUCKET_STATUS_FAILED
+    )
+    return {
+        "key": _COMMIT_STATUS_CONTEXT,
+        "state": commit_build_state,
+        "name": _COMMIT_STATUS_CONTEXT,
+        "description": (
+            _COMMIT_STATUS_DESCRIPTION_CLEAN
+            if scan_result.is_clean
+            else _COMMIT_STATUS_DESCRIPTION_VIOLATIONS.format(count=len(scan_result.findings))
+        ),
+    }
 
 
 class BitbucketAdapter(BaseCIAdapter):
@@ -52,7 +78,7 @@ class BitbucketAdapter(BaseCIAdapter):
             _LOG.debug("Bitbucket: missing PR context — skipping comment")
             return
 
-        token = fetch_env_variable(_ENV_BITBUCKET_TOKEN)
+        token = fetch_environment_variable(_ENV_BITBUCKET_TOKEN)
         if not token:
             _LOG.warning("Bitbucket: BITBUCKET_TOKEN not set — skipping comment")
             return
@@ -62,19 +88,17 @@ class BitbucketAdapter(BaseCIAdapter):
             repo_slug=repo_slug,
             pr_id=pr_id,
         )
-
         execute_http_request(
             HttpRequestConfig(
                 method=HttpMethod.POST,
                 url=url,
                 operation_label="Bitbucket PR comment",
-                headers={"Authorization": f"Bearer {token}", "Content-Type": _JSON_CONTENT_TYPE},
+                headers=_build_auth_headers(token),
                 json_body={
                     _BITBUCKET_COMMENT_CONTENT_KEY: {_BITBUCKET_COMMENT_RAW_KEY: comment_body},
                 },
             )
         )
-
         _LOG.debug("Bitbucket: PR comment posted to PR #%s", pr_id)
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
@@ -85,39 +109,24 @@ class BitbucketAdapter(BaseCIAdapter):
             _LOG.debug("Bitbucket: missing context — skipping commit status")
             return
 
-        token = fetch_env_variable(_ENV_BITBUCKET_TOKEN)
+        token = fetch_environment_variable(_ENV_BITBUCKET_TOKEN)
         if not token:
             _LOG.warning("Bitbucket: BITBUCKET_TOKEN not set — skipping commit status")
             return
 
-        commit_build_state = (
-            _BITBUCKET_STATUS_SUCCESSFUL if scan_result.is_clean else _BITBUCKET_STATUS_FAILED
-        )
         url = _BITBUCKET_API_BASE_URL + _BITBUCKET_COMMIT_STATUS_PATH.format(
             workspace=workspace,
             repo_slug=repo_slug,
             commit=sha,
         )
-        payload = {
-            "key": _COMMIT_STATUS_CONTEXT,
-            "state": commit_build_state,
-            "name": _COMMIT_STATUS_CONTEXT,
-            "description": (
-                _COMMIT_STATUS_DESCRIPTION_CLEAN
-                if scan_result.is_clean
-                else _COMMIT_STATUS_DESCRIPTION_VIOLATIONS.format(count=len(scan_result.findings))
-            ),
-        }
-
         execute_http_request(
             HttpRequestConfig(
                 method=HttpMethod.POST,
                 url=url,
                 operation_label="Bitbucket commit status",
-                headers={"Authorization": f"Bearer {token}", "Content-Type": _JSON_CONTENT_TYPE},
-                json_body=payload,
+                headers=_build_auth_headers(token),
+                json_body=_build_commit_status_payload(scan_result),
             )
         )
-
         sha_prefix = sha[:_SHA_LOG_PREFIX_LENGTH]
-        _LOG.debug("Bitbucket: commit status set to %s for %s", commit_build_state, sha_prefix)
+        _LOG.debug("Bitbucket: commit status set to %s for %s", scan_result.is_clean, sha_prefix)

--- a/phi_scan/ci/bitbucket.py
+++ b/phi_scan/ci/bitbucket.py
@@ -11,7 +11,12 @@ from typing import Any
 
 from phi_scan.ci._base import BaseCIAdapter
 from phi_scan.ci._detect import PRContext, fetch_environment_variable
-from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
+from phi_scan.ci._transport import (
+    HttpMethod,
+    HttpRequestConfig,
+    OperationLabel,
+    execute_http_request,
+)
 from phi_scan.models import ScanResult
 
 _LOG: logging.Logger = logging.getLogger(__name__)
@@ -74,7 +79,7 @@ class BitbucketAdapter(BaseCIAdapter):
         workspace = pr_context.extras.get("workspace", "")
         repo_slug = pr_context.extras.get("repo_slug", "")
 
-        if not all([pr_id, workspace, repo_slug]):
+        if not all((pr_id, workspace, repo_slug)):
             _LOG.debug("Bitbucket: missing PR context — skipping comment")
             return
 
@@ -92,7 +97,7 @@ class BitbucketAdapter(BaseCIAdapter):
             HttpRequestConfig(
                 method=HttpMethod.POST,
                 url=url,
-                operation_label="Bitbucket PR comment",
+                operation_label=OperationLabel.BITBUCKET_PR_COMMENT,
                 headers=_build_auth_headers(token),
                 json_body={
                     _BITBUCKET_COMMENT_CONTENT_KEY: {_BITBUCKET_COMMENT_RAW_KEY: comment_body},
@@ -123,7 +128,7 @@ class BitbucketAdapter(BaseCIAdapter):
             HttpRequestConfig(
                 method=HttpMethod.POST,
                 url=url,
-                operation_label="Bitbucket commit status",
+                operation_label=OperationLabel.BITBUCKET_COMMIT_STATUS,
                 headers=_build_auth_headers(token),
                 json_body=_build_commit_status_payload(scan_result),
             )

--- a/phi_scan/ci/bitbucket.py
+++ b/phi_scan/ci/bitbucket.py
@@ -10,10 +10,9 @@ Note: Bitbucket Code Insights (report + annotations) remains in
 from __future__ import annotations
 
 import logging
-import os
 
 from phi_scan.ci._base import BaseCIAdapter
-from phi_scan.ci._detect import PRContext
+from phi_scan.ci._detect import PRContext, read_env_variable
 from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
 from phi_scan.models import ScanResult
 
@@ -35,11 +34,7 @@ _BITBUCKET_COMMENT_RAW_KEY: str = "raw"
 _COMMIT_STATUS_CONTEXT: str = "phi-scan"
 _COMMIT_STATUS_DESCRIPTION_CLEAN: str = "No PHI/PII violations found"
 _COMMIT_STATUS_DESCRIPTION_VIOLATIONS: str = "{count} PHI/PII violation(s) found"
-
-
-def _env(name: str) -> str | None:
-    env_value = os.environ.get(name, "").strip()
-    return env_value if env_value else None
+_SHA_LOG_PREFIX_LENGTH: int = 8
 
 
 class BitbucketAdapter(BaseCIAdapter):
@@ -58,7 +53,7 @@ class BitbucketAdapter(BaseCIAdapter):
             _LOG.debug("Bitbucket: missing PR context — skipping comment")
             return
 
-        token = _env(_ENV_BITBUCKET_TOKEN)
+        token = read_env_variable(_ENV_BITBUCKET_TOKEN)
         if not token:
             _LOG.warning("Bitbucket: BITBUCKET_TOKEN not set — skipping comment")
             return
@@ -91,7 +86,7 @@ class BitbucketAdapter(BaseCIAdapter):
             _LOG.debug("Bitbucket: missing context — skipping commit status")
             return
 
-        token = _env(_ENV_BITBUCKET_TOKEN)
+        token = read_env_variable(_ENV_BITBUCKET_TOKEN)
         if not token:
             _LOG.warning("Bitbucket: BITBUCKET_TOKEN not set — skipping commit status")
             return
@@ -123,4 +118,4 @@ class BitbucketAdapter(BaseCIAdapter):
             )
         )
 
-        _LOG.debug("Bitbucket: commit status set to %s for %s", state, sha[:8])
+        _LOG.debug("Bitbucket: commit status set to %s for %s", state, sha[:_SHA_LOG_PREFIX_LENGTH])

--- a/phi_scan/ci/bitbucket.py
+++ b/phi_scan/ci/bitbucket.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from phi_scan.ci._base import BaseCIAdapter
+from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody
 from phi_scan.ci._detect import PRContext
 from phi_scan.ci._env import fetch_environment_variable
 from phi_scan.ci._transport import (
@@ -75,7 +75,7 @@ class BitbucketAdapter(BaseCIAdapter):
     def can_annotate_code(self) -> bool:
         return True
 
-    def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
+    def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
         pr_id = pr_context.pr_number
         workspace = pr_context.extras.get("workspace", "")
         repo_slug = pr_context.extras.get("repo_slug", "")

--- a/phi_scan/ci/bitbucket.py
+++ b/phi_scan/ci/bitbucket.py
@@ -2,9 +2,6 @@
 
 Posts PR comments and sets commit build statuses via the Bitbucket
 Cloud REST API. Uses ``BITBUCKET_TOKEN`` for authentication.
-
-Note: Bitbucket Code Insights (report + annotations) remains in
-``ci_integration.py`` for now and will be migrated in a follow-up PR.
 """
 
 from __future__ import annotations
@@ -100,7 +97,7 @@ class BitbucketAdapter(BaseCIAdapter):
         payload = {
             "key": _COMMIT_STATUS_CONTEXT,
             "state": state,
-            "name": "phi-scan",
+            "name": _COMMIT_STATUS_CONTEXT,
             "description": (
                 _COMMIT_STATUS_DESCRIPTION_CLEAN
                 if scan_result.is_clean

--- a/phi_scan/ci/bitbucket.py
+++ b/phi_scan/ci/bitbucket.py
@@ -78,7 +78,7 @@ class BitbucketAdapter(BaseCIAdapter):
     def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
         pr_id = pr_context.pr_number
         workspace = pr_context.extras.get("workspace", "")
-        repo_slug = pr_context.extras.get("repo_slug", "")
+        repo_slug = pr_context.repository or ""
 
         if not all((pr_id, workspace, repo_slug)):
             _LOG.warning("Bitbucket: missing PR context — skipping comment")
@@ -110,7 +110,7 @@ class BitbucketAdapter(BaseCIAdapter):
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
         sha = pr_context.sha
         workspace = pr_context.extras.get("workspace", "")
-        repo_slug = pr_context.extras.get("repo_slug", "")
+        repo_slug = pr_context.repository or ""
         if not sha or not workspace or not repo_slug:
             _LOG.warning("Bitbucket: missing context — skipping commit status")
             return

--- a/phi_scan/ci/circleci.py
+++ b/phi_scan/ci/circleci.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 
 from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody, UnsupportedOperation
-from phi_scan.ci._detect import CIPlatform, PRContext
+from phi_scan.ci._detect import CIPlatform, PullRequestContext
 from phi_scan.ci.bitbucket import BitbucketAdapter
 from phi_scan.ci.github import GitHubAdapter
 from phi_scan.models import ScanResult
@@ -30,55 +30,67 @@ class CircleCIAdapter(BaseCIAdapter):
     def can_post_commit_status(self) -> bool:
         return False
 
-    def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
-        pr_url = pr_context.extras.get("circle_pull_request_url", "")
-        if not pr_url:
+    def post_pull_request_comment(
+        self, comment_body: SanitisedCommentBody, pull_request_context: PullRequestContext
+    ) -> None:
+        pull_request_url = pull_request_context.extras.get("circle_pull_request_url", "")
+        if not pull_request_url:
             _LOG.warning("CircleCI: CIRCLE_PULL_REQUEST not set — skipping comment")
             return
 
-        if _GITHUB_URL_HOSTNAME in pr_url:
-            github_context = _build_github_context_from_circle(pr_url, pr_context)
-            GitHubAdapter().post_pr_comment(comment_body, github_context)
-        elif _BITBUCKET_URL_HOSTNAME in pr_url:
-            bitbucket_context = _build_bitbucket_context_from_circle(pr_url, pr_context)
-            BitbucketAdapter().post_pr_comment(comment_body, bitbucket_context)
+        if _GITHUB_URL_HOSTNAME in pull_request_url:
+            github_context = _build_github_context_from_circle(
+                pull_request_url, pull_request_context
+            )
+            GitHubAdapter().post_pull_request_comment(comment_body, github_context)
+        elif _BITBUCKET_URL_HOSTNAME in pull_request_url:
+            bitbucket_context = _build_bitbucket_context_from_circle(
+                pull_request_url, pull_request_context
+            )
+            BitbucketAdapter().post_pull_request_comment(comment_body, bitbucket_context)
         else:
             _LOG.warning("CircleCI: unrecognized VCS in CIRCLE_PULL_REQUEST URL — skipping comment")
 
-    def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+    def set_commit_status(
+        self, scan_result: ScanResult, pull_request_context: PullRequestContext
+    ) -> None:
         self._abort_unsupported_operation(UnsupportedOperation.COMMIT_STATUS)
 
 
-def _build_github_context_from_circle(pr_url: str, pr_context: PRContext) -> PRContext:
-    url_segments = pr_url.rstrip("/").split("/")
+def _build_github_context_from_circle(
+    pull_request_url: str, pull_request_context: PullRequestContext
+) -> PullRequestContext:
+    url_segments = pull_request_url.rstrip("/").split("/")
     repository = (
         f"{url_segments[-4]}/{url_segments[-3]}"
         if len(url_segments) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION
         else None
     )
-    return PRContext(
+    return PullRequestContext(
         platform=CIPlatform.GITHUB_ACTIONS,
-        pr_number=pr_context.pr_number,
+        pull_request_number=pull_request_context.pull_request_number,
         repository=repository,
-        sha=pr_context.sha,
-        branch=pr_context.branch,
-        base_branch=pr_context.base_branch,
+        sha=pull_request_context.sha,
+        branch=pull_request_context.branch,
+        base_branch=pull_request_context.base_branch,
     )
 
 
-def _build_bitbucket_context_from_circle(pr_url: str, pr_context: PRContext) -> PRContext:
-    url_segments = pr_url.rstrip("/").split("/")
+def _build_bitbucket_context_from_circle(
+    pull_request_url: str, pull_request_context: PullRequestContext
+) -> PullRequestContext:
+    url_segments = pull_request_url.rstrip("/").split("/")
     if len(url_segments) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION:
         workspace = url_segments[-4]
         repo_slug = url_segments[-3]
     else:
         workspace = repo_slug = ""
-    return PRContext(
+    return PullRequestContext(
         platform=CIPlatform.BITBUCKET,
-        pr_number=pr_context.pr_number,
-        repository=pr_context.repository,
-        sha=pr_context.sha,
-        branch=pr_context.branch,
-        base_branch=pr_context.base_branch,
+        pull_request_number=pull_request_context.pull_request_number,
+        repository=pull_request_context.repository,
+        sha=pull_request_context.sha,
+        branch=pull_request_context.branch,
+        base_branch=pull_request_context.base_branch,
         extras={"workspace": workspace, "repo_slug": repo_slug},
     )

--- a/phi_scan/ci/circleci.py
+++ b/phi_scan/ci/circleci.py
@@ -46,7 +46,7 @@ class CircleCIAdapter(BaseCIAdapter):
             _LOG.warning("CircleCI: unrecognized VCS in CIRCLE_PULL_REQUEST URL — skipping comment")
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        _LOG.debug("CircleCI: commit status not supported via adapter")
+        self._raise_unsupported("commit status")
 
 
 def _build_github_context_from_circle(pr_url: str, pr_context: PRContext) -> PRContext:

--- a/phi_scan/ci/circleci.py
+++ b/phi_scan/ci/circleci.py
@@ -33,7 +33,7 @@ class CircleCIAdapter(BaseCIAdapter):
     def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
         pr_url = pr_context.extras.get("circle_pull_request_url", "")
         if not pr_url:
-            _LOG.debug("CircleCI: CIRCLE_PULL_REQUEST not set — skipping comment")
+            _LOG.warning("CircleCI: CIRCLE_PULL_REQUEST not set — skipping comment")
             return
 
         if _GITHUB_URL_HOSTNAME in pr_url:

--- a/phi_scan/ci/circleci.py
+++ b/phi_scan/ci/circleci.py
@@ -50,9 +50,11 @@ class CircleCIAdapter(BaseCIAdapter):
 
 
 def _build_github_context_from_circle(pr_url: str, pr_context: PRContext) -> PRContext:
-    parts = pr_url.rstrip("/").split("/")
+    url_segments = pr_url.rstrip("/").split("/")
     repository = (
-        f"{parts[-4]}/{parts[-3]}" if len(parts) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION else None
+        f"{url_segments[-4]}/{url_segments[-3]}"
+        if len(url_segments) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION
+        else None
     )
     return PRContext(
         platform=CIPlatform.GITHUB_ACTIONS,
@@ -65,10 +67,10 @@ def _build_github_context_from_circle(pr_url: str, pr_context: PRContext) -> PRC
 
 
 def _build_bitbucket_context_from_circle(pr_url: str, pr_context: PRContext) -> PRContext:
-    parts = pr_url.rstrip("/").split("/")
-    if len(parts) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION:
-        workspace = parts[-4]
-        repo_slug = parts[-3]
+    url_segments = pr_url.rstrip("/").split("/")
+    if len(url_segments) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION:
+        workspace = url_segments[-4]
+        repo_slug = url_segments[-3]
     else:
         workspace = repo_slug = ""
     return PRContext(

--- a/phi_scan/ci/circleci.py
+++ b/phi_scan/ci/circleci.py
@@ -27,7 +27,7 @@ class CircleCIAdapter(BaseCIAdapter):
     """CircleCI adapter that delegates to GitHub or Bitbucket."""
 
     @property
-    def supports_commit_status(self) -> bool:
+    def can_post_commit_status(self) -> bool:
         return False
 
     def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:

--- a/phi_scan/ci/circleci.py
+++ b/phi_scan/ci/circleci.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 
-from phi_scan.ci._base import BaseCIAdapter
+from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody
 from phi_scan.ci._detect import CIPlatform, PRContext
 from phi_scan.ci.bitbucket import BitbucketAdapter
 from phi_scan.ci.github import GitHubAdapter
@@ -30,7 +30,7 @@ class CircleCIAdapter(BaseCIAdapter):
     def can_post_commit_status(self) -> bool:
         return False
 
-    def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
+    def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
         pr_url = pr_context.extras.get("circle_pull_request_url", "")
         if not pr_url:
             _LOG.debug("CircleCI: CIRCLE_PULL_REQUEST not set — skipping comment")
@@ -46,7 +46,7 @@ class CircleCIAdapter(BaseCIAdapter):
             _LOG.warning("CircleCI: unrecognized VCS in CIRCLE_PULL_REQUEST URL — skipping comment")
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        self._raise_unsupported("commit status")
+        self._raise_unsupported_operation_error("commit status")
 
 
 def _build_github_context_from_circle(pr_url: str, pr_context: PRContext) -> PRContext:

--- a/phi_scan/ci/circleci.py
+++ b/phi_scan/ci/circleci.py
@@ -46,7 +46,7 @@ class CircleCIAdapter(BaseCIAdapter):
             _LOG.warning("CircleCI: unrecognized VCS in CIRCLE_PULL_REQUEST URL — skipping comment")
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        self._raise_unsupported_operation_error(UnsupportedOperation.COMMIT_STATUS)
+        self._abort_unsupported_operation(UnsupportedOperation.COMMIT_STATUS)
 
 
 def _build_github_context_from_circle(pr_url: str, pr_context: PRContext) -> PRContext:

--- a/phi_scan/ci/circleci.py
+++ b/phi_scan/ci/circleci.py
@@ -26,6 +26,10 @@ _MIN_URL_PARTS_FOR_REPO_EXTRACTION: int = 5
 class CircleCIAdapter(BaseCIAdapter):
     """CircleCI adapter that delegates to GitHub or Bitbucket."""
 
+    @property
+    def supports_commit_status(self) -> bool:
+        return False
+
     def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
         pr_url = pr_context.extras.get("circle_pull_request_url", "")
         if not pr_url:
@@ -42,7 +46,7 @@ class CircleCIAdapter(BaseCIAdapter):
             _LOG.warning("CircleCI: unrecognized VCS in CIRCLE_PULL_REQUEST URL — skipping comment")
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        _LOG.debug("CircleCI: commit status handled via underlying VCS platform")
+        _LOG.debug("CircleCI: commit status not supported via adapter")
 
 
 def _build_github_context_from_circle(pr_url: str, pr_context: PRContext) -> PRContext:

--- a/phi_scan/ci/circleci.py
+++ b/phi_scan/ci/circleci.py
@@ -18,6 +18,8 @@ from phi_scan.models import ScanResult
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
+_GITHUB_URL_HOSTNAME: str = "github.com"
+_BITBUCKET_URL_HOSTNAME: str = "bitbucket.org"
 _MIN_URL_PARTS_FOR_REPO_EXTRACTION: int = 5
 
 
@@ -30,10 +32,10 @@ class CircleCIAdapter(BaseCIAdapter):
             _LOG.debug("CircleCI: CIRCLE_PULL_REQUEST not set — skipping comment")
             return
 
-        if "github.com" in pr_url:
+        if _GITHUB_URL_HOSTNAME in pr_url:
             github_context = _build_github_context_from_circle(pr_url, pr_context)
             GitHubAdapter().post_pr_comment(comment_body, github_context)
-        elif "bitbucket.org" in pr_url:
+        elif _BITBUCKET_URL_HOSTNAME in pr_url:
             bitbucket_context = _build_bitbucket_context_from_circle(pr_url, pr_context)
             BitbucketAdapter().post_pr_comment(comment_body, bitbucket_context)
         else:

--- a/phi_scan/ci/circleci.py
+++ b/phi_scan/ci/circleci.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 
-from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody
+from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody, UnsupportedOperation
 from phi_scan.ci._detect import CIPlatform, PRContext
 from phi_scan.ci.bitbucket import BitbucketAdapter
 from phi_scan.ci.github import GitHubAdapter
@@ -46,7 +46,7 @@ class CircleCIAdapter(BaseCIAdapter):
             _LOG.warning("CircleCI: unrecognized VCS in CIRCLE_PULL_REQUEST URL — skipping comment")
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        self._raise_unsupported_operation_error("commit status")
+        self._raise_unsupported_operation_error(UnsupportedOperation.COMMIT_STATUS)
 
 
 def _build_github_context_from_circle(pr_url: str, pr_context: PRContext) -> PRContext:

--- a/phi_scan/ci/circleci.py
+++ b/phi_scan/ci/circleci.py
@@ -1,0 +1,76 @@
+"""CircleCI adapter.
+
+CircleCI is a meta-platform that delegates PR comment posting to
+GitHub or Bitbucket based on the VCS provider detected from
+``CIRCLE_PULL_REQUEST``. CircleCI does not have a native commit
+status API — status is set via the underlying VCS platform.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from phi_scan.ci._base import BaseCIAdapter
+from phi_scan.ci._detect import CIPlatform, PRContext
+from phi_scan.ci.bitbucket import BitbucketAdapter
+from phi_scan.ci.github import GitHubAdapter
+from phi_scan.models import ScanResult
+
+_LOG: logging.Logger = logging.getLogger(__name__)
+
+_MIN_URL_PARTS_FOR_REPO_EXTRACTION: int = 5
+
+
+class CircleCIAdapter(BaseCIAdapter):
+    """CircleCI adapter that delegates to GitHub or Bitbucket."""
+
+    def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
+        pr_url = pr_context.extras.get("circle_pull_request_url", "")
+        if not pr_url:
+            _LOG.debug("CircleCI: CIRCLE_PULL_REQUEST not set — skipping comment")
+            return
+
+        if "github.com" in pr_url:
+            github_context = _build_github_context_from_circle(pr_url, pr_context)
+            GitHubAdapter().post_pr_comment(comment_body, github_context)
+        elif "bitbucket.org" in pr_url:
+            bitbucket_context = _build_bitbucket_context_from_circle(pr_url, pr_context)
+            BitbucketAdapter().post_pr_comment(comment_body, bitbucket_context)
+        else:
+            _LOG.warning("CircleCI: unrecognized VCS in CIRCLE_PULL_REQUEST URL — skipping comment")
+
+    def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+        _LOG.debug("CircleCI: commit status handled via underlying VCS platform")
+
+
+def _build_github_context_from_circle(pr_url: str, pr_context: PRContext) -> PRContext:
+    parts = pr_url.rstrip("/").split("/")
+    repository = (
+        f"{parts[-4]}/{parts[-3]}" if len(parts) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION else None
+    )
+    return PRContext(
+        platform=CIPlatform.GITHUB_ACTIONS,
+        pr_number=pr_context.pr_number,
+        repository=repository,
+        sha=pr_context.sha,
+        branch=pr_context.branch,
+        base_branch=pr_context.base_branch,
+    )
+
+
+def _build_bitbucket_context_from_circle(pr_url: str, pr_context: PRContext) -> PRContext:
+    parts = pr_url.rstrip("/").split("/")
+    if len(parts) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION:
+        workspace = parts[-4]
+        repo_slug = parts[-3]
+    else:
+        workspace = repo_slug = ""
+    return PRContext(
+        platform=CIPlatform.BITBUCKET,
+        pr_number=pr_context.pr_number,
+        repository=pr_context.repository,
+        sha=pr_context.sha,
+        branch=pr_context.branch,
+        base_branch=pr_context.base_branch,
+        extras={"workspace": workspace, "repo_slug": repo_slug},
+    )

--- a/phi_scan/ci/codebuild.py
+++ b/phi_scan/ci/codebuild.py
@@ -46,7 +46,7 @@ class CodeBuildAdapter(BaseCIAdapter):
             _LOG.warning("CodeBuild: unrecognised source repo URL — skipping PR comment")
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        _LOG.debug("CodeBuild: commit status not supported via adapter")
+        self._raise_unsupported("commit status")
 
 
 def _build_github_context_from_codebuild(repo_url: str, pr_context: PRContext) -> PRContext:

--- a/phi_scan/ci/codebuild.py
+++ b/phi_scan/ci/codebuild.py
@@ -11,7 +11,7 @@ import logging
 import os
 
 from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody, UnsupportedOperation
-from phi_scan.ci._detect import CIPlatform, PRContext
+from phi_scan.ci._detect import CIPlatform, PullRequestContext
 from phi_scan.ci.bitbucket import BitbucketAdapter
 from phi_scan.ci.github import GitHubAdapter
 from phi_scan.models import ScanResult
@@ -34,48 +34,58 @@ class CodeBuildAdapter(BaseCIAdapter):
     def can_import_findings_to_security_hub(self) -> bool:
         return True
 
-    def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
+    def post_pull_request_comment(
+        self, comment_body: SanitisedCommentBody, pull_request_context: PullRequestContext
+    ) -> None:
         repo_url = os.environ.get("CODEBUILD_SOURCE_REPO_URL", "")
         if _GITHUB_URL_HOSTNAME in repo_url:
-            github_context = _build_github_context_from_codebuild(repo_url, pr_context)
-            GitHubAdapter().post_pr_comment(comment_body, github_context)
+            github_context = _build_github_context_from_codebuild(repo_url, pull_request_context)
+            GitHubAdapter().post_pull_request_comment(comment_body, github_context)
         elif _BITBUCKET_URL_HOSTNAME in repo_url:
-            bitbucket_context = _build_bitbucket_context_from_codebuild(repo_url, pr_context)
-            BitbucketAdapter().post_pr_comment(comment_body, bitbucket_context)
+            bitbucket_context = _build_bitbucket_context_from_codebuild(
+                repo_url, pull_request_context
+            )
+            BitbucketAdapter().post_pull_request_comment(comment_body, bitbucket_context)
         else:
             _LOG.warning("CodeBuild: unrecognised source repo URL — skipping PR comment")
 
-    def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+    def set_commit_status(
+        self, scan_result: ScanResult, pull_request_context: PullRequestContext
+    ) -> None:
         self._abort_unsupported_operation(UnsupportedOperation.COMMIT_STATUS)
 
 
-def _build_github_context_from_codebuild(repo_url: str, pr_context: PRContext) -> PRContext:
+def _build_github_context_from_codebuild(
+    repo_url: str, pull_request_context: PullRequestContext
+) -> PullRequestContext:
     url_segments = repo_url.rstrip("/").rstrip(".git").split("/")
     repository = (
         f"{url_segments[-2]}/{url_segments[-1]}"
         if len(url_segments) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION
         else None
     )
-    return PRContext(
+    return PullRequestContext(
         platform=CIPlatform.GITHUB_ACTIONS,
-        pr_number=pr_context.pr_number,
+        pull_request_number=pull_request_context.pull_request_number,
         repository=repository,
-        sha=pr_context.sha,
-        branch=pr_context.branch,
-        base_branch=pr_context.base_branch,
+        sha=pull_request_context.sha,
+        branch=pull_request_context.branch,
+        base_branch=pull_request_context.base_branch,
     )
 
 
-def _build_bitbucket_context_from_codebuild(repo_url: str, pr_context: PRContext) -> PRContext:
+def _build_bitbucket_context_from_codebuild(
+    repo_url: str, pull_request_context: PullRequestContext
+) -> PullRequestContext:
     url_segments = repo_url.rstrip("/").rstrip(".git").split("/")
     workspace = url_segments[-2] if len(url_segments) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION else ""
     repo_slug = url_segments[-1] if url_segments else ""
-    return PRContext(
+    return PullRequestContext(
         platform=CIPlatform.BITBUCKET,
-        pr_number=pr_context.pr_number,
-        repository=pr_context.repository,
-        sha=pr_context.sha,
-        branch=pr_context.branch,
-        base_branch=pr_context.base_branch,
+        pull_request_number=pull_request_context.pull_request_number,
+        repository=pull_request_context.repository,
+        sha=pull_request_context.sha,
+        branch=pull_request_context.branch,
+        base_branch=pull_request_context.base_branch,
         extras={"workspace": workspace, "repo_slug": repo_slug},
     )

--- a/phi_scan/ci/codebuild.py
+++ b/phi_scan/ci/codebuild.py
@@ -50,9 +50,11 @@ class CodeBuildAdapter(BaseCIAdapter):
 
 
 def _build_github_context_from_codebuild(repo_url: str, pr_context: PRContext) -> PRContext:
-    parts = repo_url.rstrip("/").rstrip(".git").split("/")
+    url_segments = repo_url.rstrip("/").rstrip(".git").split("/")
     repository = (
-        f"{parts[-2]}/{parts[-1]}" if len(parts) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION else None
+        f"{url_segments[-2]}/{url_segments[-1]}"
+        if len(url_segments) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION
+        else None
     )
     return PRContext(
         platform=CIPlatform.GITHUB_ACTIONS,
@@ -65,9 +67,9 @@ def _build_github_context_from_codebuild(repo_url: str, pr_context: PRContext) -
 
 
 def _build_bitbucket_context_from_codebuild(repo_url: str, pr_context: PRContext) -> PRContext:
-    parts = repo_url.rstrip("/").rstrip(".git").split("/")
-    workspace = parts[-2] if len(parts) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION else ""
-    repo_slug = parts[-1] if parts else ""
+    url_segments = repo_url.rstrip("/").rstrip(".git").split("/")
+    workspace = url_segments[-2] if len(url_segments) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION else ""
+    repo_slug = url_segments[-1] if url_segments else ""
     return PRContext(
         platform=CIPlatform.BITBUCKET,
         pr_number=pr_context.pr_number,

--- a/phi_scan/ci/codebuild.py
+++ b/phi_scan/ci/codebuild.py
@@ -31,7 +31,7 @@ class CodeBuildAdapter(BaseCIAdapter):
         return False
 
     @property
-    def can_import_to_security_hub(self) -> bool:
+    def can_import_findings_to_security_hub(self) -> bool:
         return True
 
     def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:

--- a/phi_scan/ci/codebuild.py
+++ b/phi_scan/ci/codebuild.py
@@ -21,6 +21,8 @@ from phi_scan.models import ScanResult
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
+_GITHUB_URL_HOSTNAME: str = "github.com"
+_BITBUCKET_URL_HOSTNAME: str = "bitbucket.org"
 _MIN_URL_PARTS_FOR_REPO_EXTRACTION: int = 2
 
 
@@ -33,10 +35,10 @@ class CodeBuildAdapter(BaseCIAdapter):
 
     def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
         repo_url = os.environ.get("CODEBUILD_SOURCE_REPO_URL", "")
-        if "github.com" in repo_url:
+        if _GITHUB_URL_HOSTNAME in repo_url:
             github_context = _build_github_context_from_codebuild(repo_url, pr_context)
             GitHubAdapter().post_pr_comment(comment_body, github_context)
-        elif "bitbucket.org" in repo_url:
+        elif _BITBUCKET_URL_HOSTNAME in repo_url:
             bitbucket_context = _build_bitbucket_context_from_codebuild(repo_url, pr_context)
             BitbucketAdapter().post_pr_comment(comment_body, bitbucket_context)
         else:

--- a/phi_scan/ci/codebuild.py
+++ b/phi_scan/ci/codebuild.py
@@ -3,9 +3,6 @@
 CodeBuild is a meta-platform that delegates PR comment posting to
 GitHub or Bitbucket based on the source repository URL detected from
 ``CODEBUILD_SOURCE_REPO_URL``.
-
-Note: AWS Security Hub ASFF import remains in ``ci_integration.py``
-for now and will be migrated in a follow-up PR.
 """
 
 from __future__ import annotations
@@ -30,6 +27,10 @@ class CodeBuildAdapter(BaseCIAdapter):
     """AWS CodeBuild adapter that delegates to GitHub or Bitbucket."""
 
     @property
+    def supports_commit_status(self) -> bool:
+        return False
+
+    @property
     def supports_security_hub(self) -> bool:
         return True
 
@@ -45,7 +46,7 @@ class CodeBuildAdapter(BaseCIAdapter):
             _LOG.warning("CodeBuild: unrecognised source repo URL — skipping PR comment")
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        _LOG.debug("CodeBuild: commit status handled via underlying VCS platform")
+        _LOG.debug("CodeBuild: commit status not supported via adapter")
 
 
 def _build_github_context_from_codebuild(repo_url: str, pr_context: PRContext) -> PRContext:

--- a/phi_scan/ci/codebuild.py
+++ b/phi_scan/ci/codebuild.py
@@ -46,7 +46,7 @@ class CodeBuildAdapter(BaseCIAdapter):
             _LOG.warning("CodeBuild: unrecognised source repo URL — skipping PR comment")
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        self._raise_unsupported_operation_error(UnsupportedOperation.COMMIT_STATUS)
+        self._abort_unsupported_operation(UnsupportedOperation.COMMIT_STATUS)
 
 
 def _build_github_context_from_codebuild(repo_url: str, pr_context: PRContext) -> PRContext:

--- a/phi_scan/ci/codebuild.py
+++ b/phi_scan/ci/codebuild.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import os
 
-from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody
+from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody, UnsupportedOperation
 from phi_scan.ci._detect import CIPlatform, PRContext
 from phi_scan.ci.bitbucket import BitbucketAdapter
 from phi_scan.ci.github import GitHubAdapter
@@ -46,7 +46,7 @@ class CodeBuildAdapter(BaseCIAdapter):
             _LOG.warning("CodeBuild: unrecognised source repo URL — skipping PR comment")
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        self._raise_unsupported_operation_error("commit status")
+        self._raise_unsupported_operation_error(UnsupportedOperation.COMMIT_STATUS)
 
 
 def _build_github_context_from_codebuild(repo_url: str, pr_context: PRContext) -> PRContext:

--- a/phi_scan/ci/codebuild.py
+++ b/phi_scan/ci/codebuild.py
@@ -27,11 +27,11 @@ class CodeBuildAdapter(BaseCIAdapter):
     """AWS CodeBuild adapter that delegates to GitHub or Bitbucket."""
 
     @property
-    def supports_commit_status(self) -> bool:
+    def can_post_commit_status(self) -> bool:
         return False
 
     @property
-    def supports_security_hub(self) -> bool:
+    def can_import_to_security_hub(self) -> bool:
         return True
 
     def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:

--- a/phi_scan/ci/codebuild.py
+++ b/phi_scan/ci/codebuild.py
@@ -1,0 +1,76 @@
+"""AWS CodeBuild adapter.
+
+CodeBuild is a meta-platform that delegates PR comment posting to
+GitHub or Bitbucket based on the source repository URL detected from
+``CODEBUILD_SOURCE_REPO_URL``.
+
+Note: AWS Security Hub ASFF import remains in ``ci_integration.py``
+for now and will be migrated in a follow-up PR.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from phi_scan.ci._base import BaseCIAdapter
+from phi_scan.ci._detect import CIPlatform, PRContext
+from phi_scan.ci.bitbucket import BitbucketAdapter
+from phi_scan.ci.github import GitHubAdapter
+from phi_scan.models import ScanResult
+
+_LOG: logging.Logger = logging.getLogger(__name__)
+
+_MIN_URL_PARTS_FOR_REPO_EXTRACTION: int = 2
+
+
+class CodeBuildAdapter(BaseCIAdapter):
+    """AWS CodeBuild adapter that delegates to GitHub or Bitbucket."""
+
+    @property
+    def supports_security_hub(self) -> bool:
+        return True
+
+    def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
+        repo_url = os.environ.get("CODEBUILD_SOURCE_REPO_URL", "")
+        if "github.com" in repo_url:
+            github_context = _build_github_context_from_codebuild(repo_url, pr_context)
+            GitHubAdapter().post_pr_comment(comment_body, github_context)
+        elif "bitbucket.org" in repo_url:
+            bitbucket_context = _build_bitbucket_context_from_codebuild(repo_url, pr_context)
+            BitbucketAdapter().post_pr_comment(comment_body, bitbucket_context)
+        else:
+            _LOG.warning("CodeBuild: unrecognised source repo URL — skipping PR comment")
+
+    def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+        _LOG.debug("CodeBuild: commit status handled via underlying VCS platform")
+
+
+def _build_github_context_from_codebuild(repo_url: str, pr_context: PRContext) -> PRContext:
+    parts = repo_url.rstrip("/").rstrip(".git").split("/")
+    repository = (
+        f"{parts[-2]}/{parts[-1]}" if len(parts) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION else None
+    )
+    return PRContext(
+        platform=CIPlatform.GITHUB_ACTIONS,
+        pr_number=pr_context.pr_number,
+        repository=repository,
+        sha=pr_context.sha,
+        branch=pr_context.branch,
+        base_branch=pr_context.base_branch,
+    )
+
+
+def _build_bitbucket_context_from_codebuild(repo_url: str, pr_context: PRContext) -> PRContext:
+    parts = repo_url.rstrip("/").rstrip(".git").split("/")
+    workspace = parts[-2] if len(parts) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION else ""
+    repo_slug = parts[-1] if parts else ""
+    return PRContext(
+        platform=CIPlatform.BITBUCKET,
+        pr_number=pr_context.pr_number,
+        repository=pr_context.repository,
+        sha=pr_context.sha,
+        branch=pr_context.branch,
+        base_branch=pr_context.base_branch,
+        extras={"workspace": workspace, "repo_slug": repo_slug},
+    )

--- a/phi_scan/ci/codebuild.py
+++ b/phi_scan/ci/codebuild.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import os
 
-from phi_scan.ci._base import BaseCIAdapter
+from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody
 from phi_scan.ci._detect import CIPlatform, PRContext
 from phi_scan.ci.bitbucket import BitbucketAdapter
 from phi_scan.ci.github import GitHubAdapter
@@ -34,7 +34,7 @@ class CodeBuildAdapter(BaseCIAdapter):
     def can_import_to_security_hub(self) -> bool:
         return True
 
-    def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
+    def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
         repo_url = os.environ.get("CODEBUILD_SOURCE_REPO_URL", "")
         if _GITHUB_URL_HOSTNAME in repo_url:
             github_context = _build_github_context_from_codebuild(repo_url, pr_context)
@@ -46,7 +46,7 @@ class CodeBuildAdapter(BaseCIAdapter):
             _LOG.warning("CodeBuild: unrecognised source repo URL — skipping PR comment")
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        self._raise_unsupported("commit status")
+        self._raise_unsupported_operation_error("commit status")
 
 
 def _build_github_context_from_codebuild(repo_url: str, pr_context: PRContext) -> PRContext:

--- a/phi_scan/ci/github.py
+++ b/phi_scan/ci/github.py
@@ -11,7 +11,7 @@ import os
 import subprocess
 
 from phi_scan.ci._base import BaseCIAdapter
-from phi_scan.ci._detect import PRContext, read_env_variable
+from phi_scan.ci._detect import PRContext, fetch_env_variable
 from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
 from phi_scan.exceptions import CIIntegrationError
 from phi_scan.models import ScanResult
@@ -44,7 +44,7 @@ class GitHubAdapter(BaseCIAdapter):
             _LOG.debug("GitHub: no PR number — skipping comment")
             return
 
-        token = read_env_variable(_ENV_GITHUB_TOKEN)
+        token = fetch_env_variable(_ENV_GITHUB_TOKEN)
         if not token:
             _LOG.warning("GitHub: GITHUB_TOKEN not set — skipping comment")
             return
@@ -88,7 +88,7 @@ class GitHubAdapter(BaseCIAdapter):
             _LOG.debug("GitHub: missing SHA or repository — skipping status")
             return
 
-        token = read_env_variable(_ENV_GITHUB_TOKEN)
+        token = fetch_env_variable(_ENV_GITHUB_TOKEN)
         if not token:
             _LOG.warning("GitHub: GITHUB_TOKEN not set — skipping commit status")
             return

--- a/phi_scan/ci/github.py
+++ b/phi_scan/ci/github.py
@@ -11,7 +11,7 @@ import os
 import subprocess
 
 from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody
-from phi_scan.ci._detect import PRContext
+from phi_scan.ci._detect import PullRequestContext
 from phi_scan.ci._env import fetch_environment_variable
 from phi_scan.ci._transport import (
     HttpMethod,
@@ -52,9 +52,11 @@ class GitHubAdapter(BaseCIAdapter):
     def can_upload_sarif_report(self) -> bool:
         return True
 
-    def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
-        pr_number = pr_context.pr_number
-        if not pr_number:
+    def post_pull_request_comment(
+        self, comment_body: SanitisedCommentBody, pull_request_context: PullRequestContext
+    ) -> None:
+        pull_request_number = pull_request_context.pull_request_number
+        if not pull_request_number:
             _LOG.warning("GitHub: no PR number — skipping comment")
             return
 
@@ -64,12 +66,20 @@ class GitHubAdapter(BaseCIAdapter):
             return
 
         env = {**os.environ, "GITHUB_TOKEN": github_token}
-        if pr_context.repository:
-            env["GH_REPO"] = pr_context.repository
+        if pull_request_context.repository:
+            env["GH_REPO"] = pull_request_context.repository
 
         try:
             gh_result = subprocess.run(
-                ["gh", "pr", "comment", str(pr_number), "--body", comment_body, "--edit-last"],
+                [
+                    "gh",
+                    "pr",
+                    "comment",
+                    str(pull_request_number),
+                    "--body",
+                    comment_body,
+                    "--edit-last",
+                ],
                 capture_output=True,
                 text=True,
                 env=env,
@@ -77,7 +87,7 @@ class GitHubAdapter(BaseCIAdapter):
             )
             if gh_result.returncode != 0:
                 gh_result = subprocess.run(
-                    ["gh", "pr", "comment", str(pr_number), "--body", comment_body],
+                    ["gh", "pr", "comment", str(pull_request_number), "--body", comment_body],
                     capture_output=True,
                     text=True,
                     env=env,
@@ -93,11 +103,13 @@ class GitHubAdapter(BaseCIAdapter):
                 "gh CLI not found — install the GitHub CLI to enable PR comment posting"
             ) from not_found_error
 
-        _LOG.debug("GitHub: PR comment posted to #%s", pr_number)
+        _LOG.debug("GitHub: PR comment posted to #%s", pull_request_number)
 
-    def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        sha = pr_context.sha
-        repository = pr_context.repository
+    def set_commit_status(
+        self, scan_result: ScanResult, pull_request_context: PullRequestContext
+    ) -> None:
+        sha = pull_request_context.sha
+        repository = pull_request_context.repository
         if not sha or not repository:
             _LOG.warning("GitHub: missing SHA or repository — skipping status")
             return

--- a/phi_scan/ci/github.py
+++ b/phi_scan/ci/github.py
@@ -55,7 +55,7 @@ class GitHubAdapter(BaseCIAdapter):
     def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
         pr_number = pr_context.pr_number
         if not pr_number:
-            _LOG.debug("GitHub: no PR number — skipping comment")
+            _LOG.warning("GitHub: no PR number — skipping comment")
             return
 
         token = fetch_environment_variable(_ENV_GITHUB_TOKEN)
@@ -99,7 +99,7 @@ class GitHubAdapter(BaseCIAdapter):
         sha = pr_context.sha
         repository = pr_context.repository
         if not sha or not repository:
-            _LOG.debug("GitHub: missing SHA or repository — skipping status")
+            _LOG.warning("GitHub: missing SHA or repository — skipping status")
             return
 
         token = fetch_environment_variable(_ENV_GITHUB_TOKEN)

--- a/phi_scan/ci/github.py
+++ b/phi_scan/ci/github.py
@@ -49,7 +49,7 @@ class GitHubAdapter(BaseCIAdapter):
     """GitHub Actions adapter using ``gh`` CLI for comments and REST API for statuses."""
 
     @property
-    def can_upload_sarif(self) -> bool:
+    def can_upload_sarif_report(self) -> bool:
         return True
 
     def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
@@ -58,12 +58,12 @@ class GitHubAdapter(BaseCIAdapter):
             _LOG.warning("GitHub: no PR number — skipping comment")
             return
 
-        token = fetch_environment_variable(_ENV_GITHUB_TOKEN)
-        if not token:
+        github_token = fetch_environment_variable(_ENV_GITHUB_TOKEN)
+        if not github_token:
             _LOG.warning("GitHub: GITHUB_TOKEN not set — skipping comment")
             return
 
-        env = {**os.environ, "GITHUB_TOKEN": token}
+        env = {**os.environ, "GITHUB_TOKEN": github_token}
         if pr_context.repository:
             env["GH_REPO"] = pr_context.repository
 
@@ -102,8 +102,8 @@ class GitHubAdapter(BaseCIAdapter):
             _LOG.warning("GitHub: missing SHA or repository — skipping status")
             return
 
-        token = fetch_environment_variable(_ENV_GITHUB_TOKEN)
-        if not token:
+        github_token = fetch_environment_variable(_ENV_GITHUB_TOKEN)
+        if not github_token:
             _LOG.warning("GitHub: GITHUB_TOKEN not set — skipping commit status")
             return
 
@@ -131,7 +131,7 @@ class GitHubAdapter(BaseCIAdapter):
                 url=url,
                 operation_label=OperationLabel.GITHUB_COMMIT_STATUS,
                 headers={
-                    _HTTP_HEADER_AUTHORIZATION: f"Bearer {token}",
+                    _HTTP_HEADER_AUTHORIZATION: f"Bearer {github_token}",
                     _HTTP_HEADER_ACCEPT: _GITHUB_ACCEPT_HEADER_VALUE,
                     _GITHUB_API_VERSION_HEADER: _GITHUB_API_VERSION_VALUE,
                 },

--- a/phi_scan/ci/github.py
+++ b/phi_scan/ci/github.py
@@ -12,7 +12,12 @@ import subprocess
 
 from phi_scan.ci._base import BaseCIAdapter
 from phi_scan.ci._detect import PRContext, fetch_environment_variable
-from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
+from phi_scan.ci._transport import (
+    HttpMethod,
+    HttpRequestConfig,
+    OperationLabel,
+    execute_http_request,
+)
 from phi_scan.exceptions import CIIntegrationError
 from phi_scan.models import ScanResult
 
@@ -123,7 +128,7 @@ class GitHubAdapter(BaseCIAdapter):
             HttpRequestConfig(
                 method=HttpMethod.POST,
                 url=url,
-                operation_label="GitHub commit status",
+                operation_label=OperationLabel.GITHUB_COMMIT_STATUS,
                 headers={
                     _HTTP_HEADER_AUTHORIZATION: f"Bearer {token}",
                     _HTTP_HEADER_ACCEPT: _GITHUB_ACCEPT_HEADER_VALUE,

--- a/phi_scan/ci/github.py
+++ b/phi_scan/ci/github.py
@@ -11,7 +11,8 @@ import os
 import subprocess
 
 from phi_scan.ci._base import BaseCIAdapter
-from phi_scan.ci._detect import PRContext, fetch_environment_variable
+from phi_scan.ci._detect import PRContext
+from phi_scan.ci._env import fetch_environment_variable
 from phi_scan.ci._transport import (
     HttpMethod,
     HttpRequestConfig,
@@ -48,7 +49,7 @@ class GitHubAdapter(BaseCIAdapter):
     """GitHub Actions adapter using ``gh`` CLI for comments and REST API for statuses."""
 
     @property
-    def supports_sarif_upload(self) -> bool:
+    def can_upload_sarif(self) -> bool:
         return True
 
     def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:

--- a/phi_scan/ci/github.py
+++ b/phi_scan/ci/github.py
@@ -11,7 +11,7 @@ import os
 import subprocess
 
 from phi_scan.ci._base import BaseCIAdapter
-from phi_scan.ci._detect import PRContext
+from phi_scan.ci._detect import PRContext, read_env_variable
 from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
 from phi_scan.exceptions import CIIntegrationError
 from phi_scan.models import ScanResult
@@ -28,11 +28,7 @@ _COMMIT_STATUS_DESCRIPTION_CLEAN: str = "No PHI/PII violations found"
 _COMMIT_STATUS_DESCRIPTION_VIOLATIONS: str = "{count} PHI/PII violation(s) found"
 
 _MAX_ERROR_RESPONSE_LOG_LENGTH: int = 200
-
-
-def _env(name: str) -> str | None:
-    env_value = os.environ.get(name, "").strip()
-    return env_value if env_value else None
+_SHA_LOG_PREFIX_LENGTH: int = 8
 
 
 class GitHubAdapter(BaseCIAdapter):
@@ -48,7 +44,7 @@ class GitHubAdapter(BaseCIAdapter):
             _LOG.debug("GitHub: no PR number — skipping comment")
             return
 
-        token = _env(_ENV_GITHUB_TOKEN)
+        token = read_env_variable(_ENV_GITHUB_TOKEN)
         if not token:
             _LOG.warning("GitHub: GITHUB_TOKEN not set — skipping comment")
             return
@@ -92,7 +88,7 @@ class GitHubAdapter(BaseCIAdapter):
             _LOG.debug("GitHub: missing SHA or repository — skipping status")
             return
 
-        token = _env(_ENV_GITHUB_TOKEN)
+        token = read_env_variable(_ENV_GITHUB_TOKEN)
         if not token:
             _LOG.warning("GitHub: GITHUB_TOKEN not set — skipping commit status")
             return
@@ -129,4 +125,5 @@ class GitHubAdapter(BaseCIAdapter):
             )
         )
 
-        _LOG.debug("GitHub: commit status set to %s for %s", github_state, sha[:8])
+        sha_prefix = sha[:_SHA_LOG_PREFIX_LENGTH]
+        _LOG.debug("GitHub: commit status set to %s for %s", github_state, sha_prefix)

--- a/phi_scan/ci/github.py
+++ b/phi_scan/ci/github.py
@@ -10,7 +10,7 @@ import logging
 import os
 import subprocess
 
-from phi_scan.ci._base import BaseCIAdapter
+from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody
 from phi_scan.ci._detect import PRContext
 from phi_scan.ci._env import fetch_environment_variable
 from phi_scan.ci._transport import (
@@ -52,7 +52,7 @@ class GitHubAdapter(BaseCIAdapter):
     def can_upload_sarif(self) -> bool:
         return True
 
-    def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
+    def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
         pr_number = pr_context.pr_number
         if not pr_number:
             _LOG.debug("GitHub: no PR number — skipping comment")

--- a/phi_scan/ci/github.py
+++ b/phi_scan/ci/github.py
@@ -1,0 +1,132 @@
+"""GitHub Actions CI adapter.
+
+Posts PR comments via the ``gh`` CLI and sets commit statuses via the
+GitHub REST API. Uses ``GITHUB_TOKEN`` from the environment for auth.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+
+from phi_scan.ci._base import BaseCIAdapter
+from phi_scan.ci._detect import PRContext
+from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
+from phi_scan.exceptions import CIIntegrationError
+from phi_scan.models import ScanResult
+
+_LOG: logging.Logger = logging.getLogger(__name__)
+
+_ENV_GITHUB_TOKEN: str = "GITHUB_TOKEN"
+
+_GITHUB_API_BASE_URL: str = "https://api.github.com"
+_GITHUB_API_COMMIT_STATUSES_PATH: str = "/repos/{repository}/statuses/{sha}"
+
+_COMMIT_STATUS_CONTEXT: str = "phi-scan"
+_COMMIT_STATUS_DESCRIPTION_CLEAN: str = "No PHI/PII violations found"
+_COMMIT_STATUS_DESCRIPTION_VIOLATIONS: str = "{count} PHI/PII violation(s) found"
+
+_MAX_ERROR_RESPONSE_LOG_LENGTH: int = 200
+
+
+def _env(name: str) -> str | None:
+    env_value = os.environ.get(name, "").strip()
+    return env_value if env_value else None
+
+
+class GitHubAdapter(BaseCIAdapter):
+    """GitHub Actions adapter using ``gh`` CLI for comments and REST API for statuses."""
+
+    @property
+    def supports_sarif_upload(self) -> bool:
+        return True
+
+    def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
+        pr_number = pr_context.pr_number
+        if not pr_number:
+            _LOG.debug("GitHub: no PR number — skipping comment")
+            return
+
+        token = _env(_ENV_GITHUB_TOKEN)
+        if not token:
+            _LOG.warning("GitHub: GITHUB_TOKEN not set — skipping comment")
+            return
+
+        env = {**os.environ, "GITHUB_TOKEN": token}
+        if pr_context.repository:
+            env["GH_REPO"] = pr_context.repository
+
+        try:
+            gh_result = subprocess.run(
+                ["gh", "pr", "comment", str(pr_number), "--body", comment_body, "--edit-last"],
+                capture_output=True,
+                text=True,
+                env=env,
+                check=False,
+            )
+            if gh_result.returncode != 0:
+                gh_result = subprocess.run(
+                    ["gh", "pr", "comment", str(pr_number), "--body", comment_body],
+                    capture_output=True,
+                    text=True,
+                    env=env,
+                    check=False,
+                )
+            if gh_result.returncode != 0:
+                raise CIIntegrationError(
+                    f"gh pr comment failed (exit {gh_result.returncode}): "
+                    f"{gh_result.stderr.strip()[:_MAX_ERROR_RESPONSE_LOG_LENGTH]}"
+                )
+        except FileNotFoundError as not_found_error:
+            raise CIIntegrationError(
+                "gh CLI not found — install the GitHub CLI to enable PR comment posting"
+            ) from not_found_error
+
+        _LOG.debug("GitHub: PR comment posted to #%s", pr_number)
+
+    def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+        sha = pr_context.sha
+        repository = pr_context.repository
+        if not sha or not repository:
+            _LOG.debug("GitHub: missing SHA or repository — skipping status")
+            return
+
+        token = _env(_ENV_GITHUB_TOKEN)
+        if not token:
+            _LOG.warning("GitHub: GITHUB_TOKEN not set — skipping commit status")
+            return
+
+        github_state = "success" if scan_result.is_clean else "failure"
+        findings_count = len(scan_result.findings)
+        description = (
+            _COMMIT_STATUS_DESCRIPTION_CLEAN
+            if scan_result.is_clean
+            else _COMMIT_STATUS_DESCRIPTION_VIOLATIONS.format(count=findings_count)
+        )
+
+        url = _GITHUB_API_BASE_URL + _GITHUB_API_COMMIT_STATUSES_PATH.format(
+            repository=repository,
+            sha=sha,
+        )
+        payload = {
+            "state": github_state,
+            "description": description,
+            "context": _COMMIT_STATUS_CONTEXT,
+        }
+
+        execute_http_request(
+            HttpRequestConfig(
+                method=HttpMethod.POST,
+                url=url,
+                operation_label="GitHub commit status",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+                json_body=payload,
+            )
+        )
+
+        _LOG.debug("GitHub: commit status set to %s for %s", github_state, sha[:8])

--- a/phi_scan/ci/github.py
+++ b/phi_scan/ci/github.py
@@ -11,7 +11,7 @@ import os
 import subprocess
 
 from phi_scan.ci._base import BaseCIAdapter
-from phi_scan.ci._detect import PRContext, fetch_env_variable
+from phi_scan.ci._detect import PRContext, fetch_environment_variable
 from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
 from phi_scan.exceptions import CIIntegrationError
 from phi_scan.models import ScanResult
@@ -30,6 +30,14 @@ _COMMIT_STATUS_DESCRIPTION_VIOLATIONS: str = "{count} PHI/PII violation(s) found
 _MAX_ERROR_RESPONSE_LOG_LENGTH: int = 200
 _SHA_LOG_PREFIX_LENGTH: int = 8
 
+_HTTP_HEADER_AUTHORIZATION: str = "Authorization"
+_HTTP_HEADER_ACCEPT: str = "Accept"
+_GITHUB_ACCEPT_HEADER_VALUE: str = "application/vnd.github+json"
+_GITHUB_API_VERSION_HEADER: str = "X-GitHub-Api-Version"
+_GITHUB_API_VERSION_VALUE: str = "2022-11-28"
+_GITHUB_STATUS_SUCCESS: str = "success"
+_GITHUB_STATUS_FAILURE: str = "failure"
+
 
 class GitHubAdapter(BaseCIAdapter):
     """GitHub Actions adapter using ``gh`` CLI for comments and REST API for statuses."""
@@ -44,7 +52,7 @@ class GitHubAdapter(BaseCIAdapter):
             _LOG.debug("GitHub: no PR number — skipping comment")
             return
 
-        token = fetch_env_variable(_ENV_GITHUB_TOKEN)
+        token = fetch_environment_variable(_ENV_GITHUB_TOKEN)
         if not token:
             _LOG.warning("GitHub: GITHUB_TOKEN not set — skipping comment")
             return
@@ -88,12 +96,12 @@ class GitHubAdapter(BaseCIAdapter):
             _LOG.debug("GitHub: missing SHA or repository — skipping status")
             return
 
-        token = fetch_env_variable(_ENV_GITHUB_TOKEN)
+        token = fetch_environment_variable(_ENV_GITHUB_TOKEN)
         if not token:
             _LOG.warning("GitHub: GITHUB_TOKEN not set — skipping commit status")
             return
 
-        github_state = "success" if scan_result.is_clean else "failure"
+        github_state = _GITHUB_STATUS_SUCCESS if scan_result.is_clean else _GITHUB_STATUS_FAILURE
         findings_count = len(scan_result.findings)
         description = (
             _COMMIT_STATUS_DESCRIPTION_CLEAN
@@ -117,9 +125,9 @@ class GitHubAdapter(BaseCIAdapter):
                 url=url,
                 operation_label="GitHub commit status",
                 headers={
-                    "Authorization": f"Bearer {token}",
-                    "Accept": "application/vnd.github+json",
-                    "X-GitHub-Api-Version": "2022-11-28",
+                    _HTTP_HEADER_AUTHORIZATION: f"Bearer {token}",
+                    _HTTP_HEADER_ACCEPT: _GITHUB_ACCEPT_HEADER_VALUE,
+                    _GITHUB_API_VERSION_HEADER: _GITHUB_API_VERSION_VALUE,
                 },
                 json_body=payload,
             )

--- a/phi_scan/ci/gitlab.py
+++ b/phi_scan/ci/gitlab.py
@@ -46,7 +46,7 @@ class GitLabAdapter(BaseCIAdapter):
         mr_iid = pr_context.pr_number
         project_id = pr_context.repository
         if not mr_iid or not project_id:
-            _LOG.debug("GitLab: missing MR IID or project ID — skipping comment")
+            _LOG.warning("GitLab: missing MR IID or project ID — skipping comment")
             return
 
         token = fetch_environment_variable(_ENV_GITLAB_TOKEN) or fetch_environment_variable(
@@ -80,7 +80,7 @@ class GitLabAdapter(BaseCIAdapter):
         sha = pr_context.sha
         project_id = pr_context.repository
         if not sha or not project_id:
-            _LOG.debug("GitLab: missing SHA or project ID — skipping status")
+            _LOG.warning("GitLab: missing SHA or project ID — skipping status")
             return
 
         token = fetch_environment_variable(_ENV_GITLAB_TOKEN) or fetch_environment_variable(

--- a/phi_scan/ci/gitlab.py
+++ b/phi_scan/ci/gitlab.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 
 from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody
-from phi_scan.ci._detect import PRContext
+from phi_scan.ci._detect import PullRequestContext
 from phi_scan.ci._env import fetch_environment_variable
 from phi_scan.ci._transport import (
     HttpMethod,
@@ -42,9 +42,11 @@ _SHA_LOG_PREFIX_LENGTH: int = 8
 class GitLabAdapter(BaseCIAdapter):
     """GitLab CI adapter using the GitLab REST API."""
 
-    def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
-        mr_iid = pr_context.pr_number
-        project_id = pr_context.repository
+    def post_pull_request_comment(
+        self, comment_body: SanitisedCommentBody, pull_request_context: PullRequestContext
+    ) -> None:
+        mr_iid = pull_request_context.pull_request_number
+        project_id = pull_request_context.repository
         if not mr_iid or not project_id:
             _LOG.warning("GitLab: missing MR IID or project ID — skipping comment")
             return
@@ -56,7 +58,7 @@ class GitLabAdapter(BaseCIAdapter):
             _LOG.warning("GitLab: GITLAB_TOKEN and CI_JOB_TOKEN not set — skipping comment")
             return
 
-        server_url = pr_context.extras.get("ci_server_url") or _GITLAB_DEFAULT_SERVER_URL
+        server_url = pull_request_context.extras.get("ci_server_url") or _GITLAB_DEFAULT_SERVER_URL
         url = server_url.rstrip("/") + _GITLAB_API_MR_NOTES_PATH.format(
             project_id=project_id,
             mr_iid=mr_iid,
@@ -79,9 +81,11 @@ class GitLabAdapter(BaseCIAdapter):
 
         _LOG.debug("GitLab: MR note posted to !%s", mr_iid)
 
-    def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        sha = pr_context.sha
-        project_id = pr_context.repository
+    def set_commit_status(
+        self, scan_result: ScanResult, pull_request_context: PullRequestContext
+    ) -> None:
+        sha = pull_request_context.sha
+        project_id = pull_request_context.repository
         if not sha or not project_id:
             _LOG.warning("GitLab: missing SHA or project ID — skipping status")
             return
@@ -93,7 +97,7 @@ class GitLabAdapter(BaseCIAdapter):
             _LOG.warning("GitLab: no token — skipping commit status")
             return
 
-        server_url = pr_context.extras.get("ci_server_url") or _GITLAB_DEFAULT_SERVER_URL
+        server_url = pull_request_context.extras.get("ci_server_url") or _GITLAB_DEFAULT_SERVER_URL
         commit_status_state = (
             _GITLAB_STATUS_SUCCESS if scan_result.is_clean else _GITLAB_STATUS_FAILED
         )

--- a/phi_scan/ci/gitlab.py
+++ b/phi_scan/ci/gitlab.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 
 from phi_scan.ci._base import BaseCIAdapter
-from phi_scan.ci._detect import PRContext, read_env_variable
+from phi_scan.ci._detect import PRContext, fetch_env_variable
 from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
 from phi_scan.models import ScanResult
 
@@ -39,7 +39,7 @@ class GitLabAdapter(BaseCIAdapter):
             _LOG.debug("GitLab: missing MR IID or project ID — skipping comment")
             return
 
-        token = read_env_variable(_ENV_GITLAB_TOKEN) or read_env_variable(_ENV_CI_JOB_TOKEN)
+        token = fetch_env_variable(_ENV_GITLAB_TOKEN) or fetch_env_variable(_ENV_CI_JOB_TOKEN)
         if not token:
             _LOG.warning("GitLab: GITLAB_TOKEN and CI_JOB_TOKEN not set — skipping comment")
             return
@@ -71,7 +71,7 @@ class GitLabAdapter(BaseCIAdapter):
             _LOG.debug("GitLab: missing SHA or project ID — skipping status")
             return
 
-        token = read_env_variable(_ENV_GITLAB_TOKEN) or read_env_variable(_ENV_CI_JOB_TOKEN)
+        token = fetch_env_variable(_ENV_GITLAB_TOKEN) or fetch_env_variable(_ENV_CI_JOB_TOKEN)
         if not token:
             _LOG.warning("GitLab: no token — skipping commit status")
             return

--- a/phi_scan/ci/gitlab.py
+++ b/phi_scan/ci/gitlab.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 import logging
 
 from phi_scan.ci._base import BaseCIAdapter
-from phi_scan.ci._detect import PRContext, fetch_environment_variable
+from phi_scan.ci._detect import PRContext
+from phi_scan.ci._env import fetch_environment_variable
 from phi_scan.ci._transport import (
     HttpMethod,
     HttpRequestConfig,

--- a/phi_scan/ci/gitlab.py
+++ b/phi_scan/ci/gitlab.py
@@ -49,10 +49,10 @@ class GitLabAdapter(BaseCIAdapter):
             _LOG.warning("GitLab: missing MR IID or project ID — skipping comment")
             return
 
-        token = fetch_environment_variable(_ENV_GITLAB_TOKEN) or fetch_environment_variable(
+        gitlab_token = fetch_environment_variable(_ENV_GITLAB_TOKEN) or fetch_environment_variable(
             _ENV_CI_JOB_TOKEN
         )
-        if not token:
+        if not gitlab_token:
             _LOG.warning("GitLab: GITLAB_TOKEN and CI_JOB_TOKEN not set — skipping comment")
             return
 
@@ -61,7 +61,10 @@ class GitLabAdapter(BaseCIAdapter):
             project_id=project_id,
             mr_iid=mr_iid,
         )
-        headers = {_HTTP_HEADER_PRIVATE_TOKEN: token, _HTTP_HEADER_CONTENT_TYPE: _JSON_CONTENT_TYPE}
+        headers = {
+            _HTTP_HEADER_PRIVATE_TOKEN: gitlab_token,
+            _HTTP_HEADER_CONTENT_TYPE: _JSON_CONTENT_TYPE,
+        }
         payload = {"body": comment_body}
 
         execute_http_request(
@@ -83,10 +86,10 @@ class GitLabAdapter(BaseCIAdapter):
             _LOG.warning("GitLab: missing SHA or project ID — skipping status")
             return
 
-        token = fetch_environment_variable(_ENV_GITLAB_TOKEN) or fetch_environment_variable(
+        gitlab_token = fetch_environment_variable(_ENV_GITLAB_TOKEN) or fetch_environment_variable(
             _ENV_CI_JOB_TOKEN
         )
-        if not token:
+        if not gitlab_token:
             _LOG.warning("GitLab: no token — skipping commit status")
             return
 
@@ -113,7 +116,7 @@ class GitLabAdapter(BaseCIAdapter):
                 method=HttpMethod.POST,
                 url=url,
                 operation_label=OperationLabel.GITLAB_COMMIT_STATUS,
-                headers={_HTTP_HEADER_PRIVATE_TOKEN: token},
+                headers={_HTTP_HEADER_PRIVATE_TOKEN: gitlab_token},
                 json_body=payload,
             )
         )

--- a/phi_scan/ci/gitlab.py
+++ b/phi_scan/ci/gitlab.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 
 from phi_scan.ci._base import BaseCIAdapter
-from phi_scan.ci._detect import PRContext, fetch_env_variable
+from phi_scan.ci._detect import PRContext, fetch_environment_variable
 from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
 from phi_scan.models import ScanResult
 
@@ -22,8 +22,12 @@ _GITLAB_DEFAULT_SERVER_URL: str = "https://gitlab.com"
 _GITLAB_API_MR_NOTES_PATH: str = "/api/v4/projects/{project_id}/merge_requests/{mr_iid}/notes"
 _GITLAB_API_COMMIT_STATUSES_PATH: str = "/api/v4/projects/{project_id}/statuses/{sha}"
 
+_HTTP_HEADER_PRIVATE_TOKEN: str = "PRIVATE-TOKEN"
+_HTTP_HEADER_CONTENT_TYPE: str = "Content-Type"
 _JSON_CONTENT_TYPE: str = "application/json"
 _COMMIT_STATUS_CONTEXT: str = "phi-scan"
+_GITLAB_STATUS_SUCCESS: str = "success"
+_GITLAB_STATUS_FAILED: str = "failed"
 _COMMIT_STATUS_DESCRIPTION_CLEAN: str = "No PHI/PII violations found"
 _COMMIT_STATUS_DESCRIPTION_VIOLATIONS: str = "{count} PHI/PII violation(s) found"
 _SHA_LOG_PREFIX_LENGTH: int = 8
@@ -39,7 +43,9 @@ class GitLabAdapter(BaseCIAdapter):
             _LOG.debug("GitLab: missing MR IID or project ID — skipping comment")
             return
 
-        token = fetch_env_variable(_ENV_GITLAB_TOKEN) or fetch_env_variable(_ENV_CI_JOB_TOKEN)
+        token = fetch_environment_variable(_ENV_GITLAB_TOKEN) or fetch_environment_variable(
+            _ENV_CI_JOB_TOKEN
+        )
         if not token:
             _LOG.warning("GitLab: GITLAB_TOKEN and CI_JOB_TOKEN not set — skipping comment")
             return
@@ -49,7 +55,7 @@ class GitLabAdapter(BaseCIAdapter):
             project_id=project_id,
             mr_iid=mr_iid,
         )
-        headers = {"PRIVATE-TOKEN": token, "Content-Type": _JSON_CONTENT_TYPE}
+        headers = {_HTTP_HEADER_PRIVATE_TOKEN: token, _HTTP_HEADER_CONTENT_TYPE: _JSON_CONTENT_TYPE}
         payload = {"body": comment_body}
 
         execute_http_request(
@@ -71,19 +77,23 @@ class GitLabAdapter(BaseCIAdapter):
             _LOG.debug("GitLab: missing SHA or project ID — skipping status")
             return
 
-        token = fetch_env_variable(_ENV_GITLAB_TOKEN) or fetch_env_variable(_ENV_CI_JOB_TOKEN)
+        token = fetch_environment_variable(_ENV_GITLAB_TOKEN) or fetch_environment_variable(
+            _ENV_CI_JOB_TOKEN
+        )
         if not token:
             _LOG.warning("GitLab: no token — skipping commit status")
             return
 
         server_url = pr_context.extras.get("ci_server_url") or _GITLAB_DEFAULT_SERVER_URL
-        state = "success" if scan_result.is_clean else "failed"
+        commit_status_state = (
+            _GITLAB_STATUS_SUCCESS if scan_result.is_clean else _GITLAB_STATUS_FAILED
+        )
         url = server_url.rstrip("/") + _GITLAB_API_COMMIT_STATUSES_PATH.format(
             project_id=project_id,
             sha=sha,
         )
         payload = {
-            "state": state,
+            "state": commit_status_state,
             "name": _COMMIT_STATUS_CONTEXT,
             "description": (
                 _COMMIT_STATUS_DESCRIPTION_CLEAN
@@ -97,9 +107,10 @@ class GitLabAdapter(BaseCIAdapter):
                 method=HttpMethod.POST,
                 url=url,
                 operation_label="GitLab commit status",
-                headers={"PRIVATE-TOKEN": token},
+                headers={_HTTP_HEADER_PRIVATE_TOKEN: token},
                 json_body=payload,
             )
         )
 
-        _LOG.debug("GitLab: commit status set to %s for %s", state, sha[:_SHA_LOG_PREFIX_LENGTH])
+        sha_prefix = sha[:_SHA_LOG_PREFIX_LENGTH]
+        _LOG.debug("GitLab: commit status set to %s for %s", commit_status_state, sha_prefix)

--- a/phi_scan/ci/gitlab.py
+++ b/phi_scan/ci/gitlab.py
@@ -1,0 +1,110 @@
+"""GitLab CI adapter.
+
+Posts MR notes and sets commit statuses via the GitLab REST API.
+Uses ``GITLAB_TOKEN`` or ``CI_JOB_TOKEN`` for authentication.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from phi_scan.ci._base import BaseCIAdapter
+from phi_scan.ci._detect import PRContext
+from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
+from phi_scan.models import ScanResult
+
+_LOG: logging.Logger = logging.getLogger(__name__)
+
+_ENV_GITLAB_TOKEN: str = "GITLAB_TOKEN"
+_ENV_CI_JOB_TOKEN: str = "CI_JOB_TOKEN"
+
+_GITLAB_DEFAULT_SERVER_URL: str = "https://gitlab.com"
+_GITLAB_API_MR_NOTES_PATH: str = "/api/v4/projects/{project_id}/merge_requests/{mr_iid}/notes"
+_GITLAB_API_COMMIT_STATUSES_PATH: str = "/api/v4/projects/{project_id}/statuses/{sha}"
+
+_JSON_CONTENT_TYPE: str = "application/json"
+_COMMIT_STATUS_CONTEXT: str = "phi-scan"
+_COMMIT_STATUS_DESCRIPTION_CLEAN: str = "No PHI/PII violations found"
+_COMMIT_STATUS_DESCRIPTION_VIOLATIONS: str = "{count} PHI/PII violation(s) found"
+
+
+def _env(name: str) -> str | None:
+    env_value = os.environ.get(name, "").strip()
+    return env_value if env_value else None
+
+
+class GitLabAdapter(BaseCIAdapter):
+    """GitLab CI adapter using the GitLab REST API."""
+
+    def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
+        mr_iid = pr_context.pr_number
+        project_id = pr_context.repository
+        if not mr_iid or not project_id:
+            _LOG.debug("GitLab: missing MR IID or project ID — skipping comment")
+            return
+
+        token = _env(_ENV_GITLAB_TOKEN) or _env(_ENV_CI_JOB_TOKEN)
+        if not token:
+            _LOG.warning("GitLab: GITLAB_TOKEN and CI_JOB_TOKEN not set — skipping comment")
+            return
+
+        server_url = pr_context.extras.get("ci_server_url") or _GITLAB_DEFAULT_SERVER_URL
+        url = server_url.rstrip("/") + _GITLAB_API_MR_NOTES_PATH.format(
+            project_id=project_id,
+            mr_iid=mr_iid,
+        )
+        headers = {"PRIVATE-TOKEN": token, "Content-Type": _JSON_CONTENT_TYPE}
+        payload = {"body": comment_body}
+
+        execute_http_request(
+            HttpRequestConfig(
+                method=HttpMethod.POST,
+                url=url,
+                operation_label="GitLab MR comment",
+                headers=headers,
+                json_body=payload,
+            )
+        )
+
+        _LOG.debug("GitLab: MR note posted to !%s", mr_iid)
+
+    def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+        sha = pr_context.sha
+        project_id = pr_context.repository
+        if not sha or not project_id:
+            _LOG.debug("GitLab: missing SHA or project ID — skipping status")
+            return
+
+        token = _env(_ENV_GITLAB_TOKEN) or _env(_ENV_CI_JOB_TOKEN)
+        if not token:
+            _LOG.warning("GitLab: no token — skipping commit status")
+            return
+
+        server_url = pr_context.extras.get("ci_server_url") or _GITLAB_DEFAULT_SERVER_URL
+        state = "success" if scan_result.is_clean else "failed"
+        url = server_url.rstrip("/") + _GITLAB_API_COMMIT_STATUSES_PATH.format(
+            project_id=project_id,
+            sha=sha,
+        )
+        payload = {
+            "state": state,
+            "name": _COMMIT_STATUS_CONTEXT,
+            "description": (
+                _COMMIT_STATUS_DESCRIPTION_CLEAN
+                if scan_result.is_clean
+                else _COMMIT_STATUS_DESCRIPTION_VIOLATIONS.format(count=len(scan_result.findings))
+            ),
+        }
+
+        execute_http_request(
+            HttpRequestConfig(
+                method=HttpMethod.POST,
+                url=url,
+                operation_label="GitLab commit status",
+                headers={"PRIVATE-TOKEN": token},
+                json_body=payload,
+            )
+        )
+
+        _LOG.debug("GitLab: commit status set to %s for %s", state, sha[:8])

--- a/phi_scan/ci/gitlab.py
+++ b/phi_scan/ci/gitlab.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 
-from phi_scan.ci._base import BaseCIAdapter
+from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody
 from phi_scan.ci._detect import PRContext
 from phi_scan.ci._env import fetch_environment_variable
 from phi_scan.ci._transport import (
@@ -42,7 +42,7 @@ _SHA_LOG_PREFIX_LENGTH: int = 8
 class GitLabAdapter(BaseCIAdapter):
     """GitLab CI adapter using the GitLab REST API."""
 
-    def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
+    def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
         mr_iid = pr_context.pr_number
         project_id = pr_context.repository
         if not mr_iid or not project_id:

--- a/phi_scan/ci/gitlab.py
+++ b/phi_scan/ci/gitlab.py
@@ -7,10 +7,9 @@ Uses ``GITLAB_TOKEN`` or ``CI_JOB_TOKEN`` for authentication.
 from __future__ import annotations
 
 import logging
-import os
 
 from phi_scan.ci._base import BaseCIAdapter
-from phi_scan.ci._detect import PRContext
+from phi_scan.ci._detect import PRContext, read_env_variable
 from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
 from phi_scan.models import ScanResult
 
@@ -27,11 +26,7 @@ _JSON_CONTENT_TYPE: str = "application/json"
 _COMMIT_STATUS_CONTEXT: str = "phi-scan"
 _COMMIT_STATUS_DESCRIPTION_CLEAN: str = "No PHI/PII violations found"
 _COMMIT_STATUS_DESCRIPTION_VIOLATIONS: str = "{count} PHI/PII violation(s) found"
-
-
-def _env(name: str) -> str | None:
-    env_value = os.environ.get(name, "").strip()
-    return env_value if env_value else None
+_SHA_LOG_PREFIX_LENGTH: int = 8
 
 
 class GitLabAdapter(BaseCIAdapter):
@@ -44,7 +39,7 @@ class GitLabAdapter(BaseCIAdapter):
             _LOG.debug("GitLab: missing MR IID or project ID — skipping comment")
             return
 
-        token = _env(_ENV_GITLAB_TOKEN) or _env(_ENV_CI_JOB_TOKEN)
+        token = read_env_variable(_ENV_GITLAB_TOKEN) or read_env_variable(_ENV_CI_JOB_TOKEN)
         if not token:
             _LOG.warning("GitLab: GITLAB_TOKEN and CI_JOB_TOKEN not set — skipping comment")
             return
@@ -76,7 +71,7 @@ class GitLabAdapter(BaseCIAdapter):
             _LOG.debug("GitLab: missing SHA or project ID — skipping status")
             return
 
-        token = _env(_ENV_GITLAB_TOKEN) or _env(_ENV_CI_JOB_TOKEN)
+        token = read_env_variable(_ENV_GITLAB_TOKEN) or read_env_variable(_ENV_CI_JOB_TOKEN)
         if not token:
             _LOG.warning("GitLab: no token — skipping commit status")
             return
@@ -107,4 +102,4 @@ class GitLabAdapter(BaseCIAdapter):
             )
         )
 
-        _LOG.debug("GitLab: commit status set to %s for %s", state, sha[:8])
+        _LOG.debug("GitLab: commit status set to %s for %s", state, sha[:_SHA_LOG_PREFIX_LENGTH])

--- a/phi_scan/ci/gitlab.py
+++ b/phi_scan/ci/gitlab.py
@@ -10,7 +10,12 @@ import logging
 
 from phi_scan.ci._base import BaseCIAdapter
 from phi_scan.ci._detect import PRContext, fetch_environment_variable
-from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
+from phi_scan.ci._transport import (
+    HttpMethod,
+    HttpRequestConfig,
+    OperationLabel,
+    execute_http_request,
+)
 from phi_scan.models import ScanResult
 
 _LOG: logging.Logger = logging.getLogger(__name__)
@@ -62,7 +67,7 @@ class GitLabAdapter(BaseCIAdapter):
             HttpRequestConfig(
                 method=HttpMethod.POST,
                 url=url,
-                operation_label="GitLab MR comment",
+                operation_label=OperationLabel.GITLAB_MR_COMMENT,
                 headers=headers,
                 json_body=payload,
             )
@@ -106,7 +111,7 @@ class GitLabAdapter(BaseCIAdapter):
             HttpRequestConfig(
                 method=HttpMethod.POST,
                 url=url,
-                operation_label="GitLab commit status",
+                operation_label=OperationLabel.GITLAB_COMMIT_STATUS,
                 headers={_HTTP_HEADER_PRIVATE_TOKEN: token},
                 json_body=payload,
             )

--- a/phi_scan/ci/jenkins.py
+++ b/phi_scan/ci/jenkins.py
@@ -50,9 +50,11 @@ class JenkinsAdapter(BaseCIAdapter):
 
 
 def _build_github_context_from_jenkins(change_url: str, pr_context: PRContext) -> PRContext:
-    parts = change_url.rstrip("/").split("/")
+    url_segments = change_url.rstrip("/").split("/")
     repository = (
-        f"{parts[-4]}/{parts[-3]}" if len(parts) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION else None
+        f"{url_segments[-4]}/{url_segments[-3]}"
+        if len(url_segments) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION
+        else None
     )
     return PRContext(
         platform=CIPlatform.GITHUB_ACTIONS,

--- a/phi_scan/ci/jenkins.py
+++ b/phi_scan/ci/jenkins.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 
 from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody, UnsupportedOperation
-from phi_scan.ci._detect import CIPlatform, PRContext
+from phi_scan.ci._detect import CIPlatform, PullRequestContext
 from phi_scan.ci.github import GitHubAdapter
 from phi_scan.ci.gitlab import GitLabAdapter
 from phi_scan.models import ScanResult
@@ -30,37 +30,43 @@ class JenkinsAdapter(BaseCIAdapter):
     def can_post_commit_status(self) -> bool:
         return False
 
-    def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
-        change_url = pr_context.extras.get("change_url", "")
+    def post_pull_request_comment(
+        self, comment_body: SanitisedCommentBody, pull_request_context: PullRequestContext
+    ) -> None:
+        change_url = pull_request_context.extras.get("change_url", "")
         if not change_url:
             _LOG.warning("Jenkins: CHANGE_URL not set — skipping comment")
             return
 
         if _GITHUB_URL_HOSTNAME in change_url:
-            github_context = _build_github_context_from_jenkins(change_url, pr_context)
-            GitHubAdapter().post_pr_comment(comment_body, github_context)
+            github_context = _build_github_context_from_jenkins(change_url, pull_request_context)
+            GitHubAdapter().post_pull_request_comment(comment_body, github_context)
         elif _GITLAB_URL_KEYWORD in change_url:
             _LOG.debug("Jenkins: GitLab VCS detected — delegating to GitLab adapter")
-            GitLabAdapter().post_pr_comment(comment_body, pr_context)
+            GitLabAdapter().post_pull_request_comment(comment_body, pull_request_context)
         else:
             _LOG.warning("Jenkins: unrecognized VCS in CHANGE_URL — skipping comment")
 
-    def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+    def set_commit_status(
+        self, scan_result: ScanResult, pull_request_context: PullRequestContext
+    ) -> None:
         self._abort_unsupported_operation(UnsupportedOperation.COMMIT_STATUS)
 
 
-def _build_github_context_from_jenkins(change_url: str, pr_context: PRContext) -> PRContext:
+def _build_github_context_from_jenkins(
+    change_url: str, pull_request_context: PullRequestContext
+) -> PullRequestContext:
     url_segments = change_url.rstrip("/").split("/")
     repository = (
         f"{url_segments[-4]}/{url_segments[-3]}"
         if len(url_segments) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION
         else None
     )
-    return PRContext(
+    return PullRequestContext(
         platform=CIPlatform.GITHUB_ACTIONS,
-        pr_number=pr_context.pr_number,
+        pull_request_number=pull_request_context.pull_request_number,
         repository=repository,
-        sha=pr_context.sha,
-        branch=pr_context.branch,
-        base_branch=pr_context.base_branch,
+        sha=pull_request_context.sha,
+        branch=pull_request_context.branch,
+        base_branch=pull_request_context.base_branch,
     )

--- a/phi_scan/ci/jenkins.py
+++ b/phi_scan/ci/jenkins.py
@@ -46,7 +46,7 @@ class JenkinsAdapter(BaseCIAdapter):
             _LOG.warning("Jenkins: unrecognized VCS in CHANGE_URL — skipping comment")
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        _LOG.debug("Jenkins: commit status not supported via adapter")
+        self._raise_unsupported("commit status")
 
 
 def _build_github_context_from_jenkins(change_url: str, pr_context: PRContext) -> PRContext:

--- a/phi_scan/ci/jenkins.py
+++ b/phi_scan/ci/jenkins.py
@@ -33,7 +33,7 @@ class JenkinsAdapter(BaseCIAdapter):
     def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
         change_url = pr_context.extras.get("change_url", "")
         if not change_url:
-            _LOG.debug("Jenkins: CHANGE_URL not set — skipping comment")
+            _LOG.warning("Jenkins: CHANGE_URL not set — skipping comment")
             return
 
         if _GITHUB_URL_HOSTNAME in change_url:

--- a/phi_scan/ci/jenkins.py
+++ b/phi_scan/ci/jenkins.py
@@ -26,6 +26,10 @@ _MIN_URL_PARTS_FOR_REPO_EXTRACTION: int = 5
 class JenkinsAdapter(BaseCIAdapter):
     """Jenkins adapter that delegates to GitHub or GitLab based on VCS."""
 
+    @property
+    def supports_commit_status(self) -> bool:
+        return False
+
     def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
         change_url = pr_context.extras.get("change_url", "")
         if not change_url:
@@ -42,7 +46,7 @@ class JenkinsAdapter(BaseCIAdapter):
             _LOG.warning("Jenkins: unrecognized VCS in CHANGE_URL — skipping comment")
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        _LOG.debug("Jenkins: commit status handled via underlying VCS platform")
+        _LOG.debug("Jenkins: commit status not supported via adapter")
 
 
 def _build_github_context_from_jenkins(change_url: str, pr_context: PRContext) -> PRContext:

--- a/phi_scan/ci/jenkins.py
+++ b/phi_scan/ci/jenkins.py
@@ -1,0 +1,58 @@
+"""Jenkins CI adapter.
+
+Jenkins is a meta-platform that delegates PR comment posting to
+GitHub or GitLab based on the ``CHANGE_URL`` environment variable.
+Jenkins does not set a native commit status — status is handled
+via the underlying VCS platform.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from phi_scan.ci._base import BaseCIAdapter
+from phi_scan.ci._detect import CIPlatform, PRContext
+from phi_scan.ci.github import GitHubAdapter
+from phi_scan.ci.gitlab import GitLabAdapter
+from phi_scan.models import ScanResult
+
+_LOG: logging.Logger = logging.getLogger(__name__)
+
+_MIN_URL_PARTS_FOR_REPO_EXTRACTION: int = 5
+
+
+class JenkinsAdapter(BaseCIAdapter):
+    """Jenkins adapter that delegates to GitHub or GitLab based on VCS."""
+
+    def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
+        change_url = pr_context.extras.get("change_url", "")
+        if not change_url:
+            _LOG.debug("Jenkins: CHANGE_URL not set — skipping comment")
+            return
+
+        if "github.com" in change_url:
+            github_context = _build_github_context_from_jenkins(change_url, pr_context)
+            GitHubAdapter().post_pr_comment(comment_body, github_context)
+        elif "gitlab" in change_url:
+            _LOG.debug("Jenkins: GitLab VCS detected — delegating to GitLab adapter")
+            GitLabAdapter().post_pr_comment(comment_body, pr_context)
+        else:
+            _LOG.warning("Jenkins: unrecognized VCS in CHANGE_URL — skipping comment")
+
+    def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
+        _LOG.debug("Jenkins: commit status handled via underlying VCS platform")
+
+
+def _build_github_context_from_jenkins(change_url: str, pr_context: PRContext) -> PRContext:
+    parts = change_url.rstrip("/").split("/")
+    repository = (
+        f"{parts[-4]}/{parts[-3]}" if len(parts) >= _MIN_URL_PARTS_FOR_REPO_EXTRACTION else None
+    )
+    return PRContext(
+        platform=CIPlatform.GITHUB_ACTIONS,
+        pr_number=pr_context.pr_number,
+        repository=repository,
+        sha=pr_context.sha,
+        branch=pr_context.branch,
+        base_branch=pr_context.base_branch,
+    )

--- a/phi_scan/ci/jenkins.py
+++ b/phi_scan/ci/jenkins.py
@@ -27,7 +27,7 @@ class JenkinsAdapter(BaseCIAdapter):
     """Jenkins adapter that delegates to GitHub or GitLab based on VCS."""
 
     @property
-    def supports_commit_status(self) -> bool:
+    def can_post_commit_status(self) -> bool:
         return False
 
     def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:

--- a/phi_scan/ci/jenkins.py
+++ b/phi_scan/ci/jenkins.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 
-from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody
+from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody, UnsupportedOperation
 from phi_scan.ci._detect import CIPlatform, PRContext
 from phi_scan.ci.github import GitHubAdapter
 from phi_scan.ci.gitlab import GitLabAdapter
@@ -46,7 +46,7 @@ class JenkinsAdapter(BaseCIAdapter):
             _LOG.warning("Jenkins: unrecognized VCS in CHANGE_URL — skipping comment")
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        self._raise_unsupported_operation_error("commit status")
+        self._raise_unsupported_operation_error(UnsupportedOperation.COMMIT_STATUS)
 
 
 def _build_github_context_from_jenkins(change_url: str, pr_context: PRContext) -> PRContext:

--- a/phi_scan/ci/jenkins.py
+++ b/phi_scan/ci/jenkins.py
@@ -18,6 +18,8 @@ from phi_scan.models import ScanResult
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
+_GITHUB_URL_HOSTNAME: str = "github.com"
+_GITLAB_URL_KEYWORD: str = "gitlab"
 _MIN_URL_PARTS_FOR_REPO_EXTRACTION: int = 5
 
 
@@ -30,10 +32,10 @@ class JenkinsAdapter(BaseCIAdapter):
             _LOG.debug("Jenkins: CHANGE_URL not set — skipping comment")
             return
 
-        if "github.com" in change_url:
+        if _GITHUB_URL_HOSTNAME in change_url:
             github_context = _build_github_context_from_jenkins(change_url, pr_context)
             GitHubAdapter().post_pr_comment(comment_body, github_context)
-        elif "gitlab" in change_url:
+        elif _GITLAB_URL_KEYWORD in change_url:
             _LOG.debug("Jenkins: GitLab VCS detected — delegating to GitLab adapter")
             GitLabAdapter().post_pr_comment(comment_body, pr_context)
         else:

--- a/phi_scan/ci/jenkins.py
+++ b/phi_scan/ci/jenkins.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 
-from phi_scan.ci._base import BaseCIAdapter
+from phi_scan.ci._base import BaseCIAdapter, SanitisedCommentBody
 from phi_scan.ci._detect import CIPlatform, PRContext
 from phi_scan.ci.github import GitHubAdapter
 from phi_scan.ci.gitlab import GitLabAdapter
@@ -30,7 +30,7 @@ class JenkinsAdapter(BaseCIAdapter):
     def can_post_commit_status(self) -> bool:
         return False
 
-    def post_pr_comment(self, comment_body: str, pr_context: PRContext) -> None:
+    def post_pr_comment(self, comment_body: SanitisedCommentBody, pr_context: PRContext) -> None:
         change_url = pr_context.extras.get("change_url", "")
         if not change_url:
             _LOG.debug("Jenkins: CHANGE_URL not set — skipping comment")
@@ -46,7 +46,7 @@ class JenkinsAdapter(BaseCIAdapter):
             _LOG.warning("Jenkins: unrecognized VCS in CHANGE_URL — skipping comment")
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        self._raise_unsupported("commit status")
+        self._raise_unsupported_operation_error("commit status")
 
 
 def _build_github_context_from_jenkins(change_url: str, pr_context: PRContext) -> PRContext:

--- a/phi_scan/ci/jenkins.py
+++ b/phi_scan/ci/jenkins.py
@@ -46,7 +46,7 @@ class JenkinsAdapter(BaseCIAdapter):
             _LOG.warning("Jenkins: unrecognized VCS in CHANGE_URL — skipping comment")
 
     def set_commit_status(self, scan_result: ScanResult, pr_context: PRContext) -> None:
-        self._raise_unsupported_operation_error(UnsupportedOperation.COMMIT_STATUS)
+        self._abort_unsupported_operation(UnsupportedOperation.COMMIT_STATUS)
 
 
 def _build_github_context_from_jenkins(change_url: str, pr_context: PRContext) -> PRContext:

--- a/phi_scan/ci_integration.py
+++ b/phi_scan/ci_integration.py
@@ -44,10 +44,8 @@ from phi_scan.ci import (  # noqa: F401 — backward-compatible re-exports
     GitHubAdapter,
     GitLabAdapter,
     JenkinsAdapter,
-    PRContext,
     PullRequestContext,
     detect_platform,
-    get_pr_context,
     get_pull_request_context,
     resolve_adapter,
 )
@@ -62,6 +60,9 @@ from phi_scan.constants import SeverityLevel
 from phi_scan.exceptions import CIIntegrationError  # noqa: F401 — backward-compatible re-export
 from phi_scan.models import ScanResult
 from phi_scan.output import format_sarif
+
+PRContext = PullRequestContext
+get_pr_context = get_pull_request_context
 
 __all__ = [
     "AzureAdapter",

--- a/phi_scan/ci_integration.py
+++ b/phi_scan/ci_integration.py
@@ -45,8 +45,10 @@ from phi_scan.ci import (  # noqa: F401 — backward-compatible re-exports
     GitLabAdapter,
     JenkinsAdapter,
     PRContext,
+    PullRequestContext,
     detect_platform,
     get_pr_context,
+    get_pull_request_context,
     resolve_adapter,
 )
 from phi_scan.ci._base import SanitisedCommentBody
@@ -77,6 +79,7 @@ __all__ = [
     "JenkinsAdapter",
     "OperationLabel",
     "PRContext",
+    "PullRequestContext",
     "SanitisedCommentBody",
     "build_comment_body",
     "build_comment_body_with_baseline",
@@ -85,9 +88,11 @@ __all__ = [
     "detect_platform",
     "execute_http_request",
     "get_pr_context",
+    "get_pull_request_context",
     "import_findings_to_security_hub",
     "post_bitbucket_code_insights",
     "post_pr_comment",
+    "post_pull_request_comment",
     "resolve_adapter",
     "set_azure_build_tag",
     "set_azure_pr_status",
@@ -344,7 +349,7 @@ def post_pr_comment(scan_result: ScanResult, pr_context: PRContext) -> None:
     Does nothing and logs a warning when the platform is ``UNKNOWN`` or when
     required context (PR number, token) is missing.
     """
-    if not pr_context.pr_number:
+    if not pr_context.pull_request_number:
         _LOG.debug("No PR number in context — skipping comment posting")
         return
 
@@ -358,7 +363,10 @@ def post_pr_comment(scan_result: ScanResult, pr_context: PRContext) -> None:
         return
 
     comment_body = build_comment_body(scan_result)
-    adapter.post_pr_comment(comment_body, pr_context)
+    adapter.post_pull_request_comment(comment_body, pr_context)
+
+
+post_pull_request_comment = post_pr_comment
 
 
 # ---------------------------------------------------------------------------
@@ -619,7 +627,7 @@ def set_azure_build_tag(scan_result: ScanResult, pr_context: PRContext) -> None:
 
 def set_azure_pr_status(scan_result: ScanResult, pr_context: PRContext) -> None:
     """Set an Azure DevOps PR status to block or allow completion via branch policy."""
-    pr_id = pr_context.pr_number
+    pr_id = pr_context.pull_request_number
     repo_id = pr_context.repository
     collection_uri = pr_context.extras.get("collection_uri", "")
     team_project = pr_context.extras.get("team_project", "")
@@ -687,7 +695,7 @@ def create_azure_boards_work_item(scan_result: ScanResult, pr_context: PRContext
 
     collection_uri = pr_context.extras.get("collection_uri", "")
     team_project = pr_context.extras.get("team_project", "")
-    pr_id = pr_context.pr_number or "unknown"
+    pr_id = pr_context.pull_request_number or "unknown"
 
     if not all((collection_uri, team_project)):
         _LOG.debug("Azure Boards: missing context — skipping work item")

--- a/phi_scan/ci_integration.py
+++ b/phi_scan/ci_integration.py
@@ -379,7 +379,7 @@ def set_commit_status(scan_result: ScanResult, pr_context: PRContext) -> None:
         )
         return
 
-    if not adapter.supports_commit_status:
+    if not adapter.can_post_commit_status:
         _LOG.debug(
             "Adapter %s does not support commit status — skipping",
             type(adapter).__name__,

--- a/phi_scan/ci_integration.py
+++ b/phi_scan/ci_integration.py
@@ -341,6 +341,13 @@ def set_commit_status(scan_result: ScanResult, pr_context: PRContext) -> None:
         )
         return
 
+    if not adapter.supports_commit_status:
+        _LOG.debug(
+            "Adapter %s does not support commit status — skipping",
+            type(adapter).__name__,
+        )
+        return
+
     adapter.set_commit_status(scan_result, pr_context)
 
 

--- a/phi_scan/ci_integration.py
+++ b/phi_scan/ci_integration.py
@@ -43,15 +43,13 @@ from phi_scan.ci import (  # noqa: F401 — backward-compatible re-exports
     CodeBuildAdapter,
     GitHubAdapter,
     GitLabAdapter,
-    HttpMethod,
-    HttpRequestConfig,
     JenkinsAdapter,
     PRContext,
     detect_platform,
-    execute_http_request,
     get_pr_context,
     resolve_adapter,
 )
+from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
 from phi_scan.constants import SeverityLevel
 from phi_scan.exceptions import CIIntegrationError  # noqa: F401 — backward-compatible re-export
 from phi_scan.models import ScanResult

--- a/phi_scan/ci_integration.py
+++ b/phi_scan/ci_integration.py
@@ -598,7 +598,7 @@ def set_azure_build_tag(scan_result: ScanResult, pr_context: PRContext) -> None:
             url=url,
             operation_label="Azure DevOps build tag",
             binary_body=_AZURE_BUILD_TAG_EMPTY_BODY,
-            auth=("", token),
+            basic_auth_credentials=("", token),
         )
     )
 
@@ -650,7 +650,7 @@ def set_azure_pr_status(scan_result: ScanResult, pr_context: PRContext) -> None:
             url=url,
             operation_label="Azure DevOps PR status",
             json_body=payload,
-            auth=("", token),
+            basic_auth_credentials=("", token),
         )
     )
 
@@ -717,7 +717,7 @@ def create_azure_boards_work_item(scan_result: ScanResult, pr_context: PRContext
             operation_label="Azure Boards work item",
             headers={"Content-Type": _AZURE_PATCH_CONTENT_TYPE},
             json_body=patch_payload,
-            auth=("", token),
+            basic_auth_credentials=("", token),
         )
     )
 

--- a/phi_scan/ci_integration.py
+++ b/phi_scan/ci_integration.py
@@ -55,6 +55,38 @@ from phi_scan.exceptions import CIIntegrationError  # noqa: F401 — backward-co
 from phi_scan.models import ScanResult
 from phi_scan.output import format_sarif
 
+__all__ = [
+    "AzureAdapter",
+    "BaseCIAdapter",
+    "BaselineComparison",
+    "BitbucketAdapter",
+    "CIIntegrationError",
+    "CIPlatform",
+    "CircleCIAdapter",
+    "CodeBuildAdapter",
+    "GitHubAdapter",
+    "GitLabAdapter",
+    "HttpMethod",
+    "HttpRequestConfig",
+    "JenkinsAdapter",
+    "PRContext",
+    "build_comment_body",
+    "build_comment_body_with_baseline",
+    "convert_findings_to_asff",
+    "create_azure_boards_work_item",
+    "detect_platform",
+    "execute_http_request",
+    "get_pr_context",
+    "import_findings_to_security_hub",
+    "post_bitbucket_code_insights",
+    "post_pr_comment",
+    "resolve_adapter",
+    "set_azure_build_tag",
+    "set_azure_pr_status",
+    "set_commit_status",
+    "upload_sarif_to_github",
+]
+
 _LOG: logging.Logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------

--- a/phi_scan/ci_integration.py
+++ b/phi_scan/ci_integration.py
@@ -49,7 +49,12 @@ from phi_scan.ci import (  # noqa: F401 — backward-compatible re-exports
     get_pr_context,
     resolve_adapter,
 )
-from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
+from phi_scan.ci._transport import (
+    HttpMethod,
+    HttpRequestConfig,
+    OperationLabel,
+    execute_http_request,
+)
 from phi_scan.constants import SeverityLevel
 from phi_scan.exceptions import CIIntegrationError  # noqa: F401 — backward-compatible re-export
 from phi_scan.models import ScanResult
@@ -69,6 +74,7 @@ __all__ = [
     "HttpMethod",
     "HttpRequestConfig",
     "JenkinsAdapter",
+    "OperationLabel",
     "PRContext",
     "build_comment_body",
     "build_comment_body_with_baseline",
@@ -452,7 +458,7 @@ def upload_sarif_to_github(scan_result: ScanResult, pr_context: PRContext) -> No
         HttpRequestConfig(
             method=HttpMethod.POST,
             url=url,
-            operation_label="GitHub SARIF upload",
+            operation_label=OperationLabel.GITHUB_SARIF_UPLOAD,
             headers={
                 "Authorization": f"Bearer {token}",
                 "Accept": "application/vnd.github+json",
@@ -516,7 +522,7 @@ def post_bitbucket_code_insights(scan_result: ScanResult, pr_context: PRContext)
         HttpRequestConfig(
             method=HttpMethod.PUT,
             url=report_url,
-            operation_label="Bitbucket Code Insights report",
+            operation_label=OperationLabel.BITBUCKET_CODE_INSIGHTS_REPORT,
             headers=headers,
             json_body=report_payload,
         )
@@ -550,7 +556,7 @@ def post_bitbucket_code_insights(scan_result: ScanResult, pr_context: PRContext)
         HttpRequestConfig(
             method=HttpMethod.POST,
             url=annotations_url,
-            operation_label="Bitbucket Code Insights annotations",
+            operation_label=OperationLabel.BITBUCKET_CODE_INSIGHTS_ANNOTATIONS,
             headers=headers,
             json_body=annotations,
         )
@@ -574,7 +580,7 @@ def set_azure_build_tag(scan_result: ScanResult, pr_context: PRContext) -> None:
     team_project = pr_context.extras.get("team_project", "")
     build_id = pr_context.extras.get("build_id", "")
 
-    if not all([collection_uri, team_project, build_id]):
+    if not all((collection_uri, team_project, build_id)):
         _LOG.debug("Azure DevOps build tag: missing context — skipping")
         return
 
@@ -596,7 +602,7 @@ def set_azure_build_tag(scan_result: ScanResult, pr_context: PRContext) -> None:
         HttpRequestConfig(
             method=HttpMethod.PUT,
             url=url,
-            operation_label="Azure DevOps build tag",
+            operation_label=OperationLabel.AZURE_BUILD_TAG,
             binary_body=_AZURE_BUILD_TAG_EMPTY_BODY,
             basic_auth_credentials=("", token),
         )
@@ -612,7 +618,7 @@ def set_azure_pr_status(scan_result: ScanResult, pr_context: PRContext) -> None:
     collection_uri = pr_context.extras.get("collection_uri", "")
     team_project = pr_context.extras.get("team_project", "")
 
-    if not all([pr_id, repo_id, collection_uri, team_project]):
+    if not all((pr_id, repo_id, collection_uri, team_project)):
         _LOG.debug("Azure DevOps PR status: missing context — skipping")
         return
 
@@ -648,7 +654,7 @@ def set_azure_pr_status(scan_result: ScanResult, pr_context: PRContext) -> None:
         HttpRequestConfig(
             method=HttpMethod.POST,
             url=url,
-            operation_label="Azure DevOps PR status",
+            operation_label=OperationLabel.AZURE_PR_STATUS,
             json_body=payload,
             basic_auth_credentials=("", token),
         )
@@ -677,7 +683,7 @@ def create_azure_boards_work_item(scan_result: ScanResult, pr_context: PRContext
     team_project = pr_context.extras.get("team_project", "")
     pr_id = pr_context.pr_number or "unknown"
 
-    if not all([collection_uri, team_project]):
+    if not all((collection_uri, team_project)):
         _LOG.debug("Azure Boards: missing context — skipping work item")
         return
 
@@ -714,7 +720,7 @@ def create_azure_boards_work_item(scan_result: ScanResult, pr_context: PRContext
         HttpRequestConfig(
             method=HttpMethod.POST,
             url=url,
-            operation_label="Azure Boards work item",
+            operation_label=OperationLabel.AZURE_WORK_ITEM,
             headers={"Content-Type": _AZURE_PATCH_CONTENT_TYPE},
             json_body=patch_payload,
             basic_auth_credentials=("", token),

--- a/phi_scan/ci_integration.py
+++ b/phi_scan/ci_integration.py
@@ -348,8 +348,9 @@ def post_pr_comment(scan_result: ScanResult, pr_context: PRContext) -> None:
         _LOG.debug("No PR number in context — skipping comment posting")
         return
 
-    adapter = resolve_adapter(pr_context.platform)
-    if adapter is None:
+    try:
+        adapter = resolve_adapter(pr_context.platform)
+    except CIIntegrationError:
         _LOG.warning(
             "PR comment posting not implemented for platform %s",
             pr_context.platform.value,
@@ -375,8 +376,9 @@ def set_commit_status(scan_result: ScanResult, pr_context: PRContext) -> None:
         _LOG.debug("No commit SHA in context — skipping status posting")
         return
 
-    adapter = resolve_adapter(pr_context.platform)
-    if adapter is None:
+    try:
+        adapter = resolve_adapter(pr_context.platform)
+    except CIIntegrationError:
         _LOG.warning(
             "Commit status not implemented for platform %s",
             pr_context.platform.value,

--- a/phi_scan/ci_integration.py
+++ b/phi_scan/ci_integration.py
@@ -49,6 +49,7 @@ from phi_scan.ci import (  # noqa: F401 — backward-compatible re-exports
     get_pr_context,
     resolve_adapter,
 )
+from phi_scan.ci._base import SanitisedCommentBody
 from phi_scan.ci._transport import (
     HttpMethod,
     HttpRequestConfig,
@@ -76,6 +77,7 @@ __all__ = [
     "JenkinsAdapter",
     "OperationLabel",
     "PRContext",
+    "SanitisedCommentBody",
     "build_comment_body",
     "build_comment_body_with_baseline",
     "convert_findings_to_asff",
@@ -223,7 +225,7 @@ def _env(name: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def build_comment_body(scan_result: ScanResult) -> str:
+def build_comment_body(scan_result: ScanResult) -> SanitisedCommentBody:
     """Build a markdown PR/MR comment body from a ``ScanResult``.
 
     The body contains only counts, file names, and line numbers — never raw
@@ -242,7 +244,7 @@ def build_comment_body(scan_result: ScanResult) -> str:
             "",
             f"*Scan duration: {scan_result.scan_duration:.2f}s*",
         ]
-        return "\n".join(body_lines)
+        return SanitisedCommentBody("\n".join(body_lines))
 
     findings_count = len(scan_result.findings)
     header = _COMMENT_HEADER_VIOLATIONS
@@ -301,7 +303,7 @@ def build_comment_body(scan_result: ScanResult) -> str:
         comment_body = (
             comment_body[:_MAX_COMMENT_LENGTH] + "\n\n*(comment truncated — too many findings)*"
         )
-    return comment_body
+    return SanitisedCommentBody(comment_body)
 
 
 def _insert_baseline_context_into_comment(
@@ -318,14 +320,16 @@ def _insert_baseline_context_into_comment(
 def build_comment_body_with_baseline(
     scan_result: ScanResult,
     baseline_comparison: BaselineComparison,
-) -> str:
+) -> SanitisedCommentBody:
     """Build a PR/MR comment body that includes baseline comparison context."""
     baseline_line = _BASELINE_CONTEXT_FORMAT.format(
         new_findings_count=baseline_comparison.new_findings_count,
         baselined_count=baseline_comparison.baselined_count,
         resolved_count=baseline_comparison.resolved_count,
     )
-    return _insert_baseline_context_into_comment(build_comment_body(scan_result), baseline_line)
+    return SanitisedCommentBody(
+        _insert_baseline_context_into_comment(build_comment_body(scan_result), baseline_line)
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/phi_scan/ci_integration.py
+++ b/phi_scan/ci_integration.py
@@ -1,183 +1,68 @@
+# phi-scan:ignore-file
 """CI/CD platform integration for phi-scan.
 
-Provides auto-detection of the running CI/CD platform, extraction of PR/MR
-context from environment variables, PR/MR comment posting, and commit status
-reporting across all seven supported platforms:
+This module is the backward-compatible entry point for CI/CD integration.
+Platform detection, PR context extraction, and per-platform adapters now
+live in the ``phi_scan.ci`` package. This module provides:
 
-  - GitHub Actions    (via ``gh`` CLI)
-  - GitLab CI         (via GitLab REST API)
-  - Jenkins           (via GitHub/GitLab API depending on VCS source)
-  - Azure DevOps      (via Azure DevOps REST API)
-  - CircleCI          (via GitHub/Bitbucket API depending on VCS)
-  - Bitbucket         (via Bitbucket Cloud REST API)
-  - AWS CodeBuild     (via GitHub/Bitbucket API depending on webhook source)
-
-Each public function accepts a ``ScanResult`` and a ``PRContext`` and returns
-``None``. Network errors are caught and re-raised as ``CIIntegrationError`` so
-the caller (CLI scan command) can decide whether to fail the build or continue.
-
-Design constraints:
-  - No PHI leaves the process — comment bodies contain only counts, file names,
-    and line numbers. Raw entity values are never included.
-  - HTTP error messages include only the status code and reason phrase, never the
-    response body — API error responses for comment endpoints could echo back
-    request content containing finding metadata (HIPAA categories, file paths).
-  - All HTTP calls use ``httpx`` (already a project dependency).
-  - ``gh`` CLI is used for GitHub because it handles token auth and API versioning.
-  - Authentication tokens are read from environment variables only — never from
-    config files (which may be committed to version control).
+  1. **Orchestration**: ``post_pr_comment`` and ``set_commit_status``
+     dispatch to per-platform adapters via ``phi_scan.ci.resolve_adapter``.
+  2. **Comment formatting**: ``build_comment_body`` and
+     ``build_comment_body_with_baseline`` produce the markdown PR body.
+  3. **Platform-specific extras**: SARIF upload, Bitbucket Code Insights,
+     Azure build tags/PR statuses/Boards work items, and AWS Security Hub
+     ASFF import remain here pending a follow-up migration PR.
+  4. **Backward-compatible re-exports**: all names previously importable
+     from ``phi_scan.ci_integration`` continue to work.
 
 Security audit summary
 ----------------------
-This section is placed at the top of the module so it remains visible within
-GitHub's 30,000-character diff truncation limit. All claims are machine-verified
-by tests in ``tests/test_ci_integration_remaining.py``.
-
-**Exception handling** — all 12 outbound HTTP calls go through
-``_execute_http_request``, which re-raises both ``httpx.HTTPStatusError`` and
-``httpx.RequestError`` as ``CIIntegrationError``. None swallow. Verify:
-``grep -c "raise_for_status" phi_scan/ci_integration.py`` == 2 (one in the
-helper body, one in the docstring). Sentinel tests confirm error messages never
-include ``response.text``:
-  - ``test_upload_sarif_http_error_excludes_response_body``
-  - ``test_set_azure_build_tag_http_error_excludes_response_body``
-  - ``test_set_azure_pr_status_http_error_excludes_response_body``
-  - ``test_post_bitbucket_code_insights_http_error_excludes_response_body``
-
-**SARIF message text** — ``format_sarif`` delegates to
-``_build_sarif_finding_message`` (``phi_scan/output/serializers.py``). That function uses
-only ``hipaa_category.value`` (enum label), ``detection_layer.value`` (enum
-label), ``confidence`` (float), and ``remediation_hint`` (pre-canned guidance
-string). Raw entity values, ``code_context``, and ``value_hash`` are explicitly
-excluded. PHI-safety is documented in the expanded docstring in ``output.py`` and
-enforced by ``_verify_sarif_excludes_code_snippets()`` before every upload.
-
-**Outbound payload fields** — all payload builders are audited:
-  - Azure work item: only aggregate count (int) + PR number (str). Verified by
-    ``test_create_azure_boards_work_item_payload_excludes_phi_fields`` which
-    asserts entity_type, hipaa_category, value_hash, code_context, and
-    remediation_hint are all absent from the POST body.
-  - ASFF (Security Hub): file_path, line_number, entity_type,
-    hipaa_category.value, confidence (float) — zero PHI-derived data. The ASFF
-    Id field uses repository + file_path + line_number + entity_type (structural
-    fields only). value_hash and all derivatives are excluded because SSNs have
-    ~30 bits of entropy: any SHA-256 output is reversible over the 30-bit input
-    space regardless of output length. Verified by
-    ``test_convert_findings_to_asff_excludes_code_context``,
-    ``test_convert_findings_to_asff_fields_are_enumerated_types_and_counts``, and
-    ``test_convert_findings_to_asff_excludes_full_value_hash``.
-  - Bitbucket Code Insights annotations: file_path, line_number,
-    hipaa_category.value, severity label, confidence (float) — never raw entity
-    value or code_context.
+All outbound HTTP calls go through ``phi_scan.ci._transport.execute_http_request``,
+which re-raises both ``httpx.HTTPStatusError`` and ``httpx.RequestError`` as
+``CIIntegrationError``. Error messages include only the status code and reason
+phrase — never the response body.
 """
 
 from __future__ import annotations
 
 import base64
-import enum
 import gzip
 import json
 import logging
 import os
 import subprocess
-from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
-import httpx
-
+from phi_scan.ci import (  # noqa: F401 — backward-compatible re-exports
+    AzureAdapter,
+    BaseCIAdapter,
+    BitbucketAdapter,
+    CIPlatform,
+    CircleCIAdapter,
+    CodeBuildAdapter,
+    GitHubAdapter,
+    GitLabAdapter,
+    HttpMethod,
+    HttpRequestConfig,
+    JenkinsAdapter,
+    PRContext,
+    detect_platform,
+    execute_http_request,
+    get_pr_context,
+    resolve_adapter,
+)
 from phi_scan.constants import SeverityLevel
-from phi_scan.exceptions import PhiScanError
+from phi_scan.exceptions import CIIntegrationError  # noqa: F401 — backward-compatible re-export
 from phi_scan.models import ScanResult
 from phi_scan.output import format_sarif
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Constants — environment variable names
+# Constants — comment formatting
 # ---------------------------------------------------------------------------
 
-# GitHub Actions
-_ENV_GITHUB_ACTIONS: str = "GITHUB_ACTIONS"
-_ENV_GITHUB_TOKEN: str = "GITHUB_TOKEN"
-_ENV_GITHUB_REPOSITORY: str = "GITHUB_REPOSITORY"
-_ENV_GITHUB_SHA: str = "GITHUB_SHA"
-_ENV_GITHUB_REF: str = "GITHUB_REF"
-_ENV_PR_NUMBER: str = "PR_NUMBER"
-
-# GitLab CI
-_ENV_GITLAB_CI: str = "GITLAB_CI"
-_ENV_GITLAB_TOKEN: str = "GITLAB_TOKEN"
-_ENV_CI_JOB_TOKEN: str = "CI_JOB_TOKEN"
-_ENV_CI_PROJECT_ID: str = "CI_PROJECT_ID"
-_ENV_CI_MERGE_REQUEST_IID: str = "CI_MERGE_REQUEST_IID"
-_ENV_CI_SERVER_URL: str = "CI_SERVER_URL"
-_ENV_CI_COMMIT_SHA: str = "CI_COMMIT_SHA"
-_ENV_CI_COMMIT_REF_NAME: str = "CI_COMMIT_REF_NAME"
-
-# Jenkins
-_ENV_JENKINS_URL: str = "JENKINS_URL"
-_ENV_CHANGE_ID: str = "CHANGE_ID"
-_ENV_CHANGE_URL: str = "CHANGE_URL"
-
-# Azure DevOps
-_ENV_TF_BUILD: str = "TF_BUILD"
-_ENV_SYSTEM_TEAMFOUNDATIONCOLLECTIONURI: str = "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI"
-_ENV_SYSTEM_TEAMPROJECT: str = "SYSTEM_TEAMPROJECT"
-_ENV_SYSTEM_ACCESSTOKEN: str = "SYSTEM_ACCESSTOKEN"
-_ENV_BUILD_REPOSITORY_ID: str = "BUILD_REPOSITORY_ID"
-_ENV_BUILD_REPOSITORY_URI: str = "BUILD_REPOSITORY_URI"
-_ENV_SYSTEM_PULLREQUEST_PULLREQUESTID: str = "SYSTEM_PULLREQUEST_PULLREQUESTID"
-_ENV_BUILD_BUILDID: str = "BUILD_BUILDID"
-_ENV_BUILD_SOURCEVERSION: str = "BUILD_SOURCEVERSION"
-
-# CircleCI
-_ENV_CIRCLECI: str = "CIRCLECI"
-_ENV_CIRCLE_PULL_REQUEST: str = "CIRCLE_PULL_REQUEST"
-_ENV_CIRCLE_SHA1: str = "CIRCLE_SHA1"
-_ENV_CIRCLE_BRANCH: str = "CIRCLE_BRANCH"
-
-# Bitbucket Pipelines
-_ENV_BITBUCKET_BUILD_NUMBER: str = "BITBUCKET_BUILD_NUMBER"
-_ENV_BITBUCKET_TOKEN: str = "BITBUCKET_TOKEN"
-_ENV_BITBUCKET_PR_ID: str = "BITBUCKET_PR_ID"
-_ENV_BITBUCKET_REPO_SLUG: str = "BITBUCKET_REPO_SLUG"
-_ENV_BITBUCKET_WORKSPACE: str = "BITBUCKET_WORKSPACE"
-_ENV_BITBUCKET_COMMIT: str = "BITBUCKET_COMMIT"
-
-# AWS CodeBuild
-_ENV_CODEBUILD_BUILD_ID: str = "CODEBUILD_BUILD_ID"
-_ENV_CODEBUILD_WEBHOOK_TRIGGER: str = "CODEBUILD_WEBHOOK_TRIGGER"
-_ENV_CODEBUILD_SOURCE_VERSION: str = "CODEBUILD_SOURCE_VERSION"
-_ENV_CODEBUILD_WEBHOOK_BASE_REF: str = "CODEBUILD_WEBHOOK_BASE_REF"
-
-# GitHub API
-_GITHUB_API_BASE_URL: str = "https://api.github.com"
-_GITHUB_API_PR_COMMENTS_PATH: str = "/repos/{repository}/issues/{pr_number}/comments"
-_GITHUB_API_COMMIT_STATUSES_PATH: str = "/repos/{repository}/statuses/{sha}"
-
-# GitLab API
-_GITLAB_DEFAULT_SERVER_URL: str = "https://gitlab.com"
-_GITLAB_API_MR_NOTES_PATH: str = "/api/v4/projects/{project_id}/merge_requests/{mr_iid}/notes"
-_GITLAB_API_COMMIT_STATUSES_PATH: str = "/api/v4/projects/{project_id}/statuses/{sha}"
-
-# Azure DevOps API
-_AZURE_API_VERSION: str = "7.1"
-_AZURE_PR_THREADS_PATH: str = (
-    "{collection_uri}{team_project}/_apis/git/repositories/{repo_id}"
-    "/pullRequests/{pr_id}/threads?api-version={api_version}"
-)
-
-# Bitbucket Cloud API
-_BITBUCKET_API_BASE_URL: str = "https://api.bitbucket.org/2.0"
-_BITBUCKET_PR_COMMENTS_PATH: str = (
-    "/repositories/{workspace}/{repo_slug}/pullrequests/{pr_id}/comments"
-)
-_BITBUCKET_COMMIT_STATUS_PATH: str = (
-    "/repositories/{workspace}/{repo_slug}/commit/{commit}/statuses/build"
-)
-
-# Comment templates
 _COMMENT_HEADER_CLEAN: str = "## phi-scan: No PHI/PII Violations Found"
 _COMMENT_HEADER_VIOLATIONS: str = "## phi-scan: PHI/PII Violations Detected"
 _COMMENT_BADGE_CLEAN: str = "![clean](https://img.shields.io/badge/phi--scan-clean-green)"
@@ -185,26 +70,10 @@ _COMMENT_BADGE_VIOLATIONS: str = (
     "![violations](https://img.shields.io/badge/phi--scan-violations-red)"
 )
 
-# Commit status context name used across all platforms
 _COMMIT_STATUS_CONTEXT: str = "phi-scan"
 _COMMIT_STATUS_DESCRIPTION_CLEAN: str = "No PHI/PII violations found"
 _COMMIT_STATUS_DESCRIPTION_VIOLATIONS: str = "{count} PHI/PII violation(s) found"
 
-# HTTP timeout for all API calls
-_HTTP_TIMEOUT_SECONDS: float = 15.0
-
-# Content-Type header values used across platform API calls
-_JSON_CONTENT_TYPE: str = "application/json"
-_AZURE_PATCH_CONTENT_TYPE: str = "application/json-patch+json"
-
-# Bitbucket PR comment body structure keys
-_BITBUCKET_COMMENT_CONTENT_KEY: str = "content"
-_BITBUCKET_COMMENT_RAW_KEY: str = "raw"
-
-# Azure DevOps build tag PUT requires an empty body
-_AZURE_BUILD_TAG_EMPTY_BODY: bytes = b""
-
-# Maximum characters in a PR comment to stay within GitHub's 65536-char limit
 _MAX_COMMENT_LENGTH: int = 60_000
 _MAX_ERROR_RESPONSE_LOG_LENGTH: int = 200
 _DEFAULT_GIT_REF: str = "refs/heads/main"
@@ -216,16 +85,26 @@ _BASELINE_CONTEXT_FORMAT: str = (
     "{resolved_count} resolved since last scan"
 )
 
-# Maximum length of a SARIF result message.text before upload is aborted.
-# _build_sarif_finding_message() produces at most ~1200 chars
-# (remediation_hint max 1024 + category/layer/confidence overhead).
-# Values well above this indicate unexpected content was embedded.
+_MAX_FINDINGS_IN_COMMENT_TABLE: int = 50
+
+# ---------------------------------------------------------------------------
+# Constants — platform-specific extras
+# ---------------------------------------------------------------------------
+
+_ENV_GITHUB_TOKEN: str = "GITHUB_TOKEN"
+_ENV_SYSTEM_ACCESSTOKEN: str = "SYSTEM_ACCESSTOKEN"
+_ENV_BITBUCKET_TOKEN: str = "BITBUCKET_TOKEN"
+
+_HTTP_TIMEOUT_SECONDS: float = 15.0
+_JSON_CONTENT_TYPE: str = "application/json"
+_AZURE_PATCH_CONTENT_TYPE: str = "application/json-patch+json"
+_AZURE_BUILD_TAG_EMPTY_BODY: bytes = b""
+
+_GITHUB_API_BASE_URL: str = "https://api.github.com"
+_GITHUB_API_SARIF_UPLOAD_PATH: str = "/repos/{repository}/code-scanning/sarifs"
 _SARIF_MAX_MESSAGE_TEXT_LENGTH: int = 1_500
 
-# GitHub Code Scanning SARIF upload API
-_GITHUB_API_SARIF_UPLOAD_PATH: str = "/repos/{repository}/code-scanning/sarifs"
-
-# Azure DevOps build tag + PR status API paths
+_AZURE_API_VERSION: str = "7.1"
 _AZURE_BUILD_TAGS_PATH: str = (
     "{collection_uri}{team_project}/_apis/build/builds/{build_id}"
     "/tags/{tag}?api-version={api_version}"
@@ -234,11 +113,8 @@ _AZURE_PR_STATUSES_PATH: str = (
     "{collection_uri}{team_project}/_apis/git/repositories/{repo_id}"
     "/pullRequests/{pr_id}/statuses?api-version={api_version}"
 )
-# Azure build tag values
 _AZURE_TAG_CLEAN: str = "phi-scan:clean"
 _AZURE_TAG_VIOLATIONS: str = "phi-scan:violations-found"
-
-# Azure Boards work-item API
 _AZURE_WORK_ITEM_TYPE: str = "Task"
 _AZURE_WORK_ITEMS_PATH: str = (
     "{collection_uri}{team_project}/_apis/wit/workitems/${work_item_type}?api-version={api_version}"
@@ -247,16 +123,12 @@ _AZURE_WORK_ITEM_TITLE_FORMAT: str = (
     "phi-scan: {count} HIGH severity PHI/PII violation(s) in PR #{pull_request_number}"
 )
 
-# AWS Security Hub ASFF (Amazon Security Finding Format)
 _AWS_SECURITY_HUB_PRODUCT_ARN_FORMAT: str = (
     "arn:aws:securityhub:{region}:{account_id}:product/{account_id}/default"
 )
-# Explicit ASFF severity label constants — must not derive from enum internals at
-# runtime because the ASFF API contract is independent of SeverityLevel enum values.
 _AWS_SECURITY_HUB_HIGH_SEVERITY_LABEL: str = "HIGH"
 _AWS_SECURITY_HUB_MEDIUM_SEVERITY_LABEL: str = "MEDIUM"
 _AWS_SECURITY_HUB_LOW_SEVERITY_LABEL: str = "LOW"
-# ASFF uses "INFORMATIONAL" for INFO-level findings — no SeverityLevel enum equivalent.
 _AWS_SECURITY_HUB_INFO_SEVERITY_LABEL: str = "INFORMATIONAL"
 _AWS_SECURITY_HUB_SEVERITY_MAP: dict[SeverityLevel, str] = {
     SeverityLevel.HIGH: _AWS_SECURITY_HUB_HIGH_SEVERITY_LABEL,
@@ -265,7 +137,7 @@ _AWS_SECURITY_HUB_SEVERITY_MAP: dict[SeverityLevel, str] = {
     SeverityLevel.INFO: _AWS_SECURITY_HUB_INFO_SEVERITY_LABEL,
 }
 
-# Bitbucket Code Insights API
+_BITBUCKET_API_BASE_URL: str = "https://api.bitbucket.org/2.0"
 _BITBUCKET_REPORTS_PATH: str = (
     "/repositories/{workspace}/{repo_slug}/commit/{commit}/reports/{report_id}"
 )
@@ -273,12 +145,9 @@ _BITBUCKET_ANNOTATIONS_PATH: str = (
     "/repositories/{workspace}/{repo_slug}/commit/{commit}/reports/{report_id}/annotations"
 )
 _BITBUCKET_REPORT_ID: str = "phi-scan"
-# Explicit Bitbucket annotation severity label constants — must not derive from enum
-# internals at runtime because the Bitbucket API contract is independent of SeverityLevel.
 _BITBUCKET_HIGH_SEVERITY_LABEL: str = "HIGH"
 _BITBUCKET_MEDIUM_SEVERITY_LABEL: str = "MEDIUM"
 _BITBUCKET_LOW_SEVERITY_LABEL: str = "LOW"
-# Bitbucket Code Insights does not have an INFO severity level — INFO findings map to LOW.
 _BITBUCKET_INFO_SEVERITY_LABEL: str = _BITBUCKET_LOW_SEVERITY_LABEL
 _BITBUCKET_ANNOTATION_SEVERITY_MAP: dict[SeverityLevel, str] = {
     SeverityLevel.HIGH: _BITBUCKET_HIGH_SEVERITY_LABEL,
@@ -289,52 +158,13 @@ _BITBUCKET_ANNOTATION_SEVERITY_MAP: dict[SeverityLevel, str] = {
 
 
 # ---------------------------------------------------------------------------
-# Public types
+# Backward-compatible type re-exports
 # ---------------------------------------------------------------------------
-
-
-class CIPlatform(enum.Enum):
-    """Enumeration of supported CI/CD platforms."""
-
-    GITHUB_ACTIONS = "github_actions"
-    GITLAB_CI = "gitlab_ci"
-    JENKINS = "jenkins"
-    AZURE_DEVOPS = "azure_devops"
-    CIRCLECI = "circleci"
-    BITBUCKET = "bitbucket"
-    CODEBUILD = "codebuild"
-    UNKNOWN = "unknown"
-
-
-@dataclass(frozen=True)
-class PRContext:
-    """Platform-neutral PR/MR context extracted from environment variables.
-
-    Fields that are not available on the current platform are ``None``.
-    The CLI passes this object to ``post_pr_comment`` and ``set_commit_status``.
-    """
-
-    platform: CIPlatform
-    pr_number: str | None
-    repository: str | None
-    sha: str | None
-    branch: str | None
-    base_branch: str | None
-    # Platform-specific extras stored as a plain dict
-    extras: dict[str, str] = field(default_factory=dict)
-
-
-class CIIntegrationError(PhiScanError):
-    """Raised when a CI/CD platform API call fails."""
 
 
 @dataclass(frozen=True)
 class BaselineComparison:
-    """Counts from a baseline comparison to include in PR/MR comment context.
-
-    Wraps the three integer counts produced by comparing the current scan
-    against an accepted findings baseline.
-    """
+    """Counts from a baseline comparison to include in PR/MR comment context."""
 
     new_findings_count: int
     baselined_count: int
@@ -342,149 +172,7 @@ class BaselineComparison:
 
 
 # ---------------------------------------------------------------------------
-# HTTP helper — shared request/error pattern
-# ---------------------------------------------------------------------------
-
-
-class _HttpMethod(enum.StrEnum):
-    """HTTP methods used by CI/CD platform API calls in this module."""
-
-    POST = "POST"
-    PUT = "PUT"
-
-
-@dataclass(frozen=True)
-class _HttpRequestConfig:
-    """Parameters for a single outbound HTTP request.
-
-    Bundles all variable parts of the ``httpx.METHOD → raise_for_status →
-    HTTPStatusError → RequestError → CIIntegrationError`` pattern so that
-    ``_execute_http_request`` can centralise the try/except scaffolding.
-
-    The ``timeout_seconds`` field defaults to ``_HTTP_TIMEOUT_SECONDS`` so
-    callers do not need to supply it in normal use, but can override it for
-    testing or platform-specific requirements.
-    """
-
-    method: _HttpMethod
-    url: str
-    operation_label: str
-    headers: dict[str, str] | None = None
-    json_body: dict[str, Any] | list[Any] | None = None
-    binary_body: bytes | None = None
-    auth: tuple[str, str] | None = None
-    timeout_seconds: float = _HTTP_TIMEOUT_SECONDS
-
-
-def _build_request_keyword_arguments(request_config: _HttpRequestConfig) -> dict[str, Any]:
-    """Build the keyword-argument dict for ``httpx.request`` from a config object.
-
-    All values, including timeout, come exclusively from ``request_config``.
-    Omits keys whose config value is ``None`` so httpx uses its own defaults.
-
-    Args:
-        request_config: Populated request configuration.
-
-    Returns:
-        Dict ready to unpack into ``httpx.request(..., **request_keyword_arguments)``.
-    """
-    request_keyword_arguments: dict[str, Any] = {"timeout": request_config.timeout_seconds}
-    if request_config.headers is not None:
-        request_keyword_arguments["headers"] = request_config.headers
-    if request_config.json_body is not None:
-        request_keyword_arguments["json"] = request_config.json_body
-    if request_config.binary_body is not None:
-        request_keyword_arguments["content"] = request_config.binary_body
-    if request_config.auth is not None:
-        request_keyword_arguments["auth"] = request_config.auth
-    return request_keyword_arguments
-
-
-def _execute_http_request(request_config: _HttpRequestConfig) -> httpx.Response:
-    """Execute one HTTP request and translate httpx errors to CIIntegrationError.
-
-    Centralises the 12 identical try/except blocks scattered across the module.
-    The caller builds an ``_HttpRequestConfig`` with the platform-specific URL,
-    headers, payload, and a short ``operation_label`` used in the error message.
-
-    Args:
-        request_config: All parameters for the HTTP call.
-
-    Returns:
-        The successful ``httpx.Response``.
-
-    Raises:
-        CIIntegrationError: On HTTP 4xx/5xx or any network error.
-    """
-    request_keyword_arguments = _build_request_keyword_arguments(request_config)
-    try:
-        response = httpx.request(
-            request_config.method, request_config.url, **request_keyword_arguments
-        )
-        response.raise_for_status()
-    except httpx.HTTPStatusError as status_error:
-        raise CIIntegrationError(
-            f"{request_config.operation_label} failed "
-            f"(HTTP {status_error.response.status_code} "
-            f"{status_error.response.reason_phrase})"
-        ) from status_error
-    except httpx.RequestError as request_error:
-        raise CIIntegrationError(
-            f"{request_config.operation_label} request failed: {request_error}"
-        ) from request_error
-    return response
-
-
-# ---------------------------------------------------------------------------
-# Platform detection
-# ---------------------------------------------------------------------------
-
-
-def detect_platform() -> CIPlatform:
-    """Detect the currently running CI/CD platform from environment variables.
-
-    Checks well-known platform sentinel variables in order of specificity.
-    Returns ``CIPlatform.UNKNOWN`` when none of the known sentinels are set.
-
-    Returns:
-        The detected ``CIPlatform`` enum member.
-    """
-    env_get = os.environ.get
-
-    if env_get(_ENV_GITHUB_ACTIONS) == "true":
-        return CIPlatform.GITHUB_ACTIONS
-    if env_get(_ENV_GITLAB_CI) == "true":
-        return CIPlatform.GITLAB_CI
-    if env_get(_ENV_TF_BUILD) == "True":
-        return CIPlatform.AZURE_DEVOPS
-    if env_get(_ENV_CIRCLECI) == "true":
-        return CIPlatform.CIRCLECI
-    if env_get(_ENV_BITBUCKET_BUILD_NUMBER):
-        return CIPlatform.BITBUCKET
-    if env_get(_ENV_CODEBUILD_BUILD_ID):
-        return CIPlatform.CODEBUILD
-    if env_get(_ENV_JENKINS_URL):
-        return CIPlatform.JENKINS
-    return CIPlatform.UNKNOWN
-
-
-def get_pr_context() -> PRContext:
-    """Build a ``PRContext`` from the current environment.
-
-    Reads platform-specific environment variables to extract the PR number,
-    repository, commit SHA, and branch. Works for all seven supported platforms.
-    Auto-detects the platform via ``detect_platform()``.
-
-    Returns:
-        A ``PRContext`` populated with whatever context is available.
-    """
-    platform = detect_platform()
-    builder = _PLATFORM_CONTEXT_BUILDERS.get(platform, _build_unknown_context)
-    return builder()
-
-
-# ---------------------------------------------------------------------------
-# Context builders — one per platform
+# Helpers
 # ---------------------------------------------------------------------------
 
 
@@ -492,142 +180,6 @@ def _env(name: str) -> str | None:
     """Return the environment variable value, or None if unset or empty."""
     env_value = os.environ.get(name, "").strip()
     return env_value if env_value else None
-
-
-def _build_github_context() -> PRContext:
-    pr_number = _env(_ENV_PR_NUMBER)
-    if not pr_number:
-        # Fall back to extracting from GITHUB_REF (refs/pull/N/merge)
-        ref = _env(_ENV_GITHUB_REF) or ""
-        if ref.startswith("refs/pull/"):
-            pr_number = ref.split("/")[2]
-    return PRContext(
-        platform=CIPlatform.GITHUB_ACTIONS,
-        pr_number=pr_number,
-        repository=_env(_ENV_GITHUB_REPOSITORY),
-        sha=_env(_ENV_GITHUB_SHA),
-        branch=_env(_ENV_GITHUB_REF),
-        base_branch=None,
-    )
-
-
-def _build_gitlab_context() -> PRContext:
-    return PRContext(
-        platform=CIPlatform.GITLAB_CI,
-        pr_number=_env(_ENV_CI_MERGE_REQUEST_IID),
-        repository=_env(_ENV_CI_PROJECT_ID),
-        sha=_env(_ENV_CI_COMMIT_SHA),
-        branch=_env(_ENV_CI_COMMIT_REF_NAME),
-        base_branch=None,
-        extras={
-            "ci_server_url": _env(_ENV_CI_SERVER_URL) or _GITLAB_DEFAULT_SERVER_URL,
-        },
-    )
-
-
-def _build_azure_context() -> PRContext:
-    collection_uri = _env(_ENV_SYSTEM_TEAMFOUNDATIONCOLLECTIONURI) or ""
-    # Normalize: ensure trailing slash
-    if collection_uri and not collection_uri.endswith("/"):
-        collection_uri += "/"
-    return PRContext(
-        platform=CIPlatform.AZURE_DEVOPS,
-        pr_number=_env(_ENV_SYSTEM_PULLREQUEST_PULLREQUESTID),
-        repository=_env(_ENV_BUILD_REPOSITORY_ID),
-        sha=_env(_ENV_BUILD_SOURCEVERSION),
-        branch=None,
-        base_branch=None,
-        extras={
-            "collection_uri": collection_uri,
-            "team_project": _env(_ENV_SYSTEM_TEAMPROJECT) or "",
-            "build_id": _env(_ENV_BUILD_BUILDID) or "",
-        },
-    )
-
-
-def _build_circleci_context() -> PRContext:
-    pr_url = _env(_ENV_CIRCLE_PULL_REQUEST) or ""
-    pr_number: str | None = None
-    if pr_url:
-        # URL form: https://github.com/org/repo/pull/42
-        parts = pr_url.rstrip("/").split("/")
-        if parts:
-            candidate = parts[-1]
-            if candidate.isdigit():
-                pr_number = candidate
-    return PRContext(
-        platform=CIPlatform.CIRCLECI,
-        pr_number=pr_number,
-        repository=None,
-        sha=_env(_ENV_CIRCLE_SHA1),
-        branch=_env(_ENV_CIRCLE_BRANCH),
-        base_branch=None,
-        extras={"circle_pull_request_url": pr_url},
-    )
-
-
-def _build_bitbucket_context() -> PRContext:
-    return PRContext(
-        platform=CIPlatform.BITBUCKET,
-        pr_number=_env(_ENV_BITBUCKET_PR_ID),
-        repository=_env(_ENV_BITBUCKET_REPO_SLUG),
-        sha=_env(_ENV_BITBUCKET_COMMIT),
-        branch=None,
-        base_branch=None,
-        extras={
-            "workspace": _env(_ENV_BITBUCKET_WORKSPACE) or "",
-            "repo_slug": _env(_ENV_BITBUCKET_REPO_SLUG) or "",
-        },
-    )
-
-
-def _build_codebuild_context() -> PRContext:
-    trigger = _env(_ENV_CODEBUILD_WEBHOOK_TRIGGER) or ""
-    pr_number: str | None = None
-    if trigger.startswith("pr/"):
-        pr_number = trigger[3:]
-    return PRContext(
-        platform=CIPlatform.CODEBUILD,
-        pr_number=pr_number,
-        repository=None,
-        sha=_env(_ENV_CODEBUILD_SOURCE_VERSION),
-        branch=None,
-        base_branch=_env(_ENV_CODEBUILD_WEBHOOK_BASE_REF),
-    )
-
-
-def _build_jenkins_context() -> PRContext:
-    return PRContext(
-        platform=CIPlatform.JENKINS,
-        pr_number=_env(_ENV_CHANGE_ID),
-        repository=None,
-        sha=None,
-        branch=None,
-        base_branch=None,
-        extras={"change_url": _env(_ENV_CHANGE_URL) or ""},
-    )
-
-
-def _build_unknown_context() -> PRContext:
-    return PRContext(
-        platform=CIPlatform.UNKNOWN,
-        pr_number=None,
-        repository=None,
-        sha=None,
-        branch=None,
-        base_branch=None,
-    )
-
-
-_PLATFORM_CONTEXT_BUILDERS: dict[CIPlatform, Callable[[], PRContext]] = {
-    CIPlatform.GITHUB_ACTIONS: _build_github_context,
-    CIPlatform.GITLAB_CI: _build_gitlab_context,
-    CIPlatform.AZURE_DEVOPS: _build_azure_context,
-    CIPlatform.CIRCLECI: _build_circleci_context,
-    CIPlatform.BITBUCKET: _build_bitbucket_context,
-    CIPlatform.CODEBUILD: _build_codebuild_context,
-    CIPlatform.JENKINS: _build_jenkins_context,
-}
 
 
 # ---------------------------------------------------------------------------
@@ -641,12 +193,6 @@ def build_comment_body(scan_result: ScanResult) -> str:
     The body contains only counts, file names, and line numbers — never raw
     entity values. Truncated to ``_MAX_COMMENT_LENGTH`` characters to stay
     within platform comment size limits.
-
-    Args:
-        scan_result: The completed scan result to summarise.
-
-    Returns:
-        Markdown string suitable for posting as a PR/MR comment.
     """
     if scan_result.is_clean:
         header = _COMMENT_HEADER_CLEAN
@@ -670,7 +216,7 @@ def build_comment_body(scan_result: ScanResult) -> str:
         f"{count} {level.value}"
         for level, count in sorted(
             scan_result.severity_counts.items(),
-            key=lambda item: item[0].value,
+            key=lambda severity_item: severity_item[0].value,
         )
         if count > 0
     )
@@ -692,7 +238,7 @@ def build_comment_body(scan_result: ScanResult) -> str:
         "|------|------|------|----------|------------|",
     ]
 
-    for finding in scan_result.findings[:50]:  # cap table at 50 rows
+    for finding in scan_result.findings[:_MAX_FINDINGS_IN_COMMENT_TABLE]:
         body_lines.append(
             f"| `{finding.file_path}` | {finding.line_number} "
             f"| {finding.hipaa_category.value} "
@@ -700,8 +246,10 @@ def build_comment_body(scan_result: ScanResult) -> str:
             f"| {finding.confidence:.0%} |"
         )
 
-    if findings_count > 50:
-        body_lines.append(f"| … and {findings_count - 50} more | | | | |")
+    if findings_count > _MAX_FINDINGS_IN_COMMENT_TABLE:
+        body_lines.append(
+            f"| … and {findings_count - _MAX_FINDINGS_IN_COMMENT_TABLE} more | | | | |"
+        )
 
     body_lines += [
         "",
@@ -724,21 +272,9 @@ def _insert_baseline_context_into_comment(
     comment_body: str,
     baseline_line: str,
 ) -> str:
-    """Insert a baseline context line after the first header line of a comment body.
-
-    Splits on the first newline to separate the badge/header from the rest of the
-    comment, then reassembles with the baseline line inserted between them.
-
-    Args:
-        comment_body:   Standard comment body produced by ``build_comment_body()``.
-        baseline_line:  Pre-formatted baseline summary line to insert.
-
-    Returns:
-        Comment body with the baseline line inserted after the first header line.
-    """
+    """Insert a baseline context line after the first header line of a comment body."""
     lines = comment_body.split("\n", _COMMENT_BODY_SPLIT_MAX_PARTS)
     if len(lines) < _COMMENT_MIN_SECTION_COUNT:
-        # Comment body has no header/body split — prepend baseline line instead
         return baseline_line + "\n\n" + comment_body
     return "\n".join([lines[0], "", baseline_line, "", *lines[1:]])
 
@@ -747,18 +283,7 @@ def build_comment_body_with_baseline(
     scan_result: ScanResult,
     baseline_comparison: BaselineComparison,
 ) -> str:
-    """Build a PR/MR comment body that includes baseline comparison context.
-
-    Adds a summary line of the form:
-    "N new findings | M baselined | K resolved since last scan"
-
-    Args:
-        scan_result:          The completed scan result (all findings, pre-baseline filtering).
-        baseline_comparison:  Counts from comparing the scan against an accepted baseline.
-
-    Returns:
-        Markdown string with baseline context prepended to the standard comment body.
-    """
+    """Build a PR/MR comment body that includes baseline comparison context."""
     baseline_line = _BASELINE_CONTEXT_FORMAT.format(
         new_findings_count=baseline_comparison.new_findings_count,
         baselined_count=baseline_comparison.baselined_count,
@@ -768,33 +293,66 @@ def build_comment_body_with_baseline(
 
 
 # ---------------------------------------------------------------------------
-# Public API — upload SARIF to GitHub Code Scanning (6C.5)
+# Public API — post PR/MR comment (dispatches to adapter)
+# ---------------------------------------------------------------------------
+
+
+def post_pr_comment(scan_result: ScanResult, pr_context: PRContext) -> None:
+    """Post a PR/MR comment with scan findings to the detected CI/CD platform.
+
+    Selects the platform-specific adapter based on ``pr_context.platform``.
+    Does nothing and logs a warning when the platform is ``UNKNOWN`` or when
+    required context (PR number, token) is missing.
+    """
+    if not pr_context.pr_number:
+        _LOG.debug("No PR number in context — skipping comment posting")
+        return
+
+    adapter = resolve_adapter(pr_context.platform)
+    if adapter is None:
+        _LOG.warning(
+            "PR comment posting not implemented for platform %s",
+            pr_context.platform.value,
+        )
+        return
+
+    comment_body = build_comment_body(scan_result)
+    adapter.post_pr_comment(comment_body, pr_context)
+
+
+# ---------------------------------------------------------------------------
+# Public API — set commit status (dispatches to adapter)
+# ---------------------------------------------------------------------------
+
+
+def set_commit_status(scan_result: ScanResult, pr_context: PRContext) -> None:
+    """Set the commit status (PASS/FAIL) on the CI/CD platform.
+
+    Selects the platform-specific adapter based on ``pr_context.platform``.
+    Does nothing and logs a warning when required context (SHA, token) is missing.
+    """
+    if not pr_context.sha:
+        _LOG.debug("No commit SHA in context — skipping status posting")
+        return
+
+    adapter = resolve_adapter(pr_context.platform)
+    if adapter is None:
+        _LOG.warning(
+            "Commit status not implemented for platform %s",
+            pr_context.platform.value,
+        )
+        return
+
+    adapter.set_commit_status(scan_result, pr_context)
+
+
+# ---------------------------------------------------------------------------
+# Public API — upload SARIF to GitHub Code Scanning
 # ---------------------------------------------------------------------------
 
 
 def _verify_sarif_excludes_code_snippets(sarif_content: str) -> None:
-    """Verify the SARIF output contains no code snippet or contextRegion fields.
-
-    This is a structural PHI-safety guard at the network boundary. It checks for
-    two specific SARIF fields that would expose raw source content:
-
-    - ``region.snippet``: inline code snippet of the matched line.
-    - ``physicalLocation.contextRegion``: surrounding context lines.
-
-    What this check does NOT cover: ``message.text`` content, file path strings,
-    rule descriptions, or any other free-text fields. Those are trusted to be safe
-    by the ``format_sarif()`` contract (which uses only PHI-safe ``ScanFinding``
-    fields) and by ``ScanFinding.__post_init__`` validation. This guard defends
-    against structural additions to the SARIF formatter (e.g. adding snippets),
-    not against PHI inadvertently embedded in text fields.
-
-    Args:
-        sarif_content: SARIF 2.1.0 JSON string to validate.
-
-    Raises:
-        CIIntegrationError: When any result location contains a ``snippet`` or
-            ``contextRegion`` field that could expose raw source content.
-    """
+    """Verify the SARIF output contains no code snippet or contextRegion fields."""
     sarif_doc: dict[str, Any] = json.loads(sarif_content)
     for sarif_run in sarif_doc.get("runs", []):
         for sarif_result in sarif_run.get("results", []):
@@ -821,52 +379,15 @@ def _verify_sarif_excludes_code_snippets(sarif_content: str) -> None:
 
 
 def _gzip_compress_sarif(sarif_content: str) -> bytes:
-    """Gzip-compress a SARIF JSON string to bytes.
-
-    Args:
-        sarif_content: Raw SARIF 2.1.0 JSON string.
-
-    Returns:
-        Gzip-compressed bytes of the UTF-8 encoded SARIF content.
-    """
     return gzip.compress(sarif_content.encode("utf-8"))
 
 
 def _base64_encode_bytes(raw_bytes: bytes) -> str:
-    """Base64-encode bytes to an ASCII string.
-
-    Args:
-        raw_bytes: Bytes to encode.
-
-    Returns:
-        Base64-encoded ASCII string.
-    """
     return base64.b64encode(raw_bytes).decode("ascii")
 
 
 def upload_sarif_to_github(scan_result: ScanResult, pr_context: PRContext) -> None:
-    """Upload a SARIF report to the GitHub Code Scanning API for inline annotations.
-
-    Each finding appears as an inline annotation on the exact line in the PR diff.
-    Severity is mapped: HIGH→error, MEDIUM→warning, LOW/INFO→note.
-
-    PHI-safety: ``scan_result`` is passed to ``format_sarif()`` internally — this
-    function is the only path by which SARIF reaches the GitHub API, ensuring the
-    formatter's PHI exclusions are always applied. ``format_sarif()`` emits only
-    file path, line number, entity type, HIPAA category, detection layer, and
-    remediation hint. It deliberately omits ``value_hash``, ``code_context``, and
-    any raw matched values. This is enforced by ``ScanFinding.__post_init__``
-    validation, not by caller discipline.
-
-    Requires the ``security-events: write`` permission in the GitHub Actions workflow.
-
-    Args:
-        scan_result: Completed scan result — SARIF is generated internally.
-        pr_context:  GitHub PR context with repository and SHA.
-
-    Raises:
-        CIIntegrationError: When the API call fails or authentication is missing.
-    """
+    """Upload a SARIF report to the GitHub Code Scanning API for inline annotations."""
     repository = pr_context.repository
     sha = pr_context.sha
     if not repository or not sha:
@@ -882,9 +403,7 @@ def upload_sarif_to_github(scan_result: ScanResult, pr_context: PRContext) -> No
     _verify_sarif_excludes_code_snippets(sarif_content)
     sarif_base64_encoded = _base64_encode_bytes(_gzip_compress_sarif(sarif_content))
 
-    url = _GITHUB_API_BASE_URL + _GITHUB_API_SARIF_UPLOAD_PATH.format(
-        repository=repository,
-    )
+    url = _GITHUB_API_BASE_URL + _GITHUB_API_SARIF_UPLOAD_PATH.format(repository=repository)
     sarif_upload_payload = {
         "commit_sha": sha,
         "ref": pr_context.branch or _DEFAULT_GIT_REF,
@@ -892,9 +411,9 @@ def upload_sarif_to_github(scan_result: ScanResult, pr_context: PRContext) -> No
         "tool_name": "phi-scan",
     }
 
-    _execute_http_request(
-        _HttpRequestConfig(
-            method=_HttpMethod.POST,
+    execute_http_request(
+        HttpRequestConfig(
+            method=HttpMethod.POST,
             url=url,
             operation_label="GitHub SARIF upload",
             headers={
@@ -910,23 +429,12 @@ def upload_sarif_to_github(scan_result: ScanResult, pr_context: PRContext) -> No
 
 
 # ---------------------------------------------------------------------------
-# Public API — Bitbucket Code Insights annotations (6C.23 supplement)
+# Public API — Bitbucket Code Insights annotations
 # ---------------------------------------------------------------------------
 
 
 def post_bitbucket_code_insights(scan_result: ScanResult, pr_context: PRContext) -> None:
-    """Post Bitbucket Code Insights report and inline annotations.
-
-    Creates a Code Insights report on the commit and then adds one annotation
-    per finding, pointing to the exact file and line in the PR diff.
-
-    Args:
-        scan_result: The completed scan result.
-        pr_context:  Bitbucket context with commit SHA and workspace/repo.
-
-    Raises:
-        CIIntegrationError: When any API call fails.
-    """
+    """Post Bitbucket Code Insights report and inline annotations."""
     sha = pr_context.sha
     workspace = pr_context.extras.get("workspace", "")
     repo_slug = pr_context.extras.get("repo_slug", "")
@@ -951,7 +459,6 @@ def post_bitbucket_code_insights(scan_result: ScanResult, pr_context: PRContext)
         report_id=_BITBUCKET_REPORT_ID,
     )
 
-    # Create / update the report summary
     findings_count = len(scan_result.findings)
     report_payload: dict[str, Any] = {
         "title": "phi-scan PHI/PII Scan",
@@ -968,9 +475,9 @@ def post_bitbucket_code_insights(scan_result: ScanResult, pr_context: PRContext)
         ],
     }
 
-    _execute_http_request(
-        _HttpRequestConfig(
-            method=_HttpMethod.PUT,
+    execute_http_request(
+        HttpRequestConfig(
+            method=HttpMethod.PUT,
             url=report_url,
             operation_label="Bitbucket Code Insights report",
             headers=headers,
@@ -981,7 +488,6 @@ def post_bitbucket_code_insights(scan_result: ScanResult, pr_context: PRContext)
     if not scan_result.findings:
         return
 
-    # Post inline annotations (capped at 1000 — Bitbucket API limit)
     annotations_url = _BITBUCKET_API_BASE_URL + _BITBUCKET_ANNOTATIONS_PATH.format(
         workspace=workspace,
         repo_slug=repo_slug,
@@ -1003,9 +509,9 @@ def post_bitbucket_code_insights(scan_result: ScanResult, pr_context: PRContext)
         for idx, finding in enumerate(scan_result.findings[:1000])
     ]
 
-    _execute_http_request(
-        _HttpRequestConfig(
-            method=_HttpMethod.POST,
+    execute_http_request(
+        HttpRequestConfig(
+            method=HttpMethod.POST,
             url=annotations_url,
             operation_label="Bitbucket Code Insights annotations",
             headers=headers,
@@ -1021,23 +527,12 @@ def post_bitbucket_code_insights(scan_result: ScanResult, pr_context: PRContext)
 
 
 # ---------------------------------------------------------------------------
-# Public API — Azure DevOps build tag + PR status (6C.17)
+# Public API — Azure DevOps build tag + PR status
 # ---------------------------------------------------------------------------
 
 
 def set_azure_build_tag(scan_result: ScanResult, pr_context: PRContext) -> None:
-    """Tag the Azure DevOps build with phi-scan:clean or phi-scan:violations-found.
-
-    Uses ``SYSTEM_ACCESSTOKEN`` for authentication. The build ID is read from
-    the ``BUILD_BUILDID`` environment variable.
-
-    Args:
-        scan_result: The completed scan result.
-        pr_context:  Azure DevOps context with collection URI, team project, build ID.
-
-    Raises:
-        CIIntegrationError: When the API call fails.
-    """
+    """Tag the Azure DevOps build with phi-scan:clean or phi-scan:violations-found."""
     collection_uri = pr_context.extras.get("collection_uri", "")
     team_project = pr_context.extras.get("team_project", "")
     build_id = pr_context.extras.get("build_id", "")
@@ -1060,9 +555,9 @@ def set_azure_build_tag(scan_result: ScanResult, pr_context: PRContext) -> None:
         api_version=_AZURE_API_VERSION,
     )
 
-    _execute_http_request(
-        _HttpRequestConfig(
-            method=_HttpMethod.PUT,
+    execute_http_request(
+        HttpRequestConfig(
+            method=HttpMethod.PUT,
             url=url,
             operation_label="Azure DevOps build tag",
             binary_body=_AZURE_BUILD_TAG_EMPTY_BODY,
@@ -1074,18 +569,7 @@ def set_azure_build_tag(scan_result: ScanResult, pr_context: PRContext) -> None:
 
 
 def set_azure_pr_status(scan_result: ScanResult, pr_context: PRContext) -> None:
-    """Set an Azure DevOps PR status to block or allow completion via branch policy.
-
-    Posts to the Pull Request Statuses API so that a branch policy requiring
-    a green phi-scan status can block PR completion on violations.
-
-    Args:
-        scan_result: The completed scan result.
-        pr_context:  Azure DevOps PR context.
-
-    Raises:
-        CIIntegrationError: When the API call fails.
-    """
+    """Set an Azure DevOps PR status to block or allow completion via branch policy."""
     pr_id = pr_context.pr_number
     repo_id = pr_context.repository
     collection_uri = pr_context.extras.get("collection_uri", "")
@@ -1123,9 +607,9 @@ def set_azure_pr_status(scan_result: ScanResult, pr_context: PRContext) -> None:
         },
     }
 
-    _execute_http_request(
-        _HttpRequestConfig(
-            method=_HttpMethod.POST,
+    execute_http_request(
+        HttpRequestConfig(
+            method=HttpMethod.POST,
             url=url,
             operation_label="Azure DevOps PR status",
             json_body=payload,
@@ -1137,24 +621,12 @@ def set_azure_pr_status(scan_result: ScanResult, pr_context: PRContext) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Public API — Azure Boards work-item linking (6C.18, optional)
+# Public API — Azure Boards work-item linking
 # ---------------------------------------------------------------------------
 
 
 def create_azure_boards_work_item(scan_result: ScanResult, pr_context: PRContext) -> None:
-    """Create an Azure Boards Task work item for HIGH severity PHI/PII findings.
-
-    Only creates a work item when there are HIGH severity findings and the
-    ``AZURE_BOARDS_INTEGRATION`` environment variable is set to ``true``.
-    Work items are linked to the current build for traceability.
-
-    Args:
-        scan_result: The completed scan result.
-        pr_context:  Azure DevOps context.
-
-    Raises:
-        CIIntegrationError: When the API call fails.
-    """
+    """Create an Azure Boards Task work item for HIGH severity PHI/PII findings."""
     if _env("AZURE_BOARDS_INTEGRATION") != "true":
         _LOG.debug("Azure Boards: AZURE_BOARDS_INTEGRATION not enabled — skipping")
         return
@@ -1177,12 +649,6 @@ def create_azure_boards_work_item(scan_result: ScanResult, pr_context: PRContext
         _LOG.warning("Azure Boards: SYSTEM_ACCESSTOKEN not set — skipping")
         return
 
-    # PHI-SAFE OUTBOUND FIELDS (Azure Boards work item):
-    #   System.Title       — _AZURE_WORK_ITEM_TITLE_FORMAT: count (int) + pr_id (str) only
-    #   System.Description — count (int) + pr_id (str) + static text only
-    #   System.Tags        — static string literal
-    # Excluded from all fields: entity values, value_hash, hipaa_category,
-    # entity_type, file_path, line_number, code_context, remediation_hint.
     title = _AZURE_WORK_ITEM_TITLE_FORMAT.format(
         count=len(high_findings), pull_request_number=pr_id
     )
@@ -1192,13 +658,12 @@ def create_azure_boards_work_item(scan_result: ScanResult, pr_context: PRContext
         work_item_type=_AZURE_WORK_ITEM_TYPE,
         api_version=_AZURE_API_VERSION,
     )
-    # Azure DevOps work-item PATCH format
+
     patch_payload = [
         {"op": "add", "path": "/fields/System.Title", "value": title},
         {
             "op": "add",
             "path": "/fields/System.Description",
-            # PHI-SAFE: count (int) + pr_id (str) — no per-finding fields included
             "value": (
                 f"phi-scan detected {len(high_findings)} HIGH severity PHI/PII "
                 f"violation(s) in PR #{pr_id}. "
@@ -1208,9 +673,9 @@ def create_azure_boards_work_item(scan_result: ScanResult, pr_context: PRContext
         {"op": "add", "path": "/fields/System.Tags", "value": "phi-scan;security;phi-pii"},
     ]
 
-    _execute_http_request(
-        _HttpRequestConfig(
-            method=_HttpMethod.POST,
+    execute_http_request(
+        HttpRequestConfig(
+            method=HttpMethod.POST,
             url=url,
             operation_label="Azure Boards work item",
             headers={"Content-Type": _AZURE_PATCH_CONTENT_TYPE},
@@ -1227,7 +692,7 @@ def create_azure_boards_work_item(scan_result: ScanResult, pr_context: PRContext
 
 
 # ---------------------------------------------------------------------------
-# Public API — AWS Security Hub ASFF import (6C.27, optional)
+# Public API — AWS Security Hub ASFF import
 # ---------------------------------------------------------------------------
 
 
@@ -1237,21 +702,7 @@ def convert_findings_to_asff(
     aws_region: str,
     repository: str,
 ) -> list[dict[str, Any]]:
-    """Convert phi-scan findings to AWS Security Finding Format (ASFF).
-
-    Produces one ASFF finding per phi-scan finding. Each ASFF finding includes:
-    file path, line number, severity, HIPAA category, confidence, and remediation hint.
-    No raw entity values are included — only the value hash.
-
-    Args:
-        scan_result:    The completed scan result.
-        aws_account_id: AWS account ID (12-digit string).
-        aws_region:     AWS region (e.g. ``us-east-1``).
-        repository:     Repository identifier for the ProductArn.
-
-    Returns:
-        List of ASFF finding dicts ready to pass to BatchImportFindings.
-    """
+    """Convert phi-scan findings to AWS Security Finding Format (ASFF)."""
     from datetime import UTC, datetime
 
     product_arn = _AWS_SECURITY_HUB_PRODUCT_ARN_FORMAT.format(
@@ -1263,31 +714,9 @@ def convert_findings_to_asff(
     asff_findings = []
     for finding in scan_result.findings:
         severity_label = _AWS_SECURITY_HUB_SEVERITY_MAP.get(finding.severity, "MEDIUM")
-        # ASFF severity normalised score: HIGH=70, MEDIUM=40, LOW=10, INFO=0
         severity_score_map = {"HIGH": 70, "MEDIUM": 40, "LOW": 10, "INFORMATIONAL": 0}
         severity_score = severity_score_map.get(severity_label, 40)
 
-        # PHI-SAFE OUTBOUND FIELDS (ASFF — every field enumerated):
-        #   Id              — repository + file_path + line_number + entity_type
-        #                     Structural fields only — no PHI-derived data of any kind.
-        #                     value_hash and all truncations/derivatives are excluded because
-        #                     SSNs have ~30 bits of entropy: any SHA-256 output (full or
-        #                     truncated) is reversible by brute-force over the input space,
-        #                     not the hash output space. ASFF deduplication only requires
-        #                     a stable unique key per finding location, which file_path +
-        #                     line_number + entity_type provides without encoding the value.
-        #   GeneratorId     — "phi-scan/" + entity_type (pattern name, e.g. "us_ssn")
-        #   AwsAccountId    — caller-supplied AWS account ID
-        #   Title           — hipaa_category.value (enum label) + file_path + line_number
-        #   Description     — hipaa_category.value + entity_type + confidence (float) +
-        #                     file_path + line_number + static "No raw value" note
-        #   Remediation     — remediation_hint (pre-canned guidance text, see ScanFinding)
-        #   SourceUrl       — GitHub blob URL built from repository + file_path + line_number
-        #   Resources.Id    — "file://" + file_path
-        #   Resources.Other — line_number, entity_type, hipaa_category.value,
-        #                     confidence (float)
-        # Excluded from ALL fields: raw entity value, code_context, value_hash and all
-        # derivatives (truncations, prefixes). No PHI-derived data leaves this process.
         asff_finding: dict[str, Any] = {
             "SchemaVersion": "2018-10-08",
             "Id": (f"{repository}/{finding.file_path}/{finding.line_number}/{finding.entity_type}"),
@@ -1342,20 +771,7 @@ def import_findings_to_security_hub(
     scan_result: ScanResult,
     pr_context: PRContext,
 ) -> None:
-    """Import phi-scan findings to AWS Security Hub via BatchImportFindings.
-
-    Only runs when ``AWS_SECURITY_HUB`` environment variable is set to ``true``
-    and ``AWS_ACCOUNT_ID`` / ``AWS_DEFAULT_REGION`` are available. Uses the
-    AWS CLI (``aws securityhub batch-import-findings``) to avoid adding boto3
-    as a hard dependency.
-
-    Args:
-        scan_result: The completed scan result.
-        pr_context:  Context providing the repository identifier.
-
-    Raises:
-        CIIntegrationError: When the AWS CLI invocation fails.
-    """
+    """Import phi-scan findings to AWS Security Hub via BatchImportFindings."""
     if _env("AWS_SECURITY_HUB") != "true":
         _LOG.debug("Security Hub: AWS_SECURITY_HUB not enabled — skipping")
         return
@@ -1366,7 +782,7 @@ def import_findings_to_security_hub(
 
     account_id = _env("AWS_ACCOUNT_ID") or ""
     region = _env("AWS_DEFAULT_REGION") or _env("AWS_REGION") or "us-east-1"
-    repository = pr_context.repository or _env(_ENV_GITHUB_REPOSITORY) or "unknown/repo"
+    repository = pr_context.repository or _env("GITHUB_REPOSITORY") or "unknown/repo"
 
     if not account_id:
         _LOG.warning("Security Hub: AWS_ACCOUNT_ID not set — skipping")
@@ -1395,566 +811,3 @@ def import_findings_to_security_hub(
         ) from not_found_error
 
     _LOG.debug("Security Hub: imported %d ASFF finding(s)", len(asff_findings))
-
-
-# ---------------------------------------------------------------------------
-# Public API — post PR/MR comment
-# ---------------------------------------------------------------------------
-
-
-def post_pr_comment(scan_result: ScanResult, pr_context: PRContext) -> None:
-    """Post a PR/MR comment with scan findings to the detected CI/CD platform.
-
-    Selects the platform-specific implementation based on ``pr_context.platform``.
-    Does nothing and logs a warning when the platform is ``UNKNOWN`` or when
-    required context (PR number, token) is missing.
-
-    Args:
-        scan_result: The completed scan result.
-        pr_context:  Platform context extracted from environment variables.
-
-    Raises:
-        CIIntegrationError: When the platform API call fails.
-    """
-    if not pr_context.pr_number:
-        _LOG.debug("No PR number in context — skipping comment posting")
-        return
-
-    poster = _PLATFORM_COMMENT_POSTERS.get(pr_context.platform)
-    if poster is None:
-        _LOG.warning(
-            "PR comment posting not implemented for platform %s",
-            pr_context.platform.value,
-        )
-        return
-
-    comment_body = build_comment_body(scan_result)
-    poster(comment_body, pr_context)
-
-
-# ---------------------------------------------------------------------------
-# Public API — set commit status
-# ---------------------------------------------------------------------------
-
-
-def set_commit_status(scan_result: ScanResult, pr_context: PRContext) -> None:
-    """Set the commit status (PASS/FAIL) on the CI/CD platform.
-
-    Selects the platform-specific implementation based on ``pr_context.platform``.
-    Does nothing and logs a warning when required context (SHA, token) is missing.
-
-    Args:
-        scan_result: The completed scan result.
-        pr_context:  Platform context extracted from environment variables.
-
-    Raises:
-        CIIntegrationError: When the platform API call fails.
-    """
-    if not pr_context.sha:
-        _LOG.debug("No commit SHA in context — skipping status posting")
-        return
-
-    setter = _PLATFORM_STATUS_SETTERS.get(pr_context.platform)
-    if setter is None:
-        _LOG.warning(
-            "Commit status not implemented for platform %s",
-            pr_context.platform.value,
-        )
-        return
-
-    setter(scan_result, pr_context)
-
-
-# ---------------------------------------------------------------------------
-# Platform-specific comment posters
-# ---------------------------------------------------------------------------
-
-
-def _post_github_pr_comment(comment_body: str, pr_context: PRContext) -> None:
-    """Post a GitHub PR comment using the ``gh`` CLI.
-
-    Uses ``gh pr comment`` so that authentication, pagination, and API version
-    negotiation are handled by the GitHub CLI. Requires ``gh`` to be installed
-    and authenticated (``GITHUB_TOKEN`` in the environment).
-
-    Args:
-        comment_body: Markdown comment text.
-        pr_context:   GitHub PR context.
-
-    Raises:
-        CIIntegrationError: When the ``gh`` CLI invocation fails.
-    """
-    pr_number = pr_context.pr_number
-    if not pr_number:
-        _LOG.debug("GitHub: no PR number — skipping comment")
-        return
-
-    token = _env(_ENV_GITHUB_TOKEN)
-    if not token:
-        _LOG.warning("GitHub: GITHUB_TOKEN not set — skipping comment")
-        return
-
-    env = {**os.environ, "GITHUB_TOKEN": token}
-    if pr_context.repository:
-        env["GH_REPO"] = pr_context.repository
-
-    try:
-        gh_result = subprocess.run(
-            [
-                "gh",
-                "pr",
-                "comment",
-                str(pr_number),
-                "--body",
-                comment_body,
-                "--edit-last",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            check=False,
-        )
-        if gh_result.returncode != 0:
-            # --edit-last fails when there is no existing comment — fall back to create
-            gh_result = subprocess.run(
-                ["gh", "pr", "comment", str(pr_number), "--body", comment_body],
-                capture_output=True,
-                text=True,
-                env=env,
-                check=False,
-            )
-        if gh_result.returncode != 0:
-            raise CIIntegrationError(
-                f"gh pr comment failed (exit {gh_result.returncode}): "
-                f"{gh_result.stderr.strip()[:_MAX_ERROR_RESPONSE_LOG_LENGTH]}"
-            )
-    except FileNotFoundError as not_found_error:
-        raise CIIntegrationError(
-            "gh CLI not found — install the GitHub CLI to enable PR comment posting"
-        ) from not_found_error
-
-    _LOG.debug("GitHub: PR comment posted to #%s", pr_number)
-
-
-def _post_gitlab_mr_comment(comment_body: str, pr_context: PRContext) -> None:
-    """Post a GitLab MR note using the GitLab REST API.
-
-    Uses ``GITLAB_TOKEN`` (personal access token or project access token) or
-    ``CI_JOB_TOKEN`` (automatically available in GitLab CI pipelines).
-
-    Args:
-        comment_body: Markdown comment text.
-        pr_context:   GitLab MR context.
-
-    Raises:
-        CIIntegrationError: When the API call fails or authentication is missing.
-    """
-    mr_iid = pr_context.pr_number
-    project_id = pr_context.repository
-    if not mr_iid or not project_id:
-        _LOG.debug("GitLab: missing MR IID or project ID — skipping comment")
-        return
-
-    token = _env(_ENV_GITLAB_TOKEN) or _env(_ENV_CI_JOB_TOKEN)
-    if not token:
-        _LOG.warning("GitLab: GITLAB_TOKEN and CI_JOB_TOKEN not set — skipping comment")
-        return
-
-    server_url = pr_context.extras.get("ci_server_url") or _GITLAB_DEFAULT_SERVER_URL
-    url = server_url.rstrip("/") + _GITLAB_API_MR_NOTES_PATH.format(
-        project_id=project_id,
-        mr_iid=mr_iid,
-    )
-    headers = {"PRIVATE-TOKEN": token, "Content-Type": _JSON_CONTENT_TYPE}
-    payload = {"body": comment_body}
-
-    _execute_http_request(
-        _HttpRequestConfig(
-            method=_HttpMethod.POST,
-            url=url,
-            operation_label="GitLab MR comment",
-            headers=headers,
-            json_body=payload,
-        )
-    )
-
-    _LOG.debug("GitLab: MR note posted to !%s", mr_iid)
-
-
-def _post_azure_pr_comment(comment_body: str, pr_context: PRContext) -> None:
-    """Post an Azure DevOps PR thread comment using the Azure DevOps REST API.
-
-    Uses ``SYSTEM_ACCESSTOKEN`` (automatically available in Azure Pipelines when
-    'Allow scripts to access the OAuth token' is enabled in the pipeline settings).
-
-    Args:
-        comment_body: Markdown comment text.
-        pr_context:   Azure DevOps PR context.
-
-    Raises:
-        CIIntegrationError: When the API call fails or authentication is missing.
-    """
-    pr_id = pr_context.pr_number
-    repo_id = pr_context.repository
-    collection_uri = pr_context.extras.get("collection_uri", "")
-    team_project = pr_context.extras.get("team_project", "")
-
-    if not all([pr_id, repo_id, collection_uri, team_project]):
-        _LOG.debug("Azure DevOps: missing PR context — skipping comment")
-        return
-
-    token = _env(_ENV_SYSTEM_ACCESSTOKEN)
-    if not token:
-        _LOG.warning(
-            "Azure DevOps: SYSTEM_ACCESSTOKEN not set — "
-            "enable 'Allow scripts to access the OAuth token' in pipeline settings"
-        )
-        return
-
-    url = _AZURE_PR_THREADS_PATH.format(
-        collection_uri=collection_uri,
-        team_project=team_project,
-        repo_id=repo_id,
-        pr_id=pr_id,
-        api_version=_AZURE_API_VERSION,
-    )
-    payload = {
-        "comments": [{"parentCommentId": 0, "content": comment_body, "commentType": 1}],
-        "status": "active",
-    }
-
-    _execute_http_request(
-        _HttpRequestConfig(
-            method=_HttpMethod.POST,
-            url=url,
-            operation_label="Azure DevOps PR comment",
-            json_body=payload,
-            auth=("", token),
-        )
-    )
-
-    _LOG.debug("Azure DevOps: PR thread comment posted to PR #%s", pr_id)
-
-
-def _post_bitbucket_pr_comment(comment_body: str, pr_context: PRContext) -> None:
-    """Post a Bitbucket Cloud PR comment using the Bitbucket REST API.
-
-    Uses ``BITBUCKET_TOKEN`` (repository or workspace access token).
-
-    Args:
-        comment_body: Markdown comment text.
-        pr_context:   Bitbucket PR context.
-
-    Raises:
-        CIIntegrationError: When the API call fails or authentication is missing.
-    """
-    pr_id = pr_context.pr_number
-    workspace = pr_context.extras.get("workspace", "")
-    repo_slug = pr_context.extras.get("repo_slug", "")
-
-    if not all([pr_id, workspace, repo_slug]):
-        _LOG.debug("Bitbucket: missing PR context — skipping comment")
-        return
-
-    token = _env(_ENV_BITBUCKET_TOKEN)
-    if not token:
-        _LOG.warning("Bitbucket: BITBUCKET_TOKEN not set — skipping comment")
-        return
-
-    url = _BITBUCKET_API_BASE_URL + _BITBUCKET_PR_COMMENTS_PATH.format(
-        workspace=workspace,
-        repo_slug=repo_slug,
-        pr_id=pr_id,
-    )
-
-    _execute_http_request(
-        _HttpRequestConfig(
-            method=_HttpMethod.POST,
-            url=url,
-            operation_label="Bitbucket PR comment",
-            headers={"Authorization": f"Bearer {token}", "Content-Type": _JSON_CONTENT_TYPE},
-            json_body={_BITBUCKET_COMMENT_CONTENT_KEY: {_BITBUCKET_COMMENT_RAW_KEY: comment_body}},
-        )
-    )
-
-    _LOG.debug("Bitbucket: PR comment posted to PR #%s", pr_id)
-
-
-def _post_circleci_pr_comment(comment_body: str, pr_context: PRContext) -> None:
-    """Post a CircleCI PR comment by auto-detecting the VCS provider.
-
-    Inspects ``CIRCLE_PULL_REQUEST`` to determine whether the VCS is GitHub
-    (github.com) or Bitbucket (bitbucket.org), then posts via the appropriate
-    platform API.
-
-    Args:
-        comment_body: Markdown comment text.
-        pr_context:   CircleCI PR context.
-    """
-    pr_url = pr_context.extras.get("circle_pull_request_url", "")
-    if not pr_url:
-        _LOG.debug("CircleCI: CIRCLE_PULL_REQUEST not set — skipping comment")
-        return
-
-    if "github.com" in pr_url:
-        # Re-use GitHub poster via a synthetic GitHub context
-        # Extract org/repo from the PR URL
-        parts = pr_url.rstrip("/").split("/")
-        # https://github.com/ORG/REPO/pull/N  ->  parts[-4] = ORG, parts[-3] = REPO
-        if len(parts) >= 5:
-            repository = f"{parts[-4]}/{parts[-3]}"
-        else:
-            repository = None
-        github_context = PRContext(
-            platform=CIPlatform.GITHUB_ACTIONS,
-            pr_number=pr_context.pr_number,
-            repository=repository,
-            sha=pr_context.sha,
-            branch=pr_context.branch,
-            base_branch=pr_context.base_branch,
-        )
-        _post_github_pr_comment(comment_body, github_context)
-    elif "bitbucket.org" in pr_url:
-        parts = pr_url.rstrip("/").split("/")
-        if len(parts) >= 5:
-            workspace = parts[-4]
-            repo_slug = parts[-3]
-        else:
-            workspace = repo_slug = ""
-        bb_context = PRContext(
-            platform=CIPlatform.BITBUCKET,
-            pr_number=pr_context.pr_number,
-            repository=pr_context.repository,
-            sha=pr_context.sha,
-            branch=pr_context.branch,
-            base_branch=pr_context.base_branch,
-            extras={"workspace": workspace, "repo_slug": repo_slug},
-        )
-        _post_bitbucket_pr_comment(comment_body, bb_context)
-    else:
-        _LOG.warning("CircleCI: unrecognized VCS in CIRCLE_PULL_REQUEST URL — skipping comment")
-
-
-def _post_codebuild_pr_comment(comment_body: str, pr_context: PRContext) -> None:
-    """Post a CodeBuild PR comment by auto-detecting the source provider.
-
-    Uses ``GITHUB_TOKEN`` for GitHub-sourced builds and ``BITBUCKET_TOKEN``
-    for Bitbucket-sourced builds.  Source is detected from the build environment
-    — CodeBuild sets ``CODEBUILD_SOURCE_REPO_URL`` for webhook-triggered builds.
-
-    Args:
-        comment_body: Markdown comment text.
-        pr_context:   CodeBuild PR context.
-    """
-    # CodeBuild doesn't expose an explicit VCS-type env var; infer from repo URL
-    repo_url = os.environ.get("CODEBUILD_SOURCE_REPO_URL", "")
-    if "github.com" in repo_url:
-        parts = repo_url.rstrip("/").rstrip(".git").split("/")
-        repository = f"{parts[-2]}/{parts[-1]}" if len(parts) >= 2 else None
-        github_context = PRContext(
-            platform=CIPlatform.GITHUB_ACTIONS,
-            pr_number=pr_context.pr_number,
-            repository=repository,
-            sha=pr_context.sha,
-            branch=pr_context.branch,
-            base_branch=pr_context.base_branch,
-        )
-        _post_github_pr_comment(comment_body, github_context)
-    elif "bitbucket.org" in repo_url:
-        parts = repo_url.rstrip("/").rstrip(".git").split("/")
-        workspace = parts[-2] if len(parts) >= 2 else ""
-        repo_slug = parts[-1] if parts else ""
-        bb_context = PRContext(
-            platform=CIPlatform.BITBUCKET,
-            pr_number=pr_context.pr_number,
-            repository=pr_context.repository,
-            sha=pr_context.sha,
-            branch=pr_context.branch,
-            base_branch=pr_context.base_branch,
-            extras={"workspace": workspace, "repo_slug": repo_slug},
-        )
-        _post_bitbucket_pr_comment(comment_body, bb_context)
-    else:
-        _LOG.warning("CodeBuild: unrecognised source repo URL — skipping PR comment")
-
-
-_PLATFORM_COMMENT_POSTERS: dict[CIPlatform, Any] = {
-    CIPlatform.GITHUB_ACTIONS: _post_github_pr_comment,
-    CIPlatform.GITLAB_CI: _post_gitlab_mr_comment,
-    CIPlatform.AZURE_DEVOPS: _post_azure_pr_comment,
-    CIPlatform.BITBUCKET: _post_bitbucket_pr_comment,
-    CIPlatform.CIRCLECI: _post_circleci_pr_comment,
-    CIPlatform.CODEBUILD: _post_codebuild_pr_comment,
-}
-
-
-# ---------------------------------------------------------------------------
-# Platform-specific commit status setters
-# ---------------------------------------------------------------------------
-
-
-def _set_github_commit_status(scan_result: ScanResult, pr_context: PRContext) -> None:
-    """Set a GitHub commit status via the GitHub REST API.
-
-    Uses ``GITHUB_TOKEN`` from the environment.
-
-    Args:
-        scan_result: The completed scan result.
-        pr_context:  GitHub PR context with SHA and repository.
-
-    Raises:
-        CIIntegrationError: When the API call fails.
-    """
-    sha = pr_context.sha
-    repository = pr_context.repository
-    if not sha or not repository:
-        _LOG.debug("GitHub: missing SHA or repository — skipping status")
-        return
-
-    token = _env(_ENV_GITHUB_TOKEN)
-    if not token:
-        _LOG.warning("GitHub: GITHUB_TOKEN not set — skipping commit status")
-        return
-
-    github_state = "success" if scan_result.is_clean else "failure"
-    findings_count = len(scan_result.findings)
-    description = (
-        _COMMIT_STATUS_DESCRIPTION_CLEAN
-        if scan_result.is_clean
-        else _COMMIT_STATUS_DESCRIPTION_VIOLATIONS.format(count=findings_count)
-    )
-
-    url = _GITHUB_API_BASE_URL + _GITHUB_API_COMMIT_STATUSES_PATH.format(
-        repository=repository,
-        sha=sha,
-    )
-    payload = {
-        "state": github_state,
-        "description": description,
-        "context": _COMMIT_STATUS_CONTEXT,
-    }
-
-    _execute_http_request(
-        _HttpRequestConfig(
-            method=_HttpMethod.POST,
-            url=url,
-            operation_label="GitHub commit status",
-            headers={
-                "Authorization": f"Bearer {token}",
-                "Accept": "application/vnd.github+json",
-                "X-GitHub-Api-Version": "2022-11-28",
-            },
-            json_body=payload,
-        )
-    )
-
-    _LOG.debug("GitHub: commit status set to %s for %s", github_state, sha[:8])
-
-
-def _set_gitlab_commit_status(scan_result: ScanResult, pr_context: PRContext) -> None:
-    """Set a GitLab commit status using the GitLab REST API.
-
-    Args:
-        scan_result: The completed scan result.
-        pr_context:  GitLab context with SHA and project ID.
-
-    Raises:
-        CIIntegrationError: When the API call fails.
-    """
-    sha = pr_context.sha
-    project_id = pr_context.repository
-    if not sha or not project_id:
-        _LOG.debug("GitLab: missing SHA or project ID — skipping status")
-        return
-
-    token = _env(_ENV_GITLAB_TOKEN) or _env(_ENV_CI_JOB_TOKEN)
-    if not token:
-        _LOG.warning("GitLab: no token — skipping commit status")
-        return
-
-    server_url = pr_context.extras.get("ci_server_url") or _GITLAB_DEFAULT_SERVER_URL
-    state = "success" if scan_result.is_clean else "failed"
-    url = server_url.rstrip("/") + _GITLAB_API_COMMIT_STATUSES_PATH.format(
-        project_id=project_id,
-        sha=sha,
-    )
-    payload = {
-        "state": state,
-        "name": _COMMIT_STATUS_CONTEXT,
-        "description": (
-            _COMMIT_STATUS_DESCRIPTION_CLEAN
-            if scan_result.is_clean
-            else _COMMIT_STATUS_DESCRIPTION_VIOLATIONS.format(count=len(scan_result.findings))
-        ),
-    }
-
-    _execute_http_request(
-        _HttpRequestConfig(
-            method=_HttpMethod.POST,
-            url=url,
-            operation_label="GitLab commit status",
-            headers={"PRIVATE-TOKEN": token},
-            json_body=payload,
-        )
-    )
-
-    _LOG.debug("GitLab: commit status set to %s for %s", state, sha[:8])
-
-
-def _set_bitbucket_commit_status(scan_result: ScanResult, pr_context: PRContext) -> None:
-    """Set a Bitbucket commit build status using the Bitbucket Commit Status API.
-
-    Args:
-        scan_result: The completed scan result.
-        pr_context:  Bitbucket context with commit SHA.
-
-    Raises:
-        CIIntegrationError: When the API call fails.
-    """
-    sha = pr_context.sha
-    workspace = pr_context.extras.get("workspace", "")
-    repo_slug = pr_context.extras.get("repo_slug", "")
-    if not sha or not workspace or not repo_slug:
-        _LOG.debug("Bitbucket: missing context — skipping commit status")
-        return
-
-    token = _env(_ENV_BITBUCKET_TOKEN)
-    if not token:
-        _LOG.warning("Bitbucket: BITBUCKET_TOKEN not set — skipping commit status")
-        return
-
-    state = "SUCCESSFUL" if scan_result.is_clean else "FAILED"
-    url = _BITBUCKET_API_BASE_URL + _BITBUCKET_COMMIT_STATUS_PATH.format(
-        workspace=workspace,
-        repo_slug=repo_slug,
-        commit=sha,
-    )
-    payload = {
-        "key": _COMMIT_STATUS_CONTEXT,
-        "state": state,
-        "name": "phi-scan",
-        "description": (
-            _COMMIT_STATUS_DESCRIPTION_CLEAN
-            if scan_result.is_clean
-            else _COMMIT_STATUS_DESCRIPTION_VIOLATIONS.format(count=len(scan_result.findings))
-        ),
-    }
-
-    _execute_http_request(
-        _HttpRequestConfig(
-            method=_HttpMethod.POST,
-            url=url,
-            operation_label="Bitbucket commit status",
-            headers={"Authorization": f"Bearer {token}", "Content-Type": _JSON_CONTENT_TYPE},
-            json_body=payload,
-        )
-    )
-
-    _LOG.debug("Bitbucket: commit status set to %s for %s", state, sha[:8])
-
-
-_PLATFORM_STATUS_SETTERS: dict[CIPlatform, Any] = {
-    CIPlatform.GITHUB_ACTIONS: _set_github_commit_status,
-    CIPlatform.GITLAB_CI: _set_gitlab_commit_status,
-    CIPlatform.BITBUCKET: _set_bitbucket_commit_status,
-}

--- a/phi_scan/exceptions.py
+++ b/phi_scan/exceptions.py
@@ -14,6 +14,7 @@ __all__ = [
     "AuditKeyMissingError",
     "AuditLogError",
     "BaselineError",
+    "CIIntegrationError",
     "ConfigurationError",
     "FileReadError",
     "MissingOptionalDependencyError",
@@ -182,6 +183,20 @@ class PluginValidationError(PhiScanError):
     Args:
         message: Description of the validation failure including the
             offending attribute or value and what was expected.
+    """
+
+
+class CIIntegrationError(PhiScanError):
+    """Raised when a CI/CD platform API call fails.
+
+    Covers HTTP errors, authentication failures, and CLI tool invocation
+    failures across all supported CI/CD platforms. Error messages include
+    only the HTTP status code and reason phrase — never the response body,
+    which could echo back request content containing finding metadata.
+
+    Args:
+        message: Description of the failure including the platform name,
+            the operation that failed, and the status code where applicable.
     """
 
 

--- a/tests/test_ci_adapters.py
+++ b/tests/test_ci_adapters.py
@@ -9,7 +9,7 @@ Covers:
   - Meta-platform delegation (Jenkins, CircleCI, CodeBuild)
   - Transport error wrapping
   - Platform detection from env vars
-  - PRContext builders
+  - PullRequestContext builders
 """
 
 from __future__ import annotations
@@ -29,9 +29,9 @@ from phi_scan.ci import (
     GitHubAdapter,
     GitLabAdapter,
     JenkinsAdapter,
-    PRContext,
+    PullRequestContext,
     detect_platform,
-    get_pr_context,
+    get_pull_request_context,
     resolve_adapter,
 )
 from phi_scan.ci._transport import (
@@ -125,16 +125,16 @@ def test_gitlab_default_capabilities_are_false() -> None:
 def test_upload_sarif_report_raises_ci_integration_error() -> None:
     adapter = GitLabAdapter()
     scan_result_mock = MagicMock()
-    pr_context = PRContext(
+    pull_request_context = PullRequestContext(
         platform=CIPlatform.GITLAB_CI,
-        pr_number="1",
+        pull_request_number="1",
         repository="123",
         sha="abc",
         branch="main",
         base_branch=None,
     )
     with pytest.raises(CIIntegrationError, match="GitLabAdapter.*SARIF upload"):
-        adapter.upload_sarif_report(scan_result_mock, pr_context)
+        adapter.upload_sarif_report(scan_result_mock, pull_request_context)
 
 
 # ---------------------------------------------------------------------------
@@ -144,9 +144,11 @@ def test_upload_sarif_report_raises_ci_integration_error() -> None:
 _BACKWARD_COMPAT_NAMES: list[str] = [
     "CIPlatform",
     "PRContext",
+    "PullRequestContext",
     "CIIntegrationError",
     "detect_platform",
     "get_pr_context",
+    "get_pull_request_context",
     "BaseCIAdapter",
     "GitHubAdapter",
     "GitLabAdapter",
@@ -276,7 +278,7 @@ def test_detect_platform(env_vars: dict[str, str], expected_platform: CIPlatform
 
 
 # ---------------------------------------------------------------------------
-# PRContext builders
+# PullRequestContext builders
 # ---------------------------------------------------------------------------
 
 
@@ -289,9 +291,9 @@ def test_get_pr_context_github() -> None:
         "PR_NUMBER": "42",
     }
     with patch.dict("os.environ", env, clear=True):
-        context = get_pr_context()
+        context = get_pull_request_context()
     assert context.platform == CIPlatform.GITHUB_ACTIONS
-    assert context.pr_number == "42"
+    assert context.pull_request_number == "42"
     assert context.repository == "owner/repo"
     assert context.sha == "abc123"
 
@@ -304,8 +306,8 @@ def test_get_pr_context_github_extracts_pr_from_ref() -> None:
         "GITHUB_REF": "refs/pull/99/merge",
     }
     with patch.dict("os.environ", env, clear=True):
-        context = get_pr_context()
-    assert context.pr_number == "99"
+        context = get_pull_request_context()
+    assert context.pull_request_number == "99"
 
 
 def test_get_pr_context_gitlab() -> None:
@@ -318,17 +320,17 @@ def test_get_pr_context_gitlab() -> None:
         "CI_SERVER_URL": "https://gitlab.example.com",
     }
     with patch.dict("os.environ", env, clear=True):
-        context = get_pr_context()
+        context = get_pull_request_context()
     assert context.platform == CIPlatform.GITLAB_CI
-    assert context.pr_number == "7"
+    assert context.pull_request_number == "7"
     assert context.extras["ci_server_url"] == "https://gitlab.example.com"
 
 
 def test_get_pr_context_unknown() -> None:
     with patch.dict("os.environ", {}, clear=True):
-        context = get_pr_context()
+        context = get_pull_request_context()
     assert context.platform == CIPlatform.UNKNOWN
-    assert context.pr_number is None
+    assert context.pull_request_number is None
 
 
 # ---------------------------------------------------------------------------
@@ -337,17 +339,17 @@ def test_get_pr_context_unknown() -> None:
 
 
 def test_jenkins_delegates_to_github(monkeypatch: pytest.MonkeyPatch) -> None:
-    pr_context = PRContext(
+    pull_request_context = PullRequestContext(
         platform=CIPlatform.JENKINS,
-        pr_number="10",
+        pull_request_number="10",
         repository=None,
         sha=None,
         branch=None,
         base_branch=None,
         extras={"change_url": "https://github.com/owner/repo/pull/10"},
     )
-    with patch.object(GitHubAdapter, "post_pr_comment") as mock_gh:
-        JenkinsAdapter().post_pr_comment("test body", pr_context)
+    with patch.object(GitHubAdapter, "post_pull_request_comment") as mock_gh:
+        JenkinsAdapter().post_pull_request_comment("test body", pull_request_context)
         mock_gh.assert_called_once()
         delegated_context = mock_gh.call_args[0][1]
         assert delegated_context.platform == CIPlatform.GITHUB_ACTIONS
@@ -355,24 +357,24 @@ def test_jenkins_delegates_to_github(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_jenkins_delegates_to_gitlab() -> None:
-    pr_context = PRContext(
+    pull_request_context = PullRequestContext(
         platform=CIPlatform.JENKINS,
-        pr_number="5",
+        pull_request_number="5",
         repository=None,
         sha=None,
         branch=None,
         base_branch=None,
         extras={"change_url": "https://gitlab.example.com/group/project/-/merge_requests/5"},
     )
-    with patch.object(GitLabAdapter, "post_pr_comment") as mock_gl:
-        JenkinsAdapter().post_pr_comment("test body", pr_context)
+    with patch.object(GitLabAdapter, "post_pull_request_comment") as mock_gl:
+        JenkinsAdapter().post_pull_request_comment("test body", pull_request_context)
         mock_gl.assert_called_once()
 
 
 def test_jenkins_skips_when_no_change_url() -> None:
-    pr_context = PRContext(
+    pull_request_context = PullRequestContext(
         platform=CIPlatform.JENKINS,
-        pr_number="5",
+        pull_request_number="5",
         repository=None,
         sha=None,
         branch=None,
@@ -380,67 +382,67 @@ def test_jenkins_skips_when_no_change_url() -> None:
         extras={},
     )
     with (
-        patch.object(GitHubAdapter, "post_pr_comment") as mock_gh,
-        patch.object(GitLabAdapter, "post_pr_comment") as mock_gl,
+        patch.object(GitHubAdapter, "post_pull_request_comment") as mock_gh,
+        patch.object(GitLabAdapter, "post_pull_request_comment") as mock_gl,
     ):
-        JenkinsAdapter().post_pr_comment("test body", pr_context)
+        JenkinsAdapter().post_pull_request_comment("test body", pull_request_context)
         mock_gh.assert_not_called()
         mock_gl.assert_not_called()
 
 
 def test_circleci_delegates_to_github() -> None:
-    pr_context = PRContext(
+    pull_request_context = PullRequestContext(
         platform=CIPlatform.CIRCLECI,
-        pr_number="20",
+        pull_request_number="20",
         repository=None,
         sha="abc",
         branch="feature",
         base_branch=None,
         extras={"circle_pull_request_url": "https://github.com/owner/repo/pull/20"},
     )
-    with patch.object(GitHubAdapter, "post_pr_comment") as mock_gh:
-        CircleCIAdapter().post_pr_comment("test body", pr_context)
+    with patch.object(GitHubAdapter, "post_pull_request_comment") as mock_gh:
+        CircleCIAdapter().post_pull_request_comment("test body", pull_request_context)
         mock_gh.assert_called_once()
         delegated_context = mock_gh.call_args[0][1]
         assert delegated_context.repository == "owner/repo"
 
 
 def test_circleci_delegates_to_bitbucket() -> None:
-    pr_context = PRContext(
+    pull_request_context = PullRequestContext(
         platform=CIPlatform.CIRCLECI,
-        pr_number="15",
+        pull_request_number="15",
         repository=None,
         sha="abc",
         branch="feature",
         base_branch=None,
         extras={"circle_pull_request_url": "https://bitbucket.org/workspace/repo/pull-requests/15"},
     )
-    with patch.object(BitbucketAdapter, "post_pr_comment") as mock_bb:
-        CircleCIAdapter().post_pr_comment("test body", pr_context)
+    with patch.object(BitbucketAdapter, "post_pull_request_comment") as mock_bb:
+        CircleCIAdapter().post_pull_request_comment("test body", pull_request_context)
         mock_bb.assert_called_once()
 
 
 def test_codebuild_delegates_to_github() -> None:
-    pr_context = PRContext(
+    pull_request_context = PullRequestContext(
         platform=CIPlatform.CODEBUILD,
-        pr_number="30",
+        pull_request_number="30",
         repository=None,
         sha="abc",
         branch=None,
         base_branch=None,
     )
     with patch.dict("os.environ", {"CODEBUILD_SOURCE_REPO_URL": "https://github.com/owner/repo"}):
-        with patch.object(GitHubAdapter, "post_pr_comment") as mock_gh:
-            CodeBuildAdapter().post_pr_comment("test body", pr_context)
+        with patch.object(GitHubAdapter, "post_pull_request_comment") as mock_gh:
+            CodeBuildAdapter().post_pull_request_comment("test body", pull_request_context)
             mock_gh.assert_called_once()
             delegated_context = mock_gh.call_args[0][1]
             assert delegated_context.repository == "owner/repo"
 
 
 def test_codebuild_delegates_to_bitbucket() -> None:
-    pr_context = PRContext(
+    pull_request_context = PullRequestContext(
         platform=CIPlatform.CODEBUILD,
-        pr_number="30",
+        pull_request_number="30",
         repository=None,
         sha="abc",
         branch=None,
@@ -449,27 +451,27 @@ def test_codebuild_delegates_to_bitbucket() -> None:
     with patch.dict(
         "os.environ", {"CODEBUILD_SOURCE_REPO_URL": "https://bitbucket.org/workspace/repo"}
     ):
-        with patch.object(BitbucketAdapter, "post_pr_comment") as mock_bb:
-            CodeBuildAdapter().post_pr_comment("test body", pr_context)
+        with patch.object(BitbucketAdapter, "post_pull_request_comment") as mock_bb:
+            CodeBuildAdapter().post_pull_request_comment("test body", pull_request_context)
             mock_bb.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
-# PRContext is frozen
+# PullRequestContext is frozen
 # ---------------------------------------------------------------------------
 
 
 def test_pr_context_is_frozen() -> None:
-    context = PRContext(
+    context = PullRequestContext(
         platform=CIPlatform.UNKNOWN,
-        pr_number=None,
+        pull_request_number=None,
         repository=None,
         sha=None,
         branch=None,
         base_branch=None,
     )
     with pytest.raises(AttributeError):
-        context.pr_number = "999"  # type: ignore[misc]
+        context.pull_request_number = "999"  # type: ignore[misc]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ci_adapters.py
+++ b/tests/test_ci_adapters.py
@@ -164,6 +164,8 @@ _BACKWARD_COMPAT_NAMES: list[str] = [
     "execute_http_request",
 ]
 
+_DEPRECATED_ALIASES: set[str] = {"PRContext", "get_pr_context"}
+
 
 @pytest.mark.parametrize("name", _BACKWARD_COMPAT_NAMES)
 def test_backward_compat_import_from_ci_integration(name: str) -> None:
@@ -179,8 +181,12 @@ _TRANSPORT_NAMES: set[str] = {
     "execute_http_request",
 }
 
+_PARITY_NAMES: list[str] = [
+    name for name in _BACKWARD_COMPAT_NAMES if name not in _DEPRECATED_ALIASES
+]
 
-@pytest.mark.parametrize("name", _BACKWARD_COMPAT_NAMES)
+
+@pytest.mark.parametrize("name", _PARITY_NAMES)
 def test_old_and_new_paths_resolve_to_same_object(name: str) -> None:
     import phi_scan.ci as new_module
     import phi_scan.ci._transport as transport_module

--- a/tests/test_ci_adapters.py
+++ b/tests/test_ci_adapters.py
@@ -222,7 +222,7 @@ def test_execute_http_request_wraps_network_error() -> None:
         "phi_scan.ci._transport.httpx.request",
         side_effect=httpx.ConnectError("connection refused"),
     ):
-        with pytest.raises(CIIntegrationError, match="request failed.*ConnectError"):
+        with pytest.raises(CIIntegrationError, match="request failed \\(network error\\)"):
             execute_http_request(
                 HttpRequestConfig(
                     method=HttpMethod.POST,
@@ -246,7 +246,7 @@ def test_execute_http_request_network_error_excludes_url() -> None:
                 )
             )
         assert "secret.example.com" not in str(exc_info.value)
-        assert "ConnectError" in str(exc_info.value)
+        assert "network error" in str(exc_info.value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ci_adapters.py
+++ b/tests/test_ci_adapters.py
@@ -80,20 +80,20 @@ def test_resolve_adapter_unknown_raises_error() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_github_can_upload_sarif() -> None:
-    assert GitHubAdapter().can_upload_sarif is True
+def test_github_can_upload_sarif_report() -> None:
+    assert GitHubAdapter().can_upload_sarif_report is True
 
 
-def test_bitbucket_can_annotate_code() -> None:
-    assert BitbucketAdapter().can_annotate_code is True
+def test_bitbucket_can_annotate_code_findings() -> None:
+    assert BitbucketAdapter().can_annotate_code_findings is True
 
 
-def test_azure_can_create_work_item() -> None:
-    assert AzureAdapter().can_create_work_item is True
+def test_azure_can_create_work_item_from_findings() -> None:
+    assert AzureAdapter().can_create_work_item_from_findings is True
 
 
-def test_codebuild_can_import_to_security_hub() -> None:
-    assert CodeBuildAdapter().can_import_to_security_hub is True
+def test_codebuild_can_import_findings_to_security_hub() -> None:
+    assert CodeBuildAdapter().can_import_findings_to_security_hub is True
 
 
 def test_adapters_with_commit_status_support() -> None:
@@ -111,18 +111,18 @@ def test_adapters_without_commit_status_support() -> None:
 
 def test_gitlab_default_capabilities_are_false() -> None:
     adapter = GitLabAdapter()
-    assert adapter.can_upload_sarif is False
-    assert adapter.can_annotate_code is False
-    assert adapter.can_create_work_item is False
-    assert adapter.can_import_to_security_hub is False
+    assert adapter.can_upload_sarif_report is False
+    assert adapter.can_annotate_code_findings is False
+    assert adapter.can_create_work_item_from_findings is False
+    assert adapter.can_import_findings_to_security_hub is False
 
 
 # ---------------------------------------------------------------------------
-# BaseCIAdapter.upload_sarif raises domain error
+# BaseCIAdapter.upload_sarif_report raises domain error
 # ---------------------------------------------------------------------------
 
 
-def test_upload_sarif_raises_ci_integration_error() -> None:
+def test_upload_sarif_report_raises_ci_integration_error() -> None:
     adapter = GitLabAdapter()
     scan_result_mock = MagicMock()
     pr_context = PRContext(
@@ -134,7 +134,7 @@ def test_upload_sarif_raises_ci_integration_error() -> None:
         base_branch=None,
     )
     with pytest.raises(CIIntegrationError, match="GitLabAdapter.*SARIF upload"):
-        adapter.upload_sarif(scan_result_mock, pr_context)
+        adapter.upload_sarif_report(scan_result_mock, pr_context)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ci_adapters.py
+++ b/tests/test_ci_adapters.py
@@ -28,15 +28,13 @@ from phi_scan.ci import (
     CodeBuildAdapter,
     GitHubAdapter,
     GitLabAdapter,
-    HttpMethod,
-    HttpRequestConfig,
     JenkinsAdapter,
     PRContext,
     detect_platform,
-    execute_http_request,
     get_pr_context,
     resolve_adapter,
 )
+from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
 from phi_scan.exceptions import CIIntegrationError
 
 # ---------------------------------------------------------------------------
@@ -152,15 +150,21 @@ def test_backward_compat_import_from_ci_integration(name: str) -> None:
     assert hasattr(old_module, name), f"{name} not importable from phi_scan.ci_integration"
 
 
+_TRANSPORT_NAMES: set[str] = {"HttpMethod", "HttpRequestConfig", "execute_http_request"}
+
+
 @pytest.mark.parametrize("name", _BACKWARD_COMPAT_NAMES)
 def test_old_and_new_paths_resolve_to_same_object(name: str) -> None:
     import phi_scan.ci as new_module
+    import phi_scan.ci._transport as transport_module
     import phi_scan.ci_integration as old_module
 
     if name == "CIIntegrationError":
         import phi_scan.exceptions
 
         new_obj = phi_scan.exceptions.CIIntegrationError
+    elif name in _TRANSPORT_NAMES:
+        new_obj = getattr(transport_module, name)
     else:
         new_obj = getattr(new_module, name)
     old_obj = getattr(old_module, name)
@@ -193,7 +197,7 @@ def test_execute_http_request_wraps_network_error() -> None:
         "phi_scan.ci._transport.httpx.request",
         side_effect=httpx.ConnectError("connection refused"),
     ):
-        with pytest.raises(CIIntegrationError, match="request failed"):
+        with pytest.raises(CIIntegrationError, match="request failed.*ConnectError"):
             execute_http_request(
                 HttpRequestConfig(
                     method=HttpMethod.POST,
@@ -201,6 +205,23 @@ def test_execute_http_request_wraps_network_error() -> None:
                     operation_label="test operation",
                 )
             )
+
+
+def test_execute_http_request_network_error_excludes_url() -> None:
+    with patch(
+        "phi_scan.ci._transport.httpx.request",
+        side_effect=httpx.ConnectError("connection refused to https://secret.example.com/phi-data"),
+    ):
+        with pytest.raises(CIIntegrationError) as exc_info:
+            execute_http_request(
+                HttpRequestConfig(
+                    method=HttpMethod.POST,
+                    url="https://secret.example.com/phi-data",
+                    operation_label="test operation",
+                )
+            )
+        assert "secret.example.com" not in str(exc_info.value)
+        assert "ConnectError" in str(exc_info.value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ci_adapters.py
+++ b/tests/test_ci_adapters.py
@@ -70,8 +70,9 @@ def test_resolve_adapter_returns_correct_type(
     assert isinstance(adapter, expected_type)
 
 
-def test_resolve_adapter_unknown_returns_none() -> None:
-    assert resolve_adapter(CIPlatform.UNKNOWN) is None
+def test_resolve_adapter_unknown_raises_error() -> None:
+    with pytest.raises(CIIntegrationError):
+        resolve_adapter(CIPlatform.UNKNOWN)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ci_adapters.py
+++ b/tests/test_ci_adapters.py
@@ -1,0 +1,441 @@
+# phi-scan:ignore-file
+"""Tests for the phi_scan.ci adapter package.
+
+Covers:
+  - resolve_adapter returns correct adapter types
+  - Adapter capability flags
+  - BaseCIAdapter.upload_sarif default raises CIIntegrationError
+  - Import parity: all names importable via both old and new paths
+  - Meta-platform delegation (Jenkins, CircleCI, CodeBuild)
+  - Transport error wrapping
+  - Platform detection from env vars
+  - PRContext builders
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from phi_scan.ci import (
+    AzureAdapter,
+    BaseCIAdapter,
+    BitbucketAdapter,
+    CIPlatform,
+    CircleCIAdapter,
+    CodeBuildAdapter,
+    GitHubAdapter,
+    GitLabAdapter,
+    HttpMethod,
+    HttpRequestConfig,
+    JenkinsAdapter,
+    PRContext,
+    detect_platform,
+    execute_http_request,
+    get_pr_context,
+    resolve_adapter,
+)
+from phi_scan.exceptions import CIIntegrationError
+
+# ---------------------------------------------------------------------------
+# resolve_adapter
+# ---------------------------------------------------------------------------
+
+
+_EXPECTED_ADAPTER_TYPES: list[tuple[CIPlatform, type[BaseCIAdapter]]] = [
+    (CIPlatform.GITHUB_ACTIONS, GitHubAdapter),
+    (CIPlatform.GITLAB_CI, GitLabAdapter),
+    (CIPlatform.AZURE_DEVOPS, AzureAdapter),
+    (CIPlatform.BITBUCKET, BitbucketAdapter),
+    (CIPlatform.CIRCLECI, CircleCIAdapter),
+    (CIPlatform.CODEBUILD, CodeBuildAdapter),
+    (CIPlatform.JENKINS, JenkinsAdapter),
+]
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected_type"),
+    _EXPECTED_ADAPTER_TYPES,
+    ids=[p.value for p, _ in _EXPECTED_ADAPTER_TYPES],
+)
+def test_resolve_adapter_returns_correct_type(
+    platform: CIPlatform, expected_type: type[BaseCIAdapter]
+) -> None:
+    adapter = resolve_adapter(platform)
+    assert isinstance(adapter, expected_type)
+
+
+def test_resolve_adapter_unknown_returns_none() -> None:
+    assert resolve_adapter(CIPlatform.UNKNOWN) is None
+
+
+# ---------------------------------------------------------------------------
+# Capability flags
+# ---------------------------------------------------------------------------
+
+
+def test_github_supports_sarif_upload() -> None:
+    assert GitHubAdapter().supports_sarif_upload is True
+
+
+def test_bitbucket_supports_code_insights() -> None:
+    assert BitbucketAdapter().supports_code_insights is True
+
+
+def test_azure_supports_work_item_creation() -> None:
+    assert AzureAdapter().supports_work_item_creation is True
+
+
+def test_codebuild_supports_security_hub() -> None:
+    assert CodeBuildAdapter().supports_security_hub is True
+
+
+def test_gitlab_default_capabilities_are_false() -> None:
+    adapter = GitLabAdapter()
+    assert adapter.supports_sarif_upload is False
+    assert adapter.supports_code_insights is False
+    assert adapter.supports_work_item_creation is False
+    assert adapter.supports_security_hub is False
+
+
+# ---------------------------------------------------------------------------
+# BaseCIAdapter.upload_sarif raises domain error
+# ---------------------------------------------------------------------------
+
+
+def test_upload_sarif_raises_ci_integration_error() -> None:
+    adapter = GitLabAdapter()
+    scan_result_mock = MagicMock()
+    pr_context = PRContext(
+        platform=CIPlatform.GITLAB_CI,
+        pr_number="1",
+        repository="123",
+        sha="abc",
+        branch="main",
+        base_branch=None,
+    )
+    with pytest.raises(CIIntegrationError, match="GitLabAdapter.*SARIF upload"):
+        adapter.upload_sarif(scan_result_mock, pr_context)
+
+
+# ---------------------------------------------------------------------------
+# Import parity — old path still works
+# ---------------------------------------------------------------------------
+
+_BACKWARD_COMPAT_NAMES: list[str] = [
+    "CIPlatform",
+    "PRContext",
+    "CIIntegrationError",
+    "detect_platform",
+    "get_pr_context",
+    "BaseCIAdapter",
+    "GitHubAdapter",
+    "GitLabAdapter",
+    "AzureAdapter",
+    "BitbucketAdapter",
+    "CircleCIAdapter",
+    "CodeBuildAdapter",
+    "JenkinsAdapter",
+    "resolve_adapter",
+    "HttpMethod",
+    "HttpRequestConfig",
+    "execute_http_request",
+]
+
+
+@pytest.mark.parametrize("name", _BACKWARD_COMPAT_NAMES)
+def test_backward_compat_import_from_ci_integration(name: str) -> None:
+    import phi_scan.ci_integration as old_module
+
+    assert hasattr(old_module, name), f"{name} not importable from phi_scan.ci_integration"
+
+
+@pytest.mark.parametrize("name", _BACKWARD_COMPAT_NAMES)
+def test_old_and_new_paths_resolve_to_same_object(name: str) -> None:
+    import phi_scan.ci as new_module
+    import phi_scan.ci_integration as old_module
+
+    if name == "CIIntegrationError":
+        import phi_scan.exceptions
+
+        new_obj = phi_scan.exceptions.CIIntegrationError
+    else:
+        new_obj = getattr(new_module, name)
+    old_obj = getattr(old_module, name)
+    assert old_obj is new_obj, f"{name} differs between old and new import paths"
+
+
+# ---------------------------------------------------------------------------
+# Transport — error wrapping
+# ---------------------------------------------------------------------------
+
+
+def test_execute_http_request_wraps_status_error() -> None:
+    mock_response = httpx.Response(
+        status_code=403,
+        request=httpx.Request("POST", "https://example.com"),
+    )
+    with patch("phi_scan.ci._transport.httpx.request", return_value=mock_response):
+        with pytest.raises(CIIntegrationError, match="403"):
+            execute_http_request(
+                HttpRequestConfig(
+                    method=HttpMethod.POST,
+                    url="https://example.com",
+                    operation_label="test operation",
+                )
+            )
+
+
+def test_execute_http_request_wraps_network_error() -> None:
+    with patch(
+        "phi_scan.ci._transport.httpx.request",
+        side_effect=httpx.ConnectError("connection refused"),
+    ):
+        with pytest.raises(CIIntegrationError, match="request failed"):
+            execute_http_request(
+                HttpRequestConfig(
+                    method=HttpMethod.POST,
+                    url="https://example.com",
+                    operation_label="test operation",
+                )
+            )
+
+
+# ---------------------------------------------------------------------------
+# Platform detection
+# ---------------------------------------------------------------------------
+
+_DETECTION_CASES: list[tuple[dict[str, str], CIPlatform]] = [
+    ({"GITHUB_ACTIONS": "true"}, CIPlatform.GITHUB_ACTIONS),
+    ({"GITLAB_CI": "true"}, CIPlatform.GITLAB_CI),
+    ({"TF_BUILD": "True"}, CIPlatform.AZURE_DEVOPS),
+    ({"CIRCLECI": "true"}, CIPlatform.CIRCLECI),
+    ({"BITBUCKET_BUILD_NUMBER": "42"}, CIPlatform.BITBUCKET),
+    ({"CODEBUILD_BUILD_ID": "build-123"}, CIPlatform.CODEBUILD),
+    ({"JENKINS_URL": "https://jenkins.example.com"}, CIPlatform.JENKINS),
+    ({}, CIPlatform.UNKNOWN),
+]
+
+
+@pytest.mark.parametrize(
+    ("env_vars", "expected_platform"),
+    _DETECTION_CASES,
+    ids=[p.value for _, p in _DETECTION_CASES],
+)
+def test_detect_platform(env_vars: dict[str, str], expected_platform: CIPlatform) -> None:
+    with patch.dict("os.environ", env_vars, clear=True):
+        assert detect_platform() == expected_platform
+
+
+# ---------------------------------------------------------------------------
+# PRContext builders
+# ---------------------------------------------------------------------------
+
+
+def test_get_pr_context_github() -> None:
+    env = {
+        "GITHUB_ACTIONS": "true",
+        "GITHUB_REPOSITORY": "owner/repo",
+        "GITHUB_SHA": "abc123",
+        "GITHUB_REF": "refs/pull/42/merge",
+        "PR_NUMBER": "42",
+    }
+    with patch.dict("os.environ", env, clear=True):
+        context = get_pr_context()
+    assert context.platform == CIPlatform.GITHUB_ACTIONS
+    assert context.pr_number == "42"
+    assert context.repository == "owner/repo"
+    assert context.sha == "abc123"
+
+
+def test_get_pr_context_github_extracts_pr_from_ref() -> None:
+    env = {
+        "GITHUB_ACTIONS": "true",
+        "GITHUB_REPOSITORY": "owner/repo",
+        "GITHUB_SHA": "abc123",
+        "GITHUB_REF": "refs/pull/99/merge",
+    }
+    with patch.dict("os.environ", env, clear=True):
+        context = get_pr_context()
+    assert context.pr_number == "99"
+
+
+def test_get_pr_context_gitlab() -> None:
+    env = {
+        "GITLAB_CI": "true",
+        "CI_PROJECT_ID": "12345",
+        "CI_MERGE_REQUEST_IID": "7",
+        "CI_COMMIT_SHA": "def456",
+        "CI_COMMIT_REF_NAME": "feature",
+        "CI_SERVER_URL": "https://gitlab.example.com",
+    }
+    with patch.dict("os.environ", env, clear=True):
+        context = get_pr_context()
+    assert context.platform == CIPlatform.GITLAB_CI
+    assert context.pr_number == "7"
+    assert context.extras["ci_server_url"] == "https://gitlab.example.com"
+
+
+def test_get_pr_context_unknown() -> None:
+    with patch.dict("os.environ", {}, clear=True):
+        context = get_pr_context()
+    assert context.platform == CIPlatform.UNKNOWN
+    assert context.pr_number is None
+
+
+# ---------------------------------------------------------------------------
+# Meta-platform delegation
+# ---------------------------------------------------------------------------
+
+
+def test_jenkins_delegates_to_github(monkeypatch: pytest.MonkeyPatch) -> None:
+    pr_context = PRContext(
+        platform=CIPlatform.JENKINS,
+        pr_number="10",
+        repository=None,
+        sha=None,
+        branch=None,
+        base_branch=None,
+        extras={"change_url": "https://github.com/owner/repo/pull/10"},
+    )
+    with patch.object(GitHubAdapter, "post_pr_comment") as mock_gh:
+        JenkinsAdapter().post_pr_comment("test body", pr_context)
+        mock_gh.assert_called_once()
+        delegated_context = mock_gh.call_args[0][1]
+        assert delegated_context.platform == CIPlatform.GITHUB_ACTIONS
+        assert delegated_context.repository == "owner/repo"
+
+
+def test_jenkins_delegates_to_gitlab() -> None:
+    pr_context = PRContext(
+        platform=CIPlatform.JENKINS,
+        pr_number="5",
+        repository=None,
+        sha=None,
+        branch=None,
+        base_branch=None,
+        extras={"change_url": "https://gitlab.example.com/group/project/-/merge_requests/5"},
+    )
+    with patch.object(GitLabAdapter, "post_pr_comment") as mock_gl:
+        JenkinsAdapter().post_pr_comment("test body", pr_context)
+        mock_gl.assert_called_once()
+
+
+def test_jenkins_skips_when_no_change_url() -> None:
+    pr_context = PRContext(
+        platform=CIPlatform.JENKINS,
+        pr_number="5",
+        repository=None,
+        sha=None,
+        branch=None,
+        base_branch=None,
+        extras={},
+    )
+    with (
+        patch.object(GitHubAdapter, "post_pr_comment") as mock_gh,
+        patch.object(GitLabAdapter, "post_pr_comment") as mock_gl,
+    ):
+        JenkinsAdapter().post_pr_comment("test body", pr_context)
+        mock_gh.assert_not_called()
+        mock_gl.assert_not_called()
+
+
+def test_circleci_delegates_to_github() -> None:
+    pr_context = PRContext(
+        platform=CIPlatform.CIRCLECI,
+        pr_number="20",
+        repository=None,
+        sha="abc",
+        branch="feature",
+        base_branch=None,
+        extras={"circle_pull_request_url": "https://github.com/owner/repo/pull/20"},
+    )
+    with patch.object(GitHubAdapter, "post_pr_comment") as mock_gh:
+        CircleCIAdapter().post_pr_comment("test body", pr_context)
+        mock_gh.assert_called_once()
+        delegated_context = mock_gh.call_args[0][1]
+        assert delegated_context.repository == "owner/repo"
+
+
+def test_circleci_delegates_to_bitbucket() -> None:
+    pr_context = PRContext(
+        platform=CIPlatform.CIRCLECI,
+        pr_number="15",
+        repository=None,
+        sha="abc",
+        branch="feature",
+        base_branch=None,
+        extras={"circle_pull_request_url": "https://bitbucket.org/workspace/repo/pull-requests/15"},
+    )
+    with patch.object(BitbucketAdapter, "post_pr_comment") as mock_bb:
+        CircleCIAdapter().post_pr_comment("test body", pr_context)
+        mock_bb.assert_called_once()
+
+
+def test_codebuild_delegates_to_github() -> None:
+    pr_context = PRContext(
+        platform=CIPlatform.CODEBUILD,
+        pr_number="30",
+        repository=None,
+        sha="abc",
+        branch=None,
+        base_branch=None,
+    )
+    with patch.dict("os.environ", {"CODEBUILD_SOURCE_REPO_URL": "https://github.com/owner/repo"}):
+        with patch.object(GitHubAdapter, "post_pr_comment") as mock_gh:
+            CodeBuildAdapter().post_pr_comment("test body", pr_context)
+            mock_gh.assert_called_once()
+            delegated_context = mock_gh.call_args[0][1]
+            assert delegated_context.repository == "owner/repo"
+
+
+def test_codebuild_delegates_to_bitbucket() -> None:
+    pr_context = PRContext(
+        platform=CIPlatform.CODEBUILD,
+        pr_number="30",
+        repository=None,
+        sha="abc",
+        branch=None,
+        base_branch=None,
+    )
+    with patch.dict(
+        "os.environ", {"CODEBUILD_SOURCE_REPO_URL": "https://bitbucket.org/workspace/repo"}
+    ):
+        with patch.object(BitbucketAdapter, "post_pr_comment") as mock_bb:
+            CodeBuildAdapter().post_pr_comment("test body", pr_context)
+            mock_bb.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# PRContext is frozen
+# ---------------------------------------------------------------------------
+
+
+def test_pr_context_is_frozen() -> None:
+    context = PRContext(
+        platform=CIPlatform.UNKNOWN,
+        pr_number=None,
+        repository=None,
+        sha=None,
+        branch=None,
+        base_branch=None,
+    )
+    with pytest.raises(AttributeError):
+        context.pr_number = "999"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# HttpRequestConfig is frozen
+# ---------------------------------------------------------------------------
+
+
+def test_http_request_config_is_frozen() -> None:
+    config = HttpRequestConfig(
+        method=HttpMethod.POST,
+        url="https://example.com",
+        operation_label="test",
+    )
+    with pytest.raises(AttributeError):
+        config.url = "https://other.com"  # type: ignore[misc]

--- a/tests/test_ci_adapters.py
+++ b/tests/test_ci_adapters.py
@@ -79,41 +79,41 @@ def test_resolve_adapter_unknown_returns_none() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_github_supports_sarif_upload() -> None:
-    assert GitHubAdapter().supports_sarif_upload is True
+def test_github_can_upload_sarif() -> None:
+    assert GitHubAdapter().can_upload_sarif is True
 
 
-def test_bitbucket_supports_code_insights() -> None:
-    assert BitbucketAdapter().supports_code_insights is True
+def test_bitbucket_can_annotate_code() -> None:
+    assert BitbucketAdapter().can_annotate_code is True
 
 
-def test_azure_supports_work_item_creation() -> None:
-    assert AzureAdapter().supports_work_item_creation is True
+def test_azure_can_create_work_item() -> None:
+    assert AzureAdapter().can_create_work_item is True
 
 
-def test_codebuild_supports_security_hub() -> None:
-    assert CodeBuildAdapter().supports_security_hub is True
+def test_codebuild_can_import_to_security_hub() -> None:
+    assert CodeBuildAdapter().can_import_to_security_hub is True
 
 
 def test_adapters_with_commit_status_support() -> None:
-    assert GitHubAdapter().supports_commit_status is True
-    assert GitLabAdapter().supports_commit_status is True
-    assert BitbucketAdapter().supports_commit_status is True
+    assert GitHubAdapter().can_post_commit_status is True
+    assert GitLabAdapter().can_post_commit_status is True
+    assert BitbucketAdapter().can_post_commit_status is True
 
 
 def test_adapters_without_commit_status_support() -> None:
-    assert AzureAdapter().supports_commit_status is False
-    assert JenkinsAdapter().supports_commit_status is False
-    assert CircleCIAdapter().supports_commit_status is False
-    assert CodeBuildAdapter().supports_commit_status is False
+    assert AzureAdapter().can_post_commit_status is False
+    assert JenkinsAdapter().can_post_commit_status is False
+    assert CircleCIAdapter().can_post_commit_status is False
+    assert CodeBuildAdapter().can_post_commit_status is False
 
 
 def test_gitlab_default_capabilities_are_false() -> None:
     adapter = GitLabAdapter()
-    assert adapter.supports_sarif_upload is False
-    assert adapter.supports_code_insights is False
-    assert adapter.supports_work_item_creation is False
-    assert adapter.supports_security_hub is False
+    assert adapter.can_upload_sarif is False
+    assert adapter.can_annotate_code is False
+    assert adapter.can_create_work_item is False
+    assert adapter.can_import_to_security_hub is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ci_adapters.py
+++ b/tests/test_ci_adapters.py
@@ -90,6 +90,19 @@ def test_codebuild_supports_security_hub() -> None:
     assert CodeBuildAdapter().supports_security_hub is True
 
 
+def test_adapters_with_commit_status_support() -> None:
+    assert GitHubAdapter().supports_commit_status is True
+    assert GitLabAdapter().supports_commit_status is True
+    assert BitbucketAdapter().supports_commit_status is True
+
+
+def test_adapters_without_commit_status_support() -> None:
+    assert AzureAdapter().supports_commit_status is False
+    assert JenkinsAdapter().supports_commit_status is False
+    assert CircleCIAdapter().supports_commit_status is False
+    assert CodeBuildAdapter().supports_commit_status is False
+
+
 def test_gitlab_default_capabilities_are_false() -> None:
     adapter = GitLabAdapter()
     assert adapter.supports_sarif_upload is False

--- a/tests/test_ci_adapters.py
+++ b/tests/test_ci_adapters.py
@@ -34,7 +34,12 @@ from phi_scan.ci import (
     get_pr_context,
     resolve_adapter,
 )
-from phi_scan.ci._transport import HttpMethod, HttpRequestConfig, execute_http_request
+from phi_scan.ci._transport import (
+    HttpMethod,
+    HttpRequestConfig,
+    OperationLabel,
+    execute_http_request,
+)
 from phi_scan.exceptions import CIIntegrationError
 
 # ---------------------------------------------------------------------------
@@ -152,6 +157,7 @@ _BACKWARD_COMPAT_NAMES: list[str] = [
     "resolve_adapter",
     "HttpMethod",
     "HttpRequestConfig",
+    "OperationLabel",
     "execute_http_request",
 ]
 
@@ -163,7 +169,12 @@ def test_backward_compat_import_from_ci_integration(name: str) -> None:
     assert hasattr(old_module, name), f"{name} not importable from phi_scan.ci_integration"
 
 
-_TRANSPORT_NAMES: set[str] = {"HttpMethod", "HttpRequestConfig", "execute_http_request"}
+_TRANSPORT_NAMES: set[str] = {
+    "HttpMethod",
+    "HttpRequestConfig",
+    "OperationLabel",
+    "execute_http_request",
+}
 
 
 @pytest.mark.parametrize("name", _BACKWARD_COMPAT_NAMES)
@@ -200,7 +211,7 @@ def test_execute_http_request_wraps_status_error() -> None:
                 HttpRequestConfig(
                     method=HttpMethod.POST,
                     url="https://example.com",
-                    operation_label="test operation",
+                    operation_label=OperationLabel.GITHUB_COMMIT_STATUS,
                 )
             )
 
@@ -215,7 +226,7 @@ def test_execute_http_request_wraps_network_error() -> None:
                 HttpRequestConfig(
                     method=HttpMethod.POST,
                     url="https://example.com",
-                    operation_label="test operation",
+                    operation_label=OperationLabel.GITHUB_COMMIT_STATUS,
                 )
             )
 
@@ -230,7 +241,7 @@ def test_execute_http_request_network_error_excludes_url() -> None:
                 HttpRequestConfig(
                     method=HttpMethod.POST,
                     url="https://secret.example.com/phi-data",
-                    operation_label="test operation",
+                    operation_label=OperationLabel.GITHUB_COMMIT_STATUS,
                 )
             )
         assert "secret.example.com" not in str(exc_info.value)
@@ -469,7 +480,7 @@ def test_http_request_config_is_frozen() -> None:
     config = HttpRequestConfig(
         method=HttpMethod.POST,
         url="https://example.com",
-        operation_label="test",
+        operation_label=OperationLabel.GITHUB_COMMIT_STATUS,
     )
     with pytest.raises(AttributeError):
         config.url = "https://other.com"  # type: ignore[misc]

--- a/tests/test_ci_integration.py
+++ b/tests/test_ci_integration.py
@@ -23,11 +23,11 @@ from typer.testing import CliRunner
 from phi_scan.ci_integration import (
     CIIntegrationError,
     CIPlatform,
-    PRContext,
+    PullRequestContext,
     build_comment_body,
     detect_platform,
-    get_pr_context,
-    post_pr_comment,
+    get_pull_request_context,
+    post_pull_request_comment,
     set_commit_status,
 )
 from phi_scan.cli import app
@@ -258,7 +258,7 @@ def test_detect_platform_returns_unknown_when_no_ci_env_set(
 
 
 # ---------------------------------------------------------------------------
-# get_pr_context tests
+# get_pull_request_context tests
 # ---------------------------------------------------------------------------
 
 
@@ -272,10 +272,10 @@ def test_get_pr_context_github_extracts_pr_number(
     monkeypatch.setenv("GITHUB_SHA", _GITHUB_SHA)
     monkeypatch.setenv("GITHUB_REF", "refs/pull/42/merge")
 
-    context = get_pr_context()
+    context = get_pull_request_context()
 
     assert context.platform == CIPlatform.GITHUB_ACTIONS
-    assert context.pr_number == _GITHUB_PR_NUMBER
+    assert context.pull_request_number == _GITHUB_PR_NUMBER
     assert context.repository == _GITHUB_REPO
     assert context.sha == _GITHUB_SHA
 
@@ -288,9 +288,9 @@ def test_get_pr_context_github_falls_back_to_ref_for_pr_number(
     monkeypatch.delenv("PR_NUMBER", raising=False)
     monkeypatch.setenv("GITHUB_REF", "refs/pull/99/merge")
 
-    context = get_pr_context()
+    context = get_pull_request_context()
 
-    assert context.pr_number == "99"
+    assert context.pull_request_number == "99"
 
 
 def test_get_pr_context_gitlab_extracts_mr_iid(
@@ -303,10 +303,10 @@ def test_get_pr_context_gitlab_extracts_mr_iid(
     monkeypatch.setenv("CI_PROJECT_ID", _GITLAB_PROJECT_ID)
     monkeypatch.setenv("CI_COMMIT_SHA", _GITLAB_SHA)
 
-    context = get_pr_context()
+    context = get_pull_request_context()
 
     assert context.platform == CIPlatform.GITLAB_CI
-    assert context.pr_number == _GITLAB_MR_IID
+    assert context.pull_request_number == _GITLAB_MR_IID
     assert context.repository == _GITLAB_PROJECT_ID
     assert context.sha == _GITLAB_SHA
 
@@ -324,10 +324,10 @@ def test_get_pr_context_azure_extracts_pr_id(
     monkeypatch.setenv("SYSTEM_TEAMPROJECT", _AZURE_TEAM_PROJECT)
     monkeypatch.setenv("BUILD_SOURCEVERSION", _AZURE_SHA)
 
-    context = get_pr_context()
+    context = get_pull_request_context()
 
     assert context.platform == CIPlatform.AZURE_DEVOPS
-    assert context.pr_number == _AZURE_PR_ID
+    assert context.pull_request_number == _AZURE_PR_ID
     assert context.repository == _AZURE_REPO_ID
 
 
@@ -345,10 +345,10 @@ def test_get_pr_context_bitbucket_extracts_pr_id(
     monkeypatch.setenv("BITBUCKET_WORKSPACE", _BITBUCKET_WORKSPACE)
     monkeypatch.setenv("BITBUCKET_COMMIT", _BITBUCKET_COMMIT)
 
-    context = get_pr_context()
+    context = get_pull_request_context()
 
     assert context.platform == CIPlatform.BITBUCKET
-    assert context.pr_number == _BITBUCKET_PR_ID
+    assert context.pull_request_number == _BITBUCKET_PR_ID
     assert context.repository == _BITBUCKET_REPO_SLUG
     assert context.extras["workspace"] == _BITBUCKET_WORKSPACE
 
@@ -420,7 +420,7 @@ def test_build_comment_body_violation_does_not_contain_raw_entity_value() -> Non
 
 
 # ---------------------------------------------------------------------------
-# post_pr_comment — platform-specific tests (GitHub via gh CLI)
+# post_pull_request_comment — platform-specific tests (GitHub via gh CLI)
 # ---------------------------------------------------------------------------
 
 
@@ -429,9 +429,9 @@ def test_post_pr_comment_github_calls_gh_cli(
 ) -> None:
     """GitHub PR comment posting invokes the gh CLI."""
     monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken123")
-    github_context = PRContext(
+    github_context = PullRequestContext(
         platform=CIPlatform.GITHUB_ACTIONS,
-        pr_number=_GITHUB_PR_NUMBER,
+        pull_request_number=_GITHUB_PR_NUMBER,
         repository=_GITHUB_REPO,
         sha=_GITHUB_SHA,
         branch=None,
@@ -444,7 +444,7 @@ def test_post_pr_comment_github_calls_gh_cli(
         return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
 
     with patch("subprocess.run", side_effect=fake_run):
-        post_pr_comment(_make_clean_result(), github_context)
+        post_pull_request_comment(_make_clean_result(), github_context)
 
     assert any("gh" in call for call in captured_calls)
     assert any("pr" in call for call in captured_calls)
@@ -455,9 +455,9 @@ def test_post_pr_comment_github_skips_when_no_token(
 ) -> None:
     """GitHub comment posting is skipped when GITHUB_TOKEN is absent."""
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    github_context = PRContext(
+    github_context = PullRequestContext(
         platform=CIPlatform.GITHUB_ACTIONS,
-        pr_number=_GITHUB_PR_NUMBER,
+        pull_request_number=_GITHUB_PR_NUMBER,
         repository=_GITHUB_REPO,
         sha=_GITHUB_SHA,
         branch=None,
@@ -471,7 +471,7 @@ def test_post_pr_comment_github_skips_when_no_token(
         return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
 
     with patch("subprocess.run", side_effect=fake_run):
-        post_pr_comment(_make_clean_result(), github_context)
+        post_pull_request_comment(_make_clean_result(), github_context)
 
     assert call_count == 0
 
@@ -479,11 +479,11 @@ def test_post_pr_comment_github_skips_when_no_token(
 def test_post_pr_comment_skips_when_no_pr_number(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """PR comment posting is skipped when pr_number is None."""
+    """PR comment posting is skipped when pull_request_number is None."""
     monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken123")
-    no_pr_context = PRContext(
+    no_pr_context = PullRequestContext(
         platform=CIPlatform.GITHUB_ACTIONS,
-        pr_number=None,
+        pull_request_number=None,
         repository=_GITHUB_REPO,
         sha=_GITHUB_SHA,
         branch=None,
@@ -497,7 +497,7 @@ def test_post_pr_comment_skips_when_no_pr_number(
         return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
 
     with patch("subprocess.run", side_effect=fake_run):
-        post_pr_comment(_make_clean_result(), no_pr_context)
+        post_pull_request_comment(_make_clean_result(), no_pr_context)
 
     assert call_count == 0
 
@@ -507,9 +507,9 @@ def test_post_pr_comment_github_raises_ci_integration_error_on_gh_not_found(
 ) -> None:
     """CIIntegrationError raised when gh CLI is not installed."""
     monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken123")
-    github_context = PRContext(
+    github_context = PullRequestContext(
         platform=CIPlatform.GITHUB_ACTIONS,
-        pr_number=_GITHUB_PR_NUMBER,
+        pull_request_number=_GITHUB_PR_NUMBER,
         repository=_GITHUB_REPO,
         sha=_GITHUB_SHA,
         branch=None,
@@ -521,11 +521,11 @@ def test_post_pr_comment_github_raises_ci_integration_error_on_gh_not_found(
 
     with patch("subprocess.run", side_effect=raise_not_found):
         with pytest.raises(CIIntegrationError, match="gh CLI not found"):
-            post_pr_comment(_make_clean_result(), github_context)
+            post_pull_request_comment(_make_clean_result(), github_context)
 
 
 # ---------------------------------------------------------------------------
-# post_pr_comment — GitLab (HTTP)
+# post_pull_request_comment — GitLab (HTTP)
 # ---------------------------------------------------------------------------
 
 
@@ -534,9 +534,9 @@ def test_post_pr_comment_gitlab_posts_to_notes_api(
 ) -> None:
     """GitLab MR comment posting calls the GitLab Notes API endpoint."""
     monkeypatch.setenv("GITLAB_TOKEN", "glpat-testtoken")
-    gitlab_context = PRContext(
+    gitlab_context = PullRequestContext(
         platform=CIPlatform.GITLAB_CI,
-        pr_number=_GITLAB_MR_IID,
+        pull_request_number=_GITLAB_MR_IID,
         repository=_GITLAB_PROJECT_ID,
         sha=_GITLAB_SHA,
         branch=None,
@@ -552,7 +552,7 @@ def test_post_pr_comment_gitlab_posts_to_notes_api(
         return mock_response
 
     with patch("httpx.request", side_effect=stub_http_request):
-        post_pr_comment(_make_violation_result(), gitlab_context)
+        post_pull_request_comment(_make_violation_result(), gitlab_context)
 
     assert any(
         f"projects/{_GITLAB_PROJECT_ID}/merge_requests/{_GITLAB_MR_IID}/notes" in url
@@ -565,9 +565,9 @@ def test_post_pr_comment_gitlab_raises_on_http_error(
 ) -> None:
     """CIIntegrationError raised when GitLab API returns an HTTP error."""
     monkeypatch.setenv("GITLAB_TOKEN", "glpat-testtoken")
-    gitlab_context = PRContext(
+    gitlab_context = PullRequestContext(
         platform=CIPlatform.GITLAB_CI,
-        pr_number=_GITLAB_MR_IID,
+        pull_request_number=_GITLAB_MR_IID,
         repository=_GITLAB_PROJECT_ID,
         sha=_GITLAB_SHA,
         branch=None,
@@ -587,11 +587,11 @@ def test_post_pr_comment_gitlab_raises_on_http_error(
 
     with patch("httpx.request", side_effect=stub_http_request):
         with pytest.raises(CIIntegrationError, match="GitLab MR comment failed"):
-            post_pr_comment(_make_violation_result(), gitlab_context)
+            post_pull_request_comment(_make_violation_result(), gitlab_context)
 
 
 # ---------------------------------------------------------------------------
-# post_pr_comment — Bitbucket (HTTP)
+# post_pull_request_comment — Bitbucket (HTTP)
 # ---------------------------------------------------------------------------
 
 
@@ -600,9 +600,9 @@ def test_post_pr_comment_bitbucket_posts_to_pr_comments_api(
 ) -> None:
     """Bitbucket PR comment posting calls the Bitbucket Cloud PR comments endpoint."""
     monkeypatch.setenv("BITBUCKET_TOKEN", "bb_testtoken")
-    bb_context = PRContext(
+    bb_context = PullRequestContext(
         platform=CIPlatform.BITBUCKET,
-        pr_number=_BITBUCKET_PR_ID,
+        pull_request_number=_BITBUCKET_PR_ID,
         repository=_BITBUCKET_REPO_SLUG,
         sha=_BITBUCKET_COMMIT,
         branch=None,
@@ -621,7 +621,7 @@ def test_post_pr_comment_bitbucket_posts_to_pr_comments_api(
         return mock_response
 
     with patch("httpx.request", side_effect=stub_http_request):
-        post_pr_comment(_make_clean_result(), bb_context)
+        post_pull_request_comment(_make_clean_result(), bb_context)
 
     assert any(f"pullrequests/{_BITBUCKET_PR_ID}/comments" in url for url in captured_urls)
 
@@ -636,9 +636,9 @@ def test_set_commit_status_github_calls_statuses_api(
 ) -> None:
     """GitHub commit status posts to the /repos/.../statuses/{sha} endpoint."""
     monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken123")
-    github_context = PRContext(
+    github_context = PullRequestContext(
         platform=CIPlatform.GITHUB_ACTIONS,
-        pr_number=_GITHUB_PR_NUMBER,
+        pull_request_number=_GITHUB_PR_NUMBER,
         repository=_GITHUB_REPO,
         sha=_GITHUB_SHA,
         branch=None,
@@ -663,9 +663,9 @@ def test_set_commit_status_github_posts_failure_for_violations(
 ) -> None:
     """GitHub commit status state is 'failure' when violations are found."""
     monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken123")
-    github_context = PRContext(
+    github_context = PullRequestContext(
         platform=CIPlatform.GITHUB_ACTIONS,
-        pr_number=_GITHUB_PR_NUMBER,
+        pull_request_number=_GITHUB_PR_NUMBER,
         repository=_GITHUB_REPO,
         sha=_GITHUB_SHA,
         branch=None,
@@ -688,11 +688,11 @@ def test_set_commit_status_github_posts_failure_for_violations(
 def test_set_commit_status_skips_when_no_sha(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Commit status is skipped when pr_context.sha is None."""
+    """Commit status is skipped when pull_request_context.sha is None."""
     monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken123")
-    no_sha_context = PRContext(
+    no_sha_context = PullRequestContext(
         platform=CIPlatform.GITHUB_ACTIONS,
-        pr_number=_GITHUB_PR_NUMBER,
+        pull_request_number=_GITHUB_PR_NUMBER,
         repository=_GITHUB_REPO,
         sha=None,
         branch=None,
@@ -715,9 +715,9 @@ def test_set_commit_status_unknown_platform_does_nothing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Commit status for UNKNOWN platform logs a warning and returns without error."""
-    unknown_context = PRContext(
+    unknown_context = PullRequestContext(
         platform=CIPlatform.UNKNOWN,
-        pr_number="1",
+        pull_request_number="1",
         repository="org/repo",
         sha=_GITHUB_SHA,
         branch=None,

--- a/tests/test_ci_integration.py
+++ b/tests/test_ci_integration.py
@@ -349,8 +349,8 @@ def test_get_pr_context_bitbucket_extracts_pr_id(
 
     assert context.platform == CIPlatform.BITBUCKET
     assert context.pr_number == _BITBUCKET_PR_ID
+    assert context.repository == _BITBUCKET_REPO_SLUG
     assert context.extras["workspace"] == _BITBUCKET_WORKSPACE
-    assert context.extras["repo_slug"] == _BITBUCKET_REPO_SLUG
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ci_integration_remaining.py
+++ b/tests/test_ci_integration_remaining.py
@@ -25,7 +25,7 @@ from phi_scan.ci_integration import (
     BaselineComparison,
     CIIntegrationError,
     CIPlatform,
-    PRContext,
+    PullRequestContext,
     build_comment_body_with_baseline,
     convert_findings_to_asff,
     create_azure_boards_work_item,
@@ -134,23 +134,23 @@ def _make_violation_result(severity: SeverityLevel = SeverityLevel.HIGH) -> Scan
     )
 
 
-def _github_context(**overrides: object) -> PRContext:
+def _github_context(**overrides: object) -> PullRequestContext:
     defaults: dict = {
         "platform": CIPlatform.GITHUB_ACTIONS,
-        "pr_number": _GITHUB_PR_NUMBER,
+        "pull_request_number": _GITHUB_PR_NUMBER,
         "repository": _GITHUB_REPO,
         "sha": _GITHUB_SHA,
         "branch": "refs/pull/42/merge",
         "base_branch": None,
     }
     defaults.update(overrides)
-    return PRContext(**defaults)
+    return PullRequestContext(**defaults)
 
 
-def _azure_context(**overrides: object) -> PRContext:
+def _azure_context(**overrides: object) -> PullRequestContext:
     defaults: dict = {
         "platform": CIPlatform.AZURE_DEVOPS,
-        "pr_number": _AZURE_PR_ID,
+        "pull_request_number": _AZURE_PR_ID,
         "repository": _AZURE_REPO_ID,
         "sha": _AZURE_SHA,
         "branch": None,
@@ -162,13 +162,13 @@ def _azure_context(**overrides: object) -> PRContext:
         },
     }
     defaults.update(overrides)
-    return PRContext(**defaults)
+    return PullRequestContext(**defaults)
 
 
-def _bitbucket_context(**overrides: object) -> PRContext:
+def _bitbucket_context(**overrides: object) -> PullRequestContext:
     defaults: dict = {
         "platform": CIPlatform.BITBUCKET,
-        "pr_number": _BITBUCKET_PR_ID,
+        "pull_request_number": _BITBUCKET_PR_ID,
         "repository": _BITBUCKET_REPO_SLUG,
         "sha": _BITBUCKET_COMMIT,
         "branch": None,
@@ -179,7 +179,7 @@ def _bitbucket_context(**overrides: object) -> PRContext:
         },
     }
     defaults.update(overrides)
-    return PRContext(**defaults)
+    return PullRequestContext(**defaults)
 
 
 # ---------------------------------------------------------------------------
@@ -871,9 +871,9 @@ def test_import_findings_to_security_hub_skips_when_not_enabled(
         call_count += 1
         return subprocess.CompletedProcess([], returncode=0)
 
-    context = PRContext(
+    context = PullRequestContext(
         platform=CIPlatform.CODEBUILD,
-        pr_number="1",
+        pull_request_number="1",
         repository=_AWS_REPO,
         sha=_GITHUB_SHA,
         branch=None,
@@ -898,9 +898,9 @@ def test_import_findings_to_security_hub_calls_aws_cli_when_enabled(
         captured_cmds.append(cmd)
         return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
 
-    context = PRContext(
+    context = PullRequestContext(
         platform=CIPlatform.CODEBUILD,
-        pr_number="1",
+        pull_request_number="1",
         repository=_AWS_REPO,
         sha=_GITHUB_SHA,
         branch=None,
@@ -925,9 +925,9 @@ def test_import_findings_to_security_hub_skips_when_clean(
         call_count += 1
         return subprocess.CompletedProcess([], returncode=0)
 
-    context = PRContext(
+    context = PullRequestContext(
         platform=CIPlatform.CODEBUILD,
-        pr_number=None,
+        pull_request_number=None,
         repository=_AWS_REPO,
         sha=None,
         branch=None,
@@ -950,9 +950,9 @@ def test_import_findings_to_security_hub_raises_when_aws_cli_missing(
     def raise_not_found(*args: object, **kwargs: object) -> None:
         raise FileNotFoundError("aws not found")
 
-    context = PRContext(
+    context = PullRequestContext(
         platform=CIPlatform.CODEBUILD,
-        pr_number="1",
+        pull_request_number="1",
         repository=_AWS_REPO,
         sha=_GITHUB_SHA,
         branch=None,


### PR DESCRIPTION
## Summary
- Extract the 1,960-line `ci_integration.py` monolith into a new `phi_scan/ci/` package with per-platform adapter classes (`GitHubAdapter`, `GitLabAdapter`, `AzureAdapter`, `BitbucketAdapter`, `CircleCIAdapter`, `CodeBuildAdapter`, `JenkinsAdapter`)
- `BaseCIAdapter` ABC with capability flag properties (`supports_sarif_upload`, `supports_code_insights`, `supports_work_item_creation`, `supports_security_hub`)
- Shared HTTP transport in `_transport.py` centralizes error wrapping (status code + reason phrase only — never response body)
- `CIIntegrationError` moved to `phi_scan/exceptions.py` for consistency with other project exceptions
- `ci_integration.py` retains orchestration dispatch, comment formatting, platform-specific extras (SARIF, Code Insights, Azure extras, Security Hub), and backward-compatible re-exports — all existing import paths continue to work unchanged

## Test plan
- [ ] All 99 existing CI integration tests pass unchanged (backward compat verified)
- [ ] 71 new adapter tests cover: resolve_adapter registry, capability flags, upload_sarif domain error, import parity (old vs new path), transport error wrapping, platform detection, PRContext builders, meta-platform delegation (Jenkins→GitHub/GitLab, CircleCI→GitHub/Bitbucket, CodeBuild→GitHub/Bitbucket), frozen dataclass invariants
- [ ] `ruff check` and `ruff format` clean
- [ ] `mypy` passes on all 13 new/modified source files