### PR TITLE
docs: align plugin guide, CI contract, and scorecard with shipped v1 state

### DIFF
--- a/docs/PROGRAM_SCORECARD.md
+++ b/docs/PROGRAM_SCORECARD.md
@@ -111,7 +111,7 @@ is declared production-ready for v1.0.
 | 2026-04-13 | 9/9 | 8/11 | 1/8 | 3/7 | S5/S7/S8 shipped: 50 adversarial SSRF tests (IPv4-mapped IPv6, unspecified, multicast, mixed-resolution, DNS rebind TOCTOU), full-surface threat model at `docs/threat-model.md`, notifier SSRF fix (unmap IPv4-mapped IPv6 + built-in-property checks). Security category now at 73%. |
 | 2026-04-14 | 9/9 | 11/11 | 1/8 | 3/7 | S9/S10/S11 shipped: pip-audit CI gate with policy-enforced `.pip-audit-ignore.toml`, release-time CycloneDX SBOM via `.github/scripts/sbom_generator.py`, keyless Sigstore signing of wheel+sdist. Baseline CVEs cleared via direct pin bumps (cryptography 46.0.7, pygments 2.20.0). Full supply-chain policy at `docs/supply-chain.md`. Security category at 100%; overall 69%. |
 | 2026-04-15 | 9/9 | 11/11 | 6/8 | 3/7 | A1–A5 shipped: Plugin API v1 core (`BaseRecognizer` ABC, `ScanContext`/`ScanFinding` dataclasses, `PLUGIN_API_VERSION`) in PR #124. `phi-scan plugins list` command with Rich table and `--json` output in PR #125. Plugin compatibility and deprecation policy at `docs/plugin-api-v1.md`. Architecture category at 75%; overall 83%. |
-| 2026-04-16 | 9/9 | 11/11 | 8/8 | 7/7 | A6/A8 shipped: `docs/plugin-hooks-v1_1-design.md` (suppressor + output sink v1.1 design) and `docs/ci-adapter-contract.md` (CI adapter split with `BaseCIAdapter` interface, 3-phase rollout). C3/C4 shipped: `docs/community-pro-cloud-matrix.md` (feature boundary matrix across 8 categories) and "Free forever" messaging in README. C5/C6 shipped: `docs/release-versioning-policy.md` (semver, cadence, breaking-change rules) and `docs/lts-eol-policy.md` (12-month LTS, 90-day EOL notice). **All 35/35 checks passing — scorecard complete.** |
+| 2026-04-16 | 9/9 | 11/11 | 8/8 | 7/7 | A6/A8 shipped: `docs/plugin-hooks-v1_1-design.md` (suppressor + output sink v1.1 design) and A8 CI adapter split implemented in PR #130 (`phi_scan/ci/` package with `BaseCIAdapter` interface and per-platform adapters); contract documented in `docs/ci-adapter-contract.md`. C3/C4 shipped: `docs/community-pro-cloud-matrix.md` (feature boundary matrix across 8 categories) and "Free forever" messaging in README. C5/C6 shipped: `docs/release-versioning-policy.md` (semver, cadence, breaking-change rules) and `docs/lts-eol-policy.md` (12-month LTS, 90-day EOL notice). **All 35/35 checks passing — scorecard complete.** |
 
 ---
 
