### PR TITLE
Sync roadmap, scorecard, and plugin docs with shipped state

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,11 @@ repos:
 
 Copy-paste templates for all CI platforms: [docs/ci-cd-integration.md](docs/ci-cd-integration.md)
 
+> **GitHub Action:** The [`phi-scan-action`](https://github.com/joeyessak/phi-scan-action)
+> composite action provides one-liner GitHub CI/CD integration with SARIF upload,
+> PR comment, diff-only scanning, and AI review support. GitHub Marketplace
+> publication is pending org migration.
+
 ---
 
 ## Documentation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,9 @@
 # PhiScan Roadmap
 
-PhiScan is a HIPAA-compliant PHI/PII scanner for CI/CD pipelines. It runs entirely
-locally — no PHI is ever transmitted to an external service.
+PhiScan is a HIPAA-compliant PHI/PII scanner for CI/CD pipelines. All scanning
+runs locally by default — no PHI leaves your infrastructure. The optional AI
+confidence review layer sends only redacted code structure (never raw PHI values)
+to the configured AI provider when explicitly enabled.
 
 This roadmap tracks what has been built, what is in progress, and what is planned.
 All core scanning and CI/CD integration is and will remain free and open source.
@@ -114,7 +116,7 @@ Drop-in CI/CD templates for all major platforms and a production Docker image.
 
 ---
 
-## Phase 7 — AI Enhancement _(Optional)_ 🔄 In Progress `→ v0.7.0`
+## Phase 7 — AI Enhancement _(Optional)_ ✅ `v0.7.0`
 
 Reduce false positives using AI confidence scoring. Fully optional — the scanner
 operates at full capability without this phase.
@@ -127,26 +129,60 @@ operates at full capability without this phase.
 - ✅ AI token usage logged in audit trail (`prompt_tokens`, `completion_tokens`, `estimated_cost_usd`)
 - ✅ Disabled by default; opt-in via `ai.enable_ai_review: true` in `.phi-scanner.yml`
 
+> **Note:** GitHub Marketplace publication of
+> [`phi-scan-action`](https://github.com/joeyessak/phi-scan-action) is deferred
+> until the GitHub org migration is complete. The composite action is fully
+> functional; only the Marketplace listing is pending.
+
 ---
 
-## Phase 8 — Pro Tier & VS Code Extension 📋 Planned `→ v0.8.0`
+## Phase 8 — Plugin Ecosystem, Pro Tier & IDE Integration 🔄 In Progress `→ v0.8.0`
 
-Pro features, plugin ecosystem, and IDE integration.
+Plugin ecosystem, pro features, and IDE integration.
 
-- Plugin system: `BaseRecognizer` interface + entry-point registration
+**Shipped:**
+
+- ✅ Plugin API v1: `BaseRecognizer` abstract class, `ScanContext`/`ScanFinding`
+  dataclasses, `PLUGIN_API_VERSION = "1.0"` with exact-match enforcement
+- ✅ Plugin discovery via `phi_scan.plugins` entry-point group with fail-safe
+  validation and skip-on-error semantics
+- ✅ `phi-scan plugins list` command with Rich table and `--json` output
+- ✅ Plugin API compatibility and deprecation policy documented
+  ([docs/plugin-api-v1.md](docs/plugin-api-v1.md))
+- ✅ Suppressor and output-sink plugin hooks designed
+  ([docs/plugin-hooks-v1_1-design.md](docs/plugin-hooks-v1_1-design.md))
+- ✅ CI adapter split: `ci_integration.py` decomposed into `phi_scan/ci/` package
+  with per-platform adapters, shared `BaseCIAdapter` interface, and backward-
+  compatible re-exports ([docs/ci-adapter-contract.md](docs/ci-adapter-contract.md))
+
+**Remaining:**
+
 - Example plugins: `phi-scan-epic`, `phi-scan-cerner`, `phi-scan-hl7`
 - VS Code extension with inline highlighting and quick-fix suggestions
 - Pro license key system (compliance report watermarking, audit export, SLA support)
-- GitHub Marketplace listing
 
 ---
 
-## Phase 9 — Hardening & Public Launch 📋 Planned `→ v1.0.0`
+## Phase 9 — Hardening & Public Launch 🔄 In Progress `→ v1.0.0`
 
 Security audit, performance hardening, enterprise features, and public launch.
 
+**Shipped:**
+
+- ✅ Performance benchmark suite: synthetic small/medium/large corpora with
+  per-size runtime and throughput thresholds enforced in CI
+- ✅ Supply-chain hardening: `pip-audit` CI gate with policy-enforced ignore list,
+  CycloneDX SBOM generated at release time, keyless Sigstore signing of
+  wheel + sdist artifacts
+- ✅ Full-surface threat model documented ([docs/threat-model.md](docs/threat-model.md))
+  with every P0/P1 threat mapped to a named test
+- ✅ SSRF adversarial test suite: 50 tests covering IPv4-mapped IPv6, DNS rebind
+  TOCTOU, multicast, mixed-resolution, and reserved IP ranges
+
+**Remaining:**
+
 - Independent security audit
-- Performance benchmarks and optimisation (target: 10k files/sec)
+- Performance optimisation (target: 10k files/sec)
 - Enterprise SSO and audit log API
 - Signed plugin registry
 - Public launch: ProductHunt, Hacker News, security community outreach
@@ -158,5 +194,7 @@ Security audit, performance hardening, enterprise features, and public launch.
 PhiScan is open source under the MIT license. Contributions are welcome.
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines (available Phase 4+).
 
-**Core principle — non-negotiable:** All scanning executes locally. No PHI or PII
-is ever transmitted to an external API or third-party service.
+**Core principle — non-negotiable:** All scanning executes locally by default.
+No raw PHI or PII is ever transmitted externally. The optional AI confidence
+review layer sends only redacted code structure to the configured AI provider
+when explicitly enabled via `ai.enable_ai_review: true`.

--- a/docs/PROGRAM_SCORECARD.md
+++ b/docs/PROGRAM_SCORECARD.md
@@ -66,7 +66,7 @@ is declared production-ready for v1.0.
 | A5 | Plugin API compatibility and deprecation policy documented | PASS | `docs/plugin-api-v1.md` covers version contract, compatibility surface, deprecation process (2-minor-release window), failure semantics, authoring constraints. |
 | A6 | Suppressor and output-sink plugin hooks designed (v1.1 shape documented, not implemented) | PASS | `docs/plugin-hooks-v1_1-design.md` covers `BaseSuppressor`, `BaseOutputSink` draft interfaces, execution pipeline, PHI safety model, performance budget, config shape, and open questions. |
 | A7 | Parallel scan determinism validated across `workers=1` and `workers>1` | PASS | Parity tests in `tests/test_scanner.py` validate identical findings and ordering |
-| A8 | `ci_integration.py` adapter split planned with per-platform interface contract documented | PASS | `docs/ci-adapter-contract.md` covers target module layout, `BaseCIAdapter` interface, capability flags, shared transport/error model, test strategy, 3-phase rollout plan, and risk/rollback. |
+| A8 | `ci_integration.py` adapter split implemented with per-platform interface contract | PASS | Shipped in PR #130. `phi_scan/ci/` package with 7 per-platform adapters, shared `BaseCIAdapter` interface, capability flags, shared transport/error model. Design doc at `docs/ci-adapter-contract.md`. |
 
 **Passing: 8 / 8**
 

--- a/docs/ci-adapter-contract.md
+++ b/docs/ci-adapter-contract.md
@@ -1,6 +1,7 @@
 # CI Adapter Split — Interface Contract and Rollout Plan
 
-Status: **DRAFT** — design document for discussion. No implementation yet.
+Status: **IMPLEMENTED** — shipped in PR #130. The `phi_scan/ci/` package
+contains per-platform adapters matching this contract.
 
 This document describes the planned decomposition of
 `phi_scan/ci_integration.py` (1,960 lines, 7 CI platforms) into a

--- a/docs/plugin-developer-guide.md
+++ b/docs/plugin-developer-guide.md
@@ -15,7 +15,7 @@ and are discovered automatically at startup.
 A PhiScan plugin is a Python package that:
 
 1. Implements one or more `PhiRecognizer` subclasses
-2. Registers them via a `phi_scan.recognizers` entry point in `pyproject.toml`
+2. Registers them via a `phi_scan.plugins` entry point in `pyproject.toml`
 3. Returns `ScanFinding` instances from its `recognize()` method
 
 PhiScan discovers and loads all registered recognisers at scan startup.
@@ -169,7 +169,7 @@ name = "phi-scan-myplugin"
 version = "0.1.0"
 dependencies = ["phi-scan>=0.4.0"]
 
-[project.entry-points."phi_scan.recognizers"]
+[project.entry-points."phi_scan.plugins"]
 acme_employee_id = "phi_scan_myplugin.recognizer:MyCustomRecognizer"
 ```
 


### PR DESCRIPTION
## Summary

- Mark Phase 7 complete; note Marketplace publication deferred until org migration
- Split Phase 8 and Phase 9 into shipped vs remaining items (accurate status)
- Update ROADMAP wording to match README precision: local by default, optional AI review sends redacted structure only when explicitly enabled
- Update `ci-adapter-contract.md` from DRAFT to IMPLEMENTED (PR #130 shipped)
- Update scorecard A8 to reflect adapter split is implemented, not just planned
- Fix stale entry-point group in `plugin-developer-guide.md`: `phi_scan.recognizers` → `phi_scan.plugins`
- Add `phi-scan-action` reference and Marketplace deferral note to README

## Non-goals

- No code or behavior changes (docs-only PR)
- No Marketplace deployment
- No Pro/Cloud implementation

## Files changed

| File | Change |
|------|--------|
| `ROADMAP.md` | Phase 7 → complete, Phase 8/9 → shipped/remaining split, wording precision |
| `README.md` | Add `phi-scan-action` callout with Marketplace deferral note |
| `docs/PROGRAM_SCORECARD.md` | A8 wording: "planned" → "implemented" |
| `docs/ci-adapter-contract.md` | Status: DRAFT → IMPLEMENTED |
| `docs/plugin-developer-guide.md` | Fix `phi_scan.recognizers` → `phi_scan.plugins` (2 occurrences) |

## Test plan

- [x] Docs-only — no code changes, no tests affected
- [x] All internal links verified (relative paths to existing docs)
- [x] No stale `phi_scan.recognizers` references remain (grep confirmed)

## Security impact

None.

## Backward compatibility

N/A — docs only.

## Rollback plan

Revert single commit.