@@ -127,6 +127,6 @@ Checks are addressed in this sequence:
 4. **S9, S10, S11** ✓ Done — Supply-chain security gates (pip-audit CI gate, CycloneDX SBOM, Sigstore signing)
 5. **A1–A5** ✓ Done — Plugin API v1 core (PR #124), `plugins list` command (PR #125), compatibility/deprecation policy doc
 6. **A6** ✓ Done — Suppressor + output-sink v1.1 design doc (`docs/plugin-hooks-v1_1-design.md`)
-7. **A8** ✓ Done — CI adapter split design doc (`docs/ci-adapter-contract.md`)
+7. **A8** ✓ Done — CI adapter split implemented in PR #130; contract documented in `docs/ci-adapter-contract.md`.
 8. **C3, C4** ✓ Done — Feature boundary matrix (`docs/community-pro-cloud-matrix.md`), "Free forever" README messaging
 9. **C5, C6** ✓ Done — Release cadence/versioning policy (`docs/release-versioning-policy.md`), LTS/EOL policy (`docs/lts-eol-policy.md`)

--- a/docs/ci-adapter-contract.md
+++ b/docs/ci-adapter-contract.md
@@ -1,49 +1,53 @@
 # CI Adapter Split — Interface Contract and Rollout Plan
 
 Status: **IMPLEMENTED** — shipped in PR #130. The `phi_scan/ci/` package
-contains per-platform adapters matching this contract.
-
-This document describes the planned decomposition of
-`phi_scan/ci_integration.py` (1,960 lines, 7 CI platforms) into a
-per-platform adapter package with a shared interface contract.
+contains per-platform adapters matching this contract. `ci_integration.py`
+remains as a thin re-export shim for backward compatibility and will be
+removed in a future release (see Phase 3 below).
 
 ---
 
-## Problem Statement
+## Background and Motivation
 
-`ci_integration.py` is the largest module in the codebase. It handles:
+`phi_scan/ci_integration.py` was a 1,960-line module covering seven CI
+platforms (GitHub, GitLab, Azure DevOps, CircleCI, Bitbucket, AWS
+CodeBuild, Jenkins). It handled:
 
 1. Platform auto-detection from environment variables.
-2. PR/MR context extraction (7 platform-specific builders).
-3. PR comment posting (7 platform-specific HTTP calls).
-4. Commit status reporting (7 platform-specific HTTP calls).
+2. PR/MR context extraction per platform.
+3. PR comment posting per platform.
+4. Commit status reporting per platform.
 5. Platform-specific extras: GitHub SARIF upload, Azure build tags,
    Azure PR status, Azure Boards work items, Bitbucket Code Insights,
    AWS Security Hub ASFF import.
 
-All 7 platforms share the same outbound interface (`post_pull_request_comment`,
-`set_commit_status`) but diverge significantly in transport, auth, and
-API shape. The single-module design causes:
+All seven platforms shared the same outbound interface
+(`post_pull_request_comment`, `set_commit_status`) but diverged
+significantly in transport, auth, and API shape. The single-module design
+caused:
 
-- **Merge conflicts**: any CI platform change touches the same file.
-- **Test isolation**: platform-specific test fixtures crowd a single
-  test module (currently `tests/test_ci_integration.py` +
-  `tests/test_ci_integration_remaining.py`).
-- **Cognitive load**: contributors modifying GitHub support must read
+- **Merge conflicts**: every CI-platform change touched the same file.
+- **Test isolation**: platform-specific fixtures crowded one test module.
+- **Cognitive load**: contributors modifying GitHub support had to read
   past Azure, Bitbucket, and CodeBuild code.
+
+PR #130 decomposed the module into a per-platform adapter package with
+the shared interface contract documented below.
 
 ---
 
-## Target Module Layout
+## Current Module Layout
 
 ```
 phi_scan/
   ci/
     __init__.py           # re-exports detect_platform, get_pull_request_context,
                           #   post_pull_request_comment, set_commit_status
-    _base.py              # BaseCIAdapter ABC, PullRequestContext, CIIntegrationError
+    _base.py              # BaseCIAdapter ABC, PullRequestContext, UnsupportedOperation
     _transport.py         # shared _HttpRequestConfig, _execute_http_request
     _detect.py            # detect_platform(), CIPlatform enum
+    _env.py               # fetch_environment_variable() — safe env-var accessor
+                          #   shared by detection and adapter auth lookups
     github.py             # GitHubAdapter
     gitlab.py             # GitLabAdapter
     azure.py              # AzureAdapter
@@ -51,26 +55,23 @@ phi_scan/
     bitbucket.py          # BitbucketAdapter
     codebuild.py          # CodeBuildAdapter
     jenkins.py            # JenkinsAdapter
+  exceptions.py           # CIIntegrationError — shared across the codebase
 
 tests/
-  ci/
-    __init__.py
-    test_github.py
-    test_gitlab.py
-    test_azure.py
-    test_circleci.py
-    test_bitbucket.py
-    test_codebuild.py
-    test_jenkins.py
-    test_detect.py
-    test_transport.py
+  test_ci_adapters.py     # consolidated adapter test suite
+  test_ci_integration.py  # legacy entry-point coverage via the shim
+  test_ci_integration_remaining.py  # migration-holdover coverage
 ```
 
-The top-level `phi_scan/ci/__init__.py` re-exports the public API so
-existing callers (`from phi_scan.ci_integration import post_pull_request_comment`)
-can migrate with a single import-path change. The old
-`ci_integration.py` module will be retained as a thin re-export shim
-during the deprecation window (see Phase 1 below).
+`phi_scan/ci/__init__.py` re-exports the public API so that callers can
+migrate with a single import-path change
+(`from phi_scan.ci import post_pull_request_comment`). The legacy
+`phi_scan/ci_integration.py` module is retained as a thin re-export shim
+during the deprecation window; it emits a `DeprecationWarning` on import.
+
+`CIIntegrationError` lives in `phi_scan/exceptions.py` (imported by
+`_base.py` and every adapter), not in `_base.py` itself — this matches the
+project's "custom exceptions in one module" convention.
 
 ---
 
@@ -79,6 +80,7 @@ during the deprecation window (see Phase 1 below).
 ```python
 from abc import ABC, abstractmethod
 from phi_scan.models import ScanResult
+
 
 class BaseCIAdapter(ABC):
     """Per-platform CI adapter.
@@ -90,7 +92,9 @@ class BaseCIAdapter(ABC):
 
     @abstractmethod
     def post_pull_request_comment(
-        self, comment_body: str, pull_request_context: PullRequestContext,
+        self,
+        comment_body: str,
+        pull_request_context: PullRequestContext,
     ) -> None:
         """Post a comment on the PR/MR associated with this build.
 
@@ -100,7 +104,9 @@ class BaseCIAdapter(ABC):
 
     @abstractmethod
     def set_commit_status(
-        self, scan_result: ScanResult, pull_request_context: PullRequestContext,
+        self,
+        scan_result: ScanResult,
+        pull_request_context: PullRequestContext,
     ) -> None:
         """Report pass/fail status on the commit that triggered the build.
 
@@ -128,7 +134,7 @@ class BaseCIAdapter(ABC):
 
 Platform-specific extras are exposed via boolean capability properties
 rather than optional methods. This avoids `hasattr` checks and makes
-the adapter's capabilities inspectable:
+each adapter's capabilities inspectable.
 
 | Capability | GitHub | GitLab | Azure | CircleCI | Bitbucket | CodeBuild | Jenkins |
 |-----------|--------|--------|-------|----------|-----------|-----------|---------|
@@ -139,27 +145,27 @@ the adapter's capabilities inspectable:
 | `can_create_work_item_from_findings` | No | No | Yes | No | No | No | No |
 | `can_import_findings_to_security_hub` | No | No | No | No | No | Yes | No |
 
-Platforms that support an extra MUST implement the corresponding method
-(e.g. `upload_sarif_report()` on `GitHubAdapter`). The base class provides a
-default that raises `CIIntegrationError` (the domain exception) for
-each extra — not `NotImplementedError`, which is a built-in and does
-not conform to the project's custom-exception-for-domain-errors rule.
+Platforms that support an extra implement the corresponding method on
+their adapter (e.g. `upload_sarif_report()` on `GitHubAdapter`). The base
+class provides a default that raises `CIIntegrationError` — the domain
+exception — rather than the built-in `NotImplementedError`, matching the
+project's custom-exception-for-domain-errors convention.
 
 ---
 
 ## Shared Transport
 
-The `_transport.py` module extracts the existing `_HttpRequestConfig`
-dataclass and `_execute_http_request` function. All adapters use this
-shared transport layer:
+`_transport.py` holds the `_HttpRequestConfig` dataclass and
+`_execute_http_request` function used by every adapter:
 
-- Consistent error wrapping: HTTP failures always raise
-  `CIIntegrationError` with status code and reason phrase only (never
-  response body — see security audit in current `ci_integration.py`).
-- Consistent timeout handling: configurable per-request timeout with a
-  sensible default.
-- Consistent proxy support: `HTTPS_PROXY` / `HTTP_PROXY` environment
-  variables respected.
+- **Consistent error wrapping.** HTTP failures raise `CIIntegrationError`
+  with status code and reason phrase only. Response bodies are never
+  included in the error message because they may echo back request
+  content containing finding metadata.
+- **Consistent timeout handling.** Every request has a configurable
+  timeout with a safe default.
+- **Consistent proxy support.** `HTTPS_PROXY` / `HTTP_PROXY` environment
+  variables are respected.
 
 ---
 
@@ -170,90 +176,92 @@ message MUST include:
 
 - The platform name.
 - The HTTP status code and reason phrase (for HTTP failures).
-- The operation that failed (e.g. "post PR comment", "set commit
-  status").
+- The operation that failed (e.g. "post PR comment", "set commit status").
 
 The error message MUST NOT include:
 
-- The HTTP response body (may echo back request content containing
-  finding metadata).
+- The HTTP response body (may echo back finding metadata).
 - Authentication tokens or credentials.
 - Raw PHI values.
 
-This matches the existing security contract in `ci_integration.py` and
-is enforced by sentinel tests.
+This matches the existing security contract and is enforced by sentinel
+tests in `tests/test_ci_adapters.py`.
 
 ---
 
 ## Test Strategy
 
-Each adapter module gets a dedicated test file. Tests follow the
-existing pattern:
+Adapter tests currently live in a consolidated suite at
+`tests/test_ci_adapters.py`. Each platform's test block follows the same
+pattern:
 
 1. **Monkeypatch environment variables** for the platform under test.
 2. **Mock `_execute_http_request`** to avoid real HTTP calls.
 3. **Assert outbound request shape**: URL, headers, body structure.
-4. **Assert error wrapping**: HTTP failures produce
-   `CIIntegrationError` with safe messages.
+4. **Assert error wrapping**: HTTP failures produce `CIIntegrationError`
+   with safe messages.
 5. **Sentinel tests**: error messages never contain response body text.
 
-Shared transport tests go in `test_transport.py`. Platform detection
-tests go in `test_detect.py`.
+Shared transport tests and platform-detection tests live in the same
+file alongside the per-platform blocks. Legacy coverage still runs
+through `tests/test_ci_integration.py` and
+`tests/test_ci_integration_remaining.py` via the re-export shim.
 
-### Coverage Target
+### Coverage
 
-Each adapter module MUST maintain >= 90% line coverage. The shared
-transport module MUST maintain 100% coverage (it is security-critical).
+Each adapter block maintains >= 90% line coverage over its platform's
+module. `_transport.py` is security-critical and retains 100% coverage.
 
 ---
 
 ## Rollout Plan
 
-### Phase 1 — Extract and Shim (non-breaking)
+### Phase 1 — Extract and Shim ✅ Done
 
-1. Create `phi_scan/ci/` package with `_base.py`, `_transport.py`,
-   `_detect.py`.
-2. Move platform detection logic to `_detect.py`.
-3. Move shared HTTP logic to `_transport.py`.
-4. Keep `ci_integration.py` as a thin re-export shim with explicit
-   named imports (no wildcard `import *`):
-   ```python
-   # phi_scan/ci_integration.py — deprecated, will be removed in v1.3
-   from phi_scan.ci import (  # noqa: F401
-       CIIntegrationError,
-       CIPlatform,
-       PullRequestContext,
-       detect_platform,
-       get_pull_request_context,
-       post_pull_request_comment,
-       set_commit_status,
-   )
-   ```
-5. Emit `DeprecationWarning` on import of the old module path.
+Shipped in PR #130. `phi_scan/ci/` package created with `_base.py`,
+`_transport.py`, `_detect.py`, and `_env.py`. Platform detection and
+shared HTTP logic moved out of the monolith. `ci_integration.py` retained
+as a thin re-export shim emitting `DeprecationWarning` on import.
 
-**Verification**: all existing tests pass without modification.
+### Phase 2 — Per-Platform Adapters ✅ Done
 
-### Phase 2 — Per-Platform Adapters
+Shipped in PR #130. Each platform's functions were extracted into its
+adapter class (`github.py`, `gitlab.py`, `azure.py`, `circleci.py`,
+`bitbucket.py`, `codebuild.py`, `jenkins.py`), each implementing
+`BaseCIAdapter`. `phi_scan/ci/__init__.py` dispatches
+`post_pull_request_comment` and `set_commit_status` via the adapter
+registry.
 
-1. Extract each platform's functions into its adapter class
-   (`github.py`, `gitlab.py`, etc.).
-2. Implement `BaseCIAdapter` interface on each adapter.
-3. Update `phi_scan/ci/__init__.py` to dispatch `post_pull_request_comment` and
-   `set_commit_status` via the adapter registry.
-4. Split test files into per-platform modules.
+### Phase 3 — Remove Shim ⏳ Deferred follow-up
 
-**Verification**: full test suite passes, no behavior changes, coverage
->= 90% per adapter.
+Not scheduled to a specific release. Before removal:
 
-### Phase 3 — Remove Shim
+1. Internal callers migrate from `phi_scan.ci_integration` to
+   `phi_scan.ci` (the deprecation warning flags any remaining imports).
+2. External callers observe the warning for the duration of one
+   minor-release cycle per `docs/plugin-api-v1.md` deprecation policy.
+3. `ci_integration.py` is removed in a future minor release; release
+   notes call out the removal.
 
-1. Remove `ci_integration.py` after the 2-minor-release deprecation
-   window (per `docs/plugin-api-v1.md` deprecation policy).
-2. Update all internal imports to `phi_scan.ci`.
-3. Document the migration in release notes.
+Verification at removal time: `ruff check` confirms no remaining imports
+of the old module path inside the repo.
 
-**Verification**: `ruff check` confirms no remaining imports of the
-old module path.
+---
+
+## Deferred Enhancements
+
+The following improvements are optional follow-ups. None block pristine
+signoff.
+
+- **Per-platform test file split.** The consolidated
+  `tests/test_ci_adapters.py` can be decomposed into `tests/ci/` with one
+  file per platform once the suite grows large enough to justify it. The
+  test patterns described above already map cleanly onto a per-file
+  layout.
+- **Adapter registry pluggability.** Exposing a public registration hook
+  would let third-party CI adapters ship as plugins. This lands under a
+  future plugin-hooks v1.1 revision (see
+  [docs/plugin-hooks-v1_1-design.md](plugin-hooks-v1_1-design.md)).
 
 ---
 
@@ -261,16 +269,15 @@ old module path.
 
 | Risk | Mitigation |
 |------|-----------|
-| Import path breakage for downstream consumers | Phase 1 shim preserves the old import path with a deprecation warning. 2-minor-release window before removal. |
-| Behavior regression in platform-specific logic | Each adapter is extracted as a mechanical refactor with no logic changes. Existing tests are moved (not rewritten) in Phase 2. |
-| Test coverage regression | Per-adapter 90% coverage gate prevents merging undertested adapters. |
-| Merge conflicts during phased rollout | Phase 1 (non-breaking) ships first. Phase 2 can be done one platform at a time as independent PRs. |
+| Import path breakage for downstream consumers | The shim preserves the old import path with a deprecation warning through the 2-minor-release deprecation window. |
+| Behavior regression in platform-specific logic | Each adapter was extracted as a mechanical refactor with no logic changes; existing tests were moved rather than rewritten. |
+| Test coverage regression | Per-platform >= 90% coverage gate; `_transport.py` at 100%. |
 
 ### Rollback
 
-If Phase 2 introduces regressions, revert the per-platform extraction
-PRs and fall back to Phase 1 (shim + monolith). The shim ensures
-callers are unaffected.
+If a regression is discovered that cannot be fixed forward, revert PR #130
+and fall back to the pre-split monolith. The shim means downstream callers
+are unaffected either way.
 
 ---
 
@@ -279,3 +286,4 @@ callers are unaffected.
 | Document version | Date | Change |
 |-----------------|------|--------|
 | Draft 1 | 2026-04-16 | Initial design for A8 scorecard check |
+| Draft 2 | 2026-04-17 | Rewrite to current-state wording: Phase 1/2 marked done, Phase 3 marked deferred, module layout and test strategy updated to reflect shipped reality, `_env.py` and `exceptions.py` corrections applied |

--- a/docs/plugin-developer-guide.md
+++ b/docs/plugin-developer-guide.md
@@ -2,11 +2,12 @@
 
 PhiScan's plugin system allows third parties to add custom PHI recognisers
 without modifying the core codebase. Plugins register via Python entry points
-and are discovered automatically at startup.
+and are discovered automatically at scan startup.
 
-> **Note:** The plugin API is currently in preview. The interface is stable
-> for the patterns described below, but additional capabilities (custom
-> output formatters, custom compliance frameworks) are planned for Phase 8.
+This guide targets **Plugin API v1** (`PLUGIN_API_VERSION = "1.0"`). The
+authoritative contract, compatibility policy, and deprecation process live in
+[docs/plugin-api-v1.md](plugin-api-v1.md); this document is the practical
+tutorial companion.
 
 ---
 
@@ -14,21 +15,28 @@ and are discovered automatically at startup.
 
 A PhiScan plugin is a Python package that:
 
-1. Implements one or more `PhiRecognizer` subclasses
-2. Registers them via a `phi_scan.plugins` entry point in `pyproject.toml`
-3. Returns `ScanFinding` instances from its `recognize()` method
+1. Implements one or more `BaseRecognizer` subclasses.
+2. Declares class-level metadata (`name`, `entity_types`, `plugin_api_version`).
+3. Implements `detect(line, context)` — called by the host once per line of
+   every file in scope, returning zero or more `ScanFinding` objects.
+4. Registers its recognizers via a `phi_scan.plugins` entry point in
+   `pyproject.toml`.
 
-PhiScan discovers and loads all registered recognisers at scan startup.
+The host is responsible for file traversal, line iteration, value hashing,
+severity derivation, and output redaction. Plugins never handle raw PHI
+end-to-end — they return line-relative offsets and a confidence score, and
+the host takes it from there.
 
 ---
 
 ## Quick Start
 
 ```bash
-# Create a minimal plugin package
-mkdir phi-scan-myplugin && cd phi-scan-myplugin
-touch src/phi_scan_myplugin/__init__.py
-touch src/phi_scan_myplugin/recognizer.py
+mkdir phi-scan-acme && cd phi-scan-acme
+mkdir -p src/phi_scan_acme tests
+touch src/phi_scan_acme/__init__.py
+touch src/phi_scan_acme/recognizer.py
+touch tests/test_recognizer.py
 touch pyproject.toml
 ```
 
@@ -37,126 +45,121 @@ touch pyproject.toml
 ## Implementing a Recognizer
 
 ```python
-# src/phi_scan_myplugin/recognizer.py
+# src/phi_scan_acme/recognizer.py
 from __future__ import annotations
 
-from pathlib import Path
+import re
 
-from phi_scan.plugin_api import PhiRecognizer
-from phi_scan.models import ScanFinding
-from phi_scan.constants import PhiCategory, DetectionLayer, SeverityLevel
-from phi_scan.hashing import compute_value_hash, severity_from_confidence
+from phi_scan.plugin_api import BaseRecognizer, ScanContext, ScanFinding
+
+_ACME_EMPLOYEE_ID_PATTERN = re.compile(r"\bEMP-\d{6}\b")
+_ACME_EMPLOYEE_ID_CONFIDENCE = 0.90
 
 
-class MyCustomRecognizer(PhiRecognizer):
-    """Detect ACME Corp employee IDs in source code."""
+class AcmeEmployeeIdRecognizer(BaseRecognizer):
+    """Detect ACME Corp employee IDs (``EMP-123456``) in source code."""
 
-    @property
-    def name(self) -> str:
-        """Unique name for this recognizer — used in logs and findings."""
-        return "ACME_EMPLOYEE_ID"
+    name = "acme_employee_id"
+    entity_types = ("ACME_EMPLOYEE_ID",)
+    plugin_api_version = "1.0"
+    version = "0.1.0"
+    description = "Detects ACME Corp employee identifiers."
 
-    @property
-    def supported_categories(self) -> frozenset[PhiCategory]:
-        """PHI categories this recognizer can produce."""
-        return frozenset({PhiCategory.UNIQUE_ID})
-
-    def recognize(
-        self,
-        file_content: str,
-        file_path: Path,
-    ) -> list[ScanFinding]:
-        """Scan file_content for ACME employee IDs.
-
-        IMPORTANT: Never store or return raw matched values.
-        Always hash with compute_value_hash() before including in ScanFinding.
-        """
-        import re
-
-        # Example: ACME IDs are EMP- followed by 6 digits
-        pattern = re.compile(r"\bEMP-\d{6}\b")
-        findings: list[ScanFinding] = []
-
-        for line_number, line in enumerate(file_content.splitlines(), start=1):
-            match = pattern.search(line)
-            if match is None:
-                continue
-
-            matched_value = match.group()
-            confidence = 0.90
-
-            findings.append(
-                ScanFinding(
-                    file_path=file_path,          # must be relative
-                    line_number=line_number,
-                    entity_type=self.name,
-                    hipaa_category=PhiCategory.UNIQUE_ID,
-                    confidence=confidence,
-                    detection_layer=DetectionLayer.REGEX,
-                    value_hash=compute_value_hash(matched_value),   # NEVER store raw
-                    severity=severity_from_confidence(confidence),
-                    code_context=line.replace(matched_value, "[REDACTED]"),
-                    remediation_hint=(
-                        "Replace ACME employee ID with a test-only placeholder "
-                        "(e.g., EMP-000000)."
-                    ),
-                )
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        match = _ACME_EMPLOYEE_ID_PATTERN.search(line)
+        if match is None:
+            return []
+        return [
+            ScanFinding(
+                entity_type="ACME_EMPLOYEE_ID",
+                start_offset=match.start(),
+                end_offset=match.end(),
+                confidence=_ACME_EMPLOYEE_ID_CONFIDENCE,
             )
-
-        return findings
+        ]
 ```
+
+### Multiple findings per line
+
+A single line may contain several matches. `detect` is allowed to return
+more than one `ScanFinding` per call:
+
+```python
+def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+    return [
+        ScanFinding(
+            entity_type="ACME_EMPLOYEE_ID",
+            start_offset=match.start(),
+            end_offset=match.end(),
+            confidence=_ACME_EMPLOYEE_ID_CONFIDENCE,
+        )
+        for match in _ACME_EMPLOYEE_ID_PATTERN.finditer(line)
+    ]
+```
+
+Offsets are **line-relative** (0-indexed, using `match.start()` and
+`match.end()` directly). Never translate them to file-absolute positions —
+the host re-resolves line/column using `context.line_number`.
 
 ---
 
-## PHI Safety Requirements
+## Class Attribute Contract
 
-These requirements are mandatory for all plugins. Violations will cause
-your plugin to be rejected from distribution.
+Recognizers declare metadata as **class attributes**, not `@property`
+methods. The loader validates this metadata at discovery time and skips
+any plugin whose metadata is malformed.
 
-### Never Store Raw PHI Values
+| Attribute | Required | Rule |
+|-----------|----------|------|
+| `name` | Yes | Lowercase snake_case, must match `^[a-z][a-z0-9_]*$`. Used as the collision key across installed distributions. |
+| `entity_types` | Yes | Non-empty sequence (`tuple` preferred) of uppercase strings matching `^[A-Z][A-Z0-9_]*$`. Must be unique within the sequence. Every returned `ScanFinding.entity_type` MUST appear here. |
+| `plugin_api_version` | Yes | Must equal the host's `PLUGIN_API_VERSION` exactly (currently `"1.0"`). Mismatches are rejected at load time with a warning. |
+| `version` | No | Plugin's own semver string. Informational. Defaults to `"0.0.0"`. |
+| `description` | No | One-line human description. Informational. Defaults to `""`. |
 
-The `ScanFinding.value_hash` field must contain the SHA-256 digest of the
-matched value — never the value itself.
+---
 
-```python
-# CORRECT
-value_hash = compute_value_hash(matched_value)
+## What the Host Guarantees
 
-# WRONG — never do this
-value_hash = matched_value
-```
+Plugin authors do **not** hash values, derive severity, or redact output.
+The host handles these concerns uniformly for all findings so that plugin
+bugs cannot leak PHI:
 
-### Redact PHI in code_context
+- **Value hashing.** The host takes `line[start_offset:end_offset]`, hashes
+  it with SHA-256, and stores only the digest in the audit log and output.
+- **Severity derivation.** The host maps `confidence` to a `SeverityLevel`
+  using the project-wide confidence bands. Plugins must not pre-inflate
+  confidence to force a higher severity.
+- **Output redaction.** The matched slice is replaced with `[REDACTED]` in
+  any `code_context` emitted to the terminal, JSON, SARIF, CSV, or report
+  artifacts.
+- **File traversal and line iteration.** The host resolves symlinks safely,
+  enforces size and extension policies, and decodes text. Plugins receive
+  a single decoded `line` per call.
 
-The `code_context` field holds the source line shown to the user. The
-matched PHI must be replaced with `[REDACTED]`.
+---
 
-```python
-# CORRECT
-code_context = line.replace(matched_value, "[REDACTED]")
+## Plugin Author Obligations
 
-# WRONG — exposes PHI in output
-code_context = line
-```
+These obligations are mandatory. A plugin that violates any of them will
+be rejected from distribution through official channels and may be blocked
+by the host at runtime in a future API revision.
 
-### Relative File Paths Only
-
-`ScanFinding.file_path` must be relative to the scan root. Never use an
-absolute path.
-
-```python
-# CORRECT (file_path passed in from PhiScan is already relative)
-file_path=file_path
-
-# WRONG
-file_path=Path("/absolute/path/to/file.py")
-```
-
-### No External Network Calls
-
-Recognisers must operate entirely locally. No API calls, no database
-lookups, no DNS resolution. PhiScan's security contract is "no data ever
-leaves your infrastructure."
+1. **Never log `line` content or matched slices.** Do not emit the line,
+   the `line[start:end]` slice, or any substring containing user data to
+   `print`, `logging`, structured logs, telemetry, or any other sink.
+2. **No network calls, DNS lookups, or database queries.** Recognizers
+   must operate entirely in-process. PhiScan's contract to its users is
+   that no data leaves the machine during scanning; plugins inherit that
+   contract.
+3. **No writing matched slices to disk.** Do not persist matched content
+   to temporary files, caches, or state directories.
+4. **Sanitize raised exceptions.** If `detect` raises, the host drops the
+   line's batch with a warning. Exception messages MUST NOT include the
+   `line`, the matched slice, or any substring of either.
+5. **Do not open or read `context.file_path`.** The host already provides
+   the line content. Opening the file directly bypasses the host's safe
+   traversal, size, and decoding policies and is prohibited.
 
 ---
 
@@ -165,17 +168,17 @@ leaves your infrastructure."
 ```toml
 # pyproject.toml
 [project]
-name = "phi-scan-myplugin"
+name = "phi-scan-acme"
 version = "0.1.0"
-dependencies = ["phi-scan>=0.4.0"]
+dependencies = ["phi-scan>=0.4.0,<1.0"]
 
 [project.entry-points."phi_scan.plugins"]
-acme_employee_id = "phi_scan_myplugin.recognizer:MyCustomRecognizer"
+acme_employee_id = "phi_scan_acme.recognizer:AcmeEmployeeIdRecognizer"
 ```
 
-The entry point name (`acme_employee_id`) must be unique across all installed
-plugins. Use a namespace prefix to avoid collisions:
-`yourcompany_<name>` or `phi_scan_<name>`.
+The entry point key (`acme_employee_id`) must be unique across every
+installed plugin. Prefix with your organisation or product name to avoid
+collisions: `acme_<name>`, `phi_scan_<name>`.
 
 ---
 
@@ -186,78 +189,102 @@ plugins. Use a namespace prefix to avoid collisions:
 ```python
 # tests/test_recognizer.py
 from pathlib import Path
-from phi_scan_myplugin.recognizer import MyCustomRecognizer
+
+from phi_scan.plugin_api import ScanContext
+from phi_scan_acme.recognizer import AcmeEmployeeIdRecognizer
+
+
+def _build_context() -> ScanContext:
+    return ScanContext(
+        file_path=Path("config.py"),
+        line_number=1,
+        file_extension=".py",
+    )
 
 
 def test_recognizer_detects_employee_id() -> None:
-    recognizer = MyCustomRecognizer()
-    content = 'employee_id = "EMP-123456"'
-    findings = recognizer.recognize(content, Path("config.py"))
+    recognizer = AcmeEmployeeIdRecognizer()
+    findings = recognizer.detect('employee_id = "EMP-123456"', _build_context())
 
     assert len(findings) == 1
-    assert findings[0].entity_type == "ACME_EMPLOYEE_ID"
-    assert findings[0].line_number == 1
-    assert "EMP-123456" not in findings[0].code_context   # must be redacted
-    assert "[REDACTED]" in findings[0].code_context
+    finding = findings[0]
+    assert finding.entity_type == "ACME_EMPLOYEE_ID"
+    assert finding.start_offset == 16
+    assert finding.end_offset == 26
+    assert 0.0 <= finding.confidence <= 1.0
 
 
-def test_recognizer_no_false_positive_on_clean_content() -> None:
-    recognizer = MyCustomRecognizer()
-    findings = recognizer.recognize("x = 123", Path("app.py"))
-    assert findings == []
+def test_recognizer_returns_empty_list_on_clean_line() -> None:
+    recognizer = AcmeEmployeeIdRecognizer()
+    assert recognizer.detect("x = 123", _build_context()) == []
 
 
-def test_recognizer_phi_not_in_value_hash() -> None:
-    """value_hash must be SHA-256, not the raw matched value."""
-    recognizer = MyCustomRecognizer()
-    findings = recognizer.recognize('emp = "EMP-123456"', Path("test.py"))
-    assert len(findings) == 1
-    assert findings[0].value_hash != "EMP-123456"
-    assert len(findings[0].value_hash) == 64   # SHA-256 hex digest
+def test_recognizer_finds_multiple_matches_per_line() -> None:
+    recognizer = AcmeEmployeeIdRecognizer()
+    findings = recognizer.detect("EMP-111111 EMP-222222", _build_context())
+    assert len(findings) == 2
 ```
 
-### Integration Test
+### Integration Test — Discovery
+
+Use the host's public loader API to confirm PhiScan sees your plugin.
+Both helpers return a `PluginRegistry`:
+
+- `discover_plugin_registry()` — exposes both loaded and skipped plugins,
+  useful for asserting why a plugin was rejected.
+- `load_plugin_registry()` — returns only successfully loaded plugins,
+  matching runtime behaviour.
 
 ```python
-def test_plugin_discovered_by_phi_scan() -> None:
-    """Verify the plugin is found by PhiScan's entry point discovery."""
-    from phi_scan.plugin_api import load_recognizer_plugins
-    recognizers = load_recognizer_plugins()
-    names = [r.name for r in recognizers]
-    assert "ACME_EMPLOYEE_ID" in names
+from phi_scan.plugin_loader import (
+    discover_plugin_registry,
+    load_plugin_registry,
+)
+
+
+def test_plugin_is_loaded_by_host() -> None:
+    registry = load_plugin_registry()
+    recognizer_names = [plugin.recognizer.name for plugin in registry.loaded]
+    assert "acme_employee_id" in recognizer_names
+
+
+def test_plugin_has_no_skip_reason() -> None:
+    registry = discover_plugin_registry()
+    skipped_names = [plugin.entry_point_name for plugin in registry.skipped]
+    assert "acme_employee_id" not in skipped_names
 ```
 
 ### Test Fixture Requirements
 
-Never use real PHI in test fixtures. For patterns that require structurally
-valid values (Luhn checksum, check digit), use the safe values from
-`phi_scan/constants.py` as a reference.
+Never use real PHI in test fixtures. When a pattern requires a structurally
+valid value (checksum, check digit), synthesize one — never copy from a
+real record, document, or dataset.
 
 ---
 
-## Confidence Score Guidelines
+## Confidence Guidance
 
-Use the following table as a reference when setting `base_confidence`:
+`confidence` is a float in `[0.0, 1.0]`. Use the following bands as a
+starting reference; tune based on false-positive and false-negative rates
+in your target corpora.
 
 | Signal Strength | Recommended Confidence |
-|---|---|
-| Checksum or algorithm validation | 0.92–0.97 |
-| Strong structural match + context keyword | 0.88–0.92 |
+|-----------------|------------------------|
+| Checksum or algorithm validation (e.g. Luhn, check digit) | 0.92–0.97 |
+| Strong structural match + supporting context keyword | 0.88–0.92 |
 | Strong structural match, no context | 0.80–0.88 |
-| Field-name detection (value not inspected) | 0.85–0.90 |
-| Weak pattern, NLP-style | 0.50–0.70 |
+| Field-name match only (value not inspected) | 0.85–0.90 |
+| Weak NLP-style signal | 0.50–0.70 |
 
-Confidence is used to derive `severity`:
-- `confidence ≥ 0.90` → `HIGH`
-- `confidence ≥ 0.70` → `MEDIUM`
-- `confidence ≥ 0.40` → `LOW`
-- `confidence < 0.40` → `INFO`
+The host derives `SeverityLevel` from `confidence` using the project-wide
+bands documented in [docs/confidence-scoring.md](confidence-scoring.md).
+Plugins should not encode severity decisions themselves.
 
 ---
 
 ## Distributing Your Plugin
 
-### PyPI Distribution
+### PyPI
 
 ```bash
 uv build
@@ -265,23 +292,35 @@ uv publish
 ```
 
 Users install with:
+
 ```bash
-pip install phi-scan-myplugin
-# PhiScan discovers the plugin automatically at startup
+pip install phi-scan-acme
+# PhiScan discovers the plugin automatically on the next scan.
 phi-scan scan .
 ```
 
 ### Naming Convention
 
-PyPI package name: `phi-scan-<name>` (e.g., `phi-scan-acme`, `phi-scan-dicom`)  
-Python import name: `phi_scan_<name>` (e.g., `phi_scan_acme`, `phi_scan_dicom`)
+- PyPI package: `phi-scan-<name>` (e.g. `phi-scan-acme`, `phi-scan-dicom`)
+- Python import name: `phi_scan_<name>`
+- Recognizer `name`: lowercase snake_case, organisation-prefixed
+  (`acme_employee_id`, `dicom_patient_id`)
 
-### Versioning
+### Version Compatibility
 
-Pin the minimum PhiScan version your plugin requires:
+Pin the minimum PhiScan version your plugin targets and cap the major
+version so that a future v2 API break does not silently install against
+an incompatible host:
+
 ```toml
 dependencies = ["phi-scan>=0.4.0,<1.0"]
 ```
+
+The host enforces exact-match on `plugin_api_version` at load time. If a
+future v1.1 minor bump introduces new optional surface, your plugin will
+continue to load unchanged under the existing `"1.0"` declaration —
+consult [docs/plugin-api-v1.md](plugin-api-v1.md) for the compatibility
+and deprecation policy before upgrading your declared API version.
 
 ---
 
@@ -289,71 +328,64 @@ dependencies = ["phi-scan>=0.4.0,<1.0"]
 
 ```bash
 phi-scan plugins list
+phi-scan plugins list --json   # machine-readable
 ```
 
-Shows all discovered plugins with their recognizer names and supported
-PHI categories.
+Shows every discovered plugin, whether it loaded or was skipped, and the
+reason for any skip.
 
 ---
 
 ## API Reference
 
-### `PhiRecognizer` (Abstract Base Class)
+### `BaseRecognizer` (Abstract Base Class)
 
 ```python
-from phi_scan.plugin_api import PhiRecognizer
+from collections.abc import Sequence
 
-class PhiRecognizer(ABC):
+from phi_scan.plugin_api import BaseRecognizer, ScanContext, ScanFinding
 
-    @property
-    @abstractmethod
-    def name(self) -> str:
-        """Unique recognizer name. Used in entity_type and logs."""
-        ...
 
-    @property
-    @abstractmethod
-    def supported_categories(self) -> frozenset[PhiCategory]:
-        """PHI categories this recognizer may produce."""
-        ...
+class BaseRecognizer(ABC):
+    name: str
+    entity_types: Sequence[str]
+    plugin_api_version: str = "1.0"
+    version: str = "0.0.0"
+    description: str = ""
 
     @abstractmethod
-    def recognize(
-        self,
-        file_content: str,
-        file_path: Path,
-    ) -> list[ScanFinding]:
-        """Scan file_content for PHI. Return empty list if no findings."""
-        ...
+    def detect(self, line: str, context: ScanContext) -> list[ScanFinding]:
+        """Return ScanFinding objects for the given line. May be empty."""
 ```
 
-### Utility Functions
+### `ScanContext`
 
 ```python
-from phi_scan.hashing import compute_value_hash, severity_from_confidence
-
-# Hash a matched value (ALWAYS use this — never store raw PHI)
-value_hash: str = compute_value_hash("EMP-123456")
-# Returns: SHA-256 hex digest string, 64 characters
-
-# Derive severity from a confidence score
-severity: SeverityLevel = severity_from_confidence(0.92)
-# Returns: SeverityLevel.HIGH
+@dataclass(frozen=True)
+class ScanContext:
+    file_path: Path         # provided for language-gating/logging; never open
+    line_number: int        # 1-indexed
+    file_extension: str     # includes leading dot, "" if none
 ```
 
-### Available Enums
+### `ScanFinding`
 
 ```python
-from phi_scan.constants import PhiCategory, DetectionLayer, SeverityLevel
+@dataclass(frozen=True)
+class ScanFinding:
+    entity_type: str        # must appear in recognizer.entity_types
+    start_offset: int       # line-relative, 0-indexed, >= 0
+    end_offset: int         # line-relative, exclusive, > start_offset
+    confidence: float       # [0.0, 1.0]
+```
 
-# PhiCategory — use the most specific applicable category
-PhiCategory.NAME
-PhiCategory.SSN
-PhiCategory.UNIQUE_ID     # catch-all for proprietary identifiers
-PhiCategory.BIOMETRIC
-# ... (see docs/hipaa-identifiers.md for full list)
+The dataclass validates its arguments in `__post_init__`, so malformed
+findings raise at construction time rather than silently corrupting output.
 
-# DetectionLayer — use REGEX for pattern-based, NLP for ML-based
-DetectionLayer.REGEX
-DetectionLayer.NLP
+### Version Constant
+
+```python
+from phi_scan.plugin_api import PLUGIN_API_VERSION
+
+assert PLUGIN_API_VERSION == "1.0"
 ```


### PR DESCRIPTION
## Summary

Final docs consistency pass closing three pristine-signoff blockers. Documentation only — no runtime changes.

- **`docs/plugin-developer-guide.md`** — full rewrite to Plugin API v1:
  - `BaseRecognizer` + `detect(line, context)` per-line model (replaces old `PhiRecognizer.recognize(file_content, file_path)`).
  - Class-attribute metadata (`name`, `entity_types`, `plugin_api_version`, `version`, `description`) replaces `@property` style.
  - Line-relative offsets (`match.start()` / `match.end()`) called out explicitly.
  - "What the host guarantees" (hashing, severity derivation, redaction, traversal) split from "Plugin author obligations" (no PHI logging, no network, no disk writes, sanitized exceptions, no opening `context.file_path`).
  - Confidence guidance table retained, severity-derivation column removed.
  - Integration test snippet uses real public loader names `discover_plugin_registry()` / `load_plugin_registry()`.
  - Internal helpers (`compute_value_hash`, `severity_from_confidence`) removed from plugin-author surface.
- **`docs/ci-adapter-contract.md`** — body rewrite from design/future tense to current-state:
  - Phase 1/2 marked done, Phase 3 marked deferred follow-up with no release target.
  - Module layout reflects shipped reality: `_env.py` included with one-line role, `CIIntegrationError` location corrected to `phi_scan/exceptions.py`.
  - Test strategy matches shipped `tests/test_ci_adapters.py` (consolidated), with per-platform split noted under "Deferred enhancements".
  - New version-history row for this correction.
- **`docs/PROGRAM_SCORECARD.md`** — execution-order A8 entry reworded to "implemented in PR #130; contract documented"; 2026-04-16 weekly-log narrative updated for consistency. Totals unchanged.

## Test plan

- [ ] CI green (markdown-only PR; lint/type/test jobs should pass unchanged)
- [ ] Reviewer reads `docs/plugin-developer-guide.md` against `phi_scan/plugin_api.py` and confirms every example compiles against the real v1 surface
- [ ] Reviewer confirms `docs/ci-adapter-contract.md` matches `phi_scan/ci/` package layout and `phi_scan/exceptions.py` location
- [ ] Reviewer confirms scorecard A8 wording is consistent across row, execution-order section, and weekly log