### PR TITLE
docs: add org migration prep checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,12 @@ Copy-paste templates for all CI platforms: [docs/ci-cd-integration.md](docs/ci-c
 > **GitHub Action:** The [`phi-scan-action`](https://github.com/joeyessak/phi-scan-action)
 > composite action provides one-liner GitHub CI/CD integration with SARIF upload,
 > PR comment, diff-only scanning, and AI review support. GitHub Marketplace
-> publication is pending org migration.
+> publication is deferred pending org migration completion + post-pristine signoff.
+>
+> Note: Organization migration to `phiscanhq` is planned after pristine signoff.
+> No action is required from users during planning; GitHub redirects will be used
+> during transfer. See [docs/org-migration-checklist.md](docs/org-migration-checklist.md)
+> for the operational runbook.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -185,6 +185,11 @@ Security audit, performance hardening, enterprise features, and public launch.
 - Performance optimisation (target: 10k files/sec)
 - Enterprise SSO and audit log API
 - Signed plugin registry
+- Organisation migration from `joeyessak/*` to `phiscanhq/*` — planned,
+  not started. Blocked on pristine signoff; runbook in
+  [docs/org-migration-checklist.md](docs/org-migration-checklist.md).
+  GitHub Marketplace publication of `phi-scan-action` is deferred until
+  post-migration.
 - Public launch: ProductHunt, Hacker News, security community outreach
 
 ---

--- a/docs/org-migration-checklist.md
+++ b/docs/org-migration-checklist.md
@@ -1,0 +1,298 @@
+# Org Migration Checklist — `joeyessak/*` → `phiscanhq/*`
+
+Status: **PLANNED — NOT STARTED.** No transfer actions are authorised
+until every repo-pristine blocker is merged and the maintainer gives an
+explicit "migration go" approval. This document is the operational
+runbook for that future transfer.
+
+## Scope
+
+- `joeyessak/phi-scan` → `phiscanhq/phi-scan`
+- `joeyessak/phi-scan-action` → `phiscanhq/phi-scan-action`
+
+Out of scope for this phase: `phi-scan-pro` (does not yet exist and is
+explicitly excluded from this runbook).
+
+## Transfer order
+
+1. `phi-scan` first. Validate end-to-end (CI, release dry-run, PyPI token
+   continuity, Sigstore signing, ghcr push) before moving to step 2.
+2. `phi-scan-action` second. Its canonical reference paths depend on the
+   post-migration state of `phi-scan`, so it moves after validation.
+
+---
+
+## 1. Pre-flight
+
+Complete every item before initiating any transfer.
+
+### 1.1 Repo cleanliness
+
+- [ ] No open draft release or in-flight publish job on `joeyessak/phi-scan`.
+- [ ] No open pull requests mid-merge; no in-progress CI runs.
+- [ ] `main` is green on the most recent commit.
+- [ ] Release branch (if any) is either merged or explicitly parked.
+
+### 1.2 Hardcoded organisation references
+
+Grep for hardcoded `joeyessak/` references that must be updated
+post-transfer. Items here need a plan (update now, update post-transfer,
+or rely on GitHub redirect) before proceeding.
+
+- [ ] `.github/workflows/**/*.yml` — action refs, OIDC subjects, artifact
+      URLs, `gh` CLI calls.
+- [ ] `.github/scripts/**` — any scripted `joeyessak/` URLs.
+- [ ] `docs/**/*.md` — install instructions, CI snippets, badge URLs.
+- [ ] `README.md` — install instructions, badge URLs, action references.
+- [ ] `pyproject.toml` — project URLs (`Homepage`, `Source`, `Issues`).
+- [ ] `.pre-commit-hooks.yaml` and any consumer-facing
+      `.pre-commit-config.yaml` example.
+- [ ] Docker image references in docs and workflows
+      (`ghcr.io/joeyessak/phi-scan`).
+
+Command reference (run locally, not blocking):
+
+```bash
+grep -rn "joeyessak" --include="*.md" --include="*.yml" --include="*.yaml" --include="*.toml" --include="*.py" .
+```
+
+### 1.3 Current-state snapshot
+
+Capture the current configuration so it can be recreated exactly on the
+new org.
+
+- [ ] **Branch protection / rulesets** (current `joeyessak/phi-scan`):
+    - Ruleset name: `Protect main`.
+    - Rules enforced: `deletion` (blocked), `non_fast_forward` (blocked),
+      `pull_request` (required; 0 approving reviews; merge/squash/rebase
+      all allowed), `required_status_checks`
+      (`Python 3.12 on ubuntu-latest`).
+    - Capture UI screenshot and attach to migration ticket (do not paste
+      raw JSON into this document).
+- [ ] **Actions secrets** (current repo-level):
+    - `ANTHROPIC_API_KEY` — AI review workflow.
+    - `PYPI_API_TOKEN` — release publish workflow.
+    - Document any additional org-level or environment-level secrets
+      added after this snapshot.
+- [ ] **Actions variables** — capture any non-secret variables in use.
+- [ ] **Environments** — list names and protection rules, if any.
+- [ ] **Webhooks** — enumerate destinations and events.
+- [ ] **Collaborators and teams** — record current direct collaborators.
+- [ ] **Pages / deployment configuration** — if in use.
+- [ ] `CODEOWNERS` — confirm file accurately reflects reviewers; update
+      any `@joeyessak` references if a team is preferred on the new org.
+
+### 1.4 External dependency inventory
+
+- [ ] PyPI project `phi-scan` — owner currently `joeyessak`; confirm
+      maintainer email and 2FA status.
+- [ ] ghcr.io — current image path `ghcr.io/joeyessak/phi-scan`.
+- [ ] Sigstore signing — currently keyless OIDC with workload subject
+      `repo:joeyessak/phi-scan:…`.
+- [ ] `phi-scan-action` — consumers reference via `joeyessak/phi-scan-action@v1`.
+- [ ] Downstream pre-commit users — reference `joeyessak/phi-scan`; redirect
+      is expected to work.
+
+### 1.5 Communication
+
+- [ ] Draft (do not publish yet) a migration notice covering: new canonical
+      paths, redirect continuity, action required by consumers (none
+      expected), rollback window.
+- [ ] Prepare release-notes entry for the next patch release announcing
+      the move.
+
+### 1.6 Go / no-go
+
+- [ ] All pristine blockers merged.
+- [ ] Maintainer has given explicit "migration go" approval in writing.
+- [ ] Migration ticket tracks the checklist execution.
+
+---
+
+## 2. Transfer — `phi-scan`
+
+### 2.1 Execute transfer
+
+- [ ] Initiate GitHub repo transfer from `joeyessak/phi-scan` to
+      `phiscanhq/phi-scan`.
+- [ ] Accept transfer on the `phiscanhq` side.
+
+### 2.2 Re-apply repo configuration
+
+- [ ] Recreate the `Protect main` ruleset on the new repo with the same
+      enforced rules (deletion blocked, non-fast-forward blocked, PR
+      required with 0 approvals, required check `Python 3.12 on
+      ubuntu-latest`). Verify the ruleset is `enforcement: active`.
+- [ ] Recreate Actions secrets on `phiscanhq/phi-scan`:
+    - [ ] `ANTHROPIC_API_KEY` — same value (rotate later if routine).
+    - [ ] `PYPI_API_TOKEN` — see §2.3 for rotation policy.
+- [ ] Recreate any Actions variables from the pre-flight snapshot.
+- [ ] Recreate environments and their protection rules.
+- [ ] Recreate webhooks.
+- [ ] Reconfirm `CODEOWNERS` resolves on the new org (teams, if used,
+      must exist on `phiscanhq`).
+
+### 2.3 PyPI token rotation
+
+Current publish model uses a repo Actions secret `PYPI_API_TOKEN`, read
+by the release workflow as `UV_PUBLISH_TOKEN`. Transfer does NOT invalidate
+the token, but the old token is scoped under the old organisational
+identity and must be rotated.
+
+- [ ] Generate a new PyPI API token scoped to the `phi-scan` project.
+- [ ] Store the new token as `PYPI_API_TOKEN` on `phiscanhq/phi-scan`.
+- [ ] Run a release dry-run (or a patch release to TestPyPI if configured)
+      to confirm the new token works.
+- [ ] Revoke the old token on PyPI once the new token is validated in a
+      real publish.
+
+### 2.4 Sigstore / OIDC workload identity
+
+Release artifacts are signed keyless with Sigstore. The OIDC subject
+encodes the repo path and will change at transfer time from
+`repo:joeyessak/phi-scan:…` to `repo:phiscanhq/phi-scan:…`.
+
+- [ ] Run the release workflow against a tagged pre-release (or a
+      dry-run signing job) on the new repo.
+- [ ] Download the produced `.sigstore.json` bundle.
+- [ ] Verify the bundle: confirm the embedded certificate's OIDC subject
+      is `repo:phiscanhq/phi-scan:…` and that `cosign verify-blob` (or
+      `sigstore-python verify`) accepts the new subject.
+- [ ] Update `docs/supply-chain.md` verification example to reference the
+      new subject.
+
+### 2.5 GHCR container continuity
+
+- [ ] Build and push the image to `ghcr.io/phiscanhq/phi-scan` tagged
+      with the current release version and `latest`.
+- [ ] Keep `ghcr.io/joeyessak/phi-scan` in place for the observation
+      window so existing pull commands succeed via redirect.
+- [ ] Update docs and workflows that reference the image path to the
+      new canonical path. Retain a one-line note pointing users to the
+      new path.
+
+### 2.6 Hardcoded reference sweep (round 2)
+
+- [ ] Re-run the `joeyessak/` grep from §1.2 on the new repo.
+- [ ] Open a small follow-up PR updating docs, badges, and workflow
+      references to `phiscanhq/`. Rely on GitHub redirect for external
+      consumers but clean up canonical documentation.
+
+### 2.7 End-to-end validation
+
+- [ ] CI passes on a no-op PR against the new `main`.
+- [ ] Release workflow dry-run (or patch release) succeeds end-to-end:
+      PyPI publish, SBOM generation, Sigstore signing, ghcr push.
+- [ ] `pip install phi-scan==<version>` from PyPI works and matches the
+      new SBOM.
+- [ ] Sigstore bundle verification passes against the new OIDC subject.
+- [ ] Third-party `.pre-commit-config.yaml` pinning `joeyessak/phi-scan`
+      still resolves via redirect (manual smoke test).
+
+---
+
+## 3. Transfer — `phi-scan-action`
+
+Execute only after §2.7 passes cleanly.
+
+- [ ] Initiate and accept transfer `joeyessak/phi-scan-action` →
+      `phiscanhq/phi-scan-action`.
+- [ ] Recreate secrets, rulesets, and environments as in §2.2.
+- [ ] Update canonical usage examples in docs and README to
+      `phiscanhq/phi-scan-action@v1`.
+- [ ] Publish a deprecation note on the old path (release notes +
+      README banner) pointing consumers to the new canonical path.
+      Redirect is expected to work; the note exists for trust and clarity.
+- [ ] Smoke-test the action from a consumer workflow pinned to the new
+      canonical path.
+
+---
+
+## 4. Post-flight
+
+### 4.1 Announce
+
+- [ ] Publish the migration notice drafted in §1.5 (release notes +
+      repo README banner if desired).
+- [ ] Update `docs/supply-chain.md` and any other operational docs to
+      reference the new OIDC subject and image path.
+
+### 4.2 Observation window — 48 hours
+
+During the first 48 hours after `phi-scan` transfer:
+
+- [ ] Freeze new releases unless required for an emergency fix. If an
+      emergency release is cut, re-verify Sigstore subject and PyPI
+      publish as a sentinel.
+- [ ] Monitor issues for redirect failures, pre-commit resolution errors,
+      or signing verification failures.
+- [ ] Monitor CI on `main` daily.
+- [ ] Track ghcr pull counts on both old and new image paths to detect
+      stale references.
+
+### 4.3 Cleanup (after 48h clean)
+
+- [ ] Revoke old PyPI token (if not already done in §2.3).
+- [ ] Close the migration ticket with a summary and post-mortem note.
+- [ ] Schedule removal of the legacy ghcr image path for a later minor
+      release, with notice.
+
+---
+
+## 5. Rollback
+
+If a critical break is detected within the 48-hour observation window
+(CI broken on `main` with no forward-fix in sight, PyPI publish blocked,
+Sigstore verification broken for released artifacts, or widespread
+redirect failure), execute rollback:
+
+### 5.1 Immediate freeze
+
+- [ ] Freeze all releases on the new org.
+- [ ] Post a brief incident notice on the repo indicating rollback is in
+      progress.
+
+### 5.2 Transfer back
+
+- [ ] Transfer `phiscanhq/phi-scan` back to `joeyessak/phi-scan` via the
+      GitHub transfer flow.
+- [ ] If already transferred, transfer `phi-scan-action` back as well.
+- [ ] Recreate rulesets, secrets, environments on the restored repo from
+      the pre-flight snapshot (§1.3).
+
+### 5.3 Artifact continuity during rollback
+
+- [ ] Re-validate PyPI token on the restored repo; rotate if the new
+      token was already published.
+- [ ] Re-validate Sigstore subject reverts to
+      `repo:joeyessak/phi-scan:…` for subsequent signing runs.
+- [ ] Revert ghcr image path in docs/workflows; keep any `phiscanhq/`
+      images in place for historical access.
+
+### 5.4 Post-rollback
+
+- [ ] Open a post-mortem documenting root cause, blast radius, and
+      remediation required before a second attempt.
+- [ ] Update this checklist with any gaps identified.
+- [ ] Maintainer explicitly re-approves any subsequent migration attempt.
+
+---
+
+## Appendix A — Reference snapshot
+
+This appendix captures state as of the pre-flight date so that future
+readers can verify the runbook against what existed at the time it was
+written. Refresh this section immediately before execution.
+
+| Item | Value (as of writing) |
+|------|----------------------|
+| Source org/repo | `joeyessak/phi-scan` |
+| Target org/repo | `phiscanhq/phi-scan` |
+| Secondary repo | `joeyessak/phi-scan-action` → `phiscanhq/phi-scan-action` |
+| Ruleset name | `Protect main` |
+| Required status check | `Python 3.12 on ubuntu-latest` |
+| Actions secrets | `ANTHROPIC_API_KEY`, `PYPI_API_TOKEN` |
+| PyPI project | `phi-scan` |
+| Container image | `ghcr.io/joeyessak/phi-scan` → `ghcr.io/phiscanhq/phi-scan` |
+| Sigstore OIDC subject | `repo:joeyessak/phi-scan:…` → `repo:phiscanhq/phi-scan:…` |
+| Observation window | 48 hours post-transfer |


### PR DESCRIPTION
## Summary

Documentation-only PR. **No migration actions are taken or authorised.**
This PR drafts the operational runbook for the future `joeyessak/*` →
`phiscanhq/*` migration and marks the migration as planned but not started.

- `docs/org-migration-checklist.md` — grouped into Pre-flight / Transfer (`phi-scan` first, then `phi-scan-action`) / Post-flight / Rollback. Covers:
  - Hardcoded org-reference grep across workflows, docs, scripts, pyproject.
  - Current-state snapshot of the `Protect main` ruleset and Actions secrets (`ANTHROPIC_API_KEY`, `PYPI_API_TOKEN`) textually, with screenshot capture step rather than raw JSON.
  - PyPI token rotation: new scoped token post-transfer, validate, then revoke old.
  - Sigstore OIDC subject verification post-transfer (`repo:joeyessak/phi-scan:…` → `repo:phiscanhq/phi-scan:…`).
  - GHCR continuity: retag to `ghcr.io/phiscanhq/phi-scan`, keep old path during observation window.
  - Pre-commit / consumer references: rely on GitHub redirect, publish migration note for trust.
  - 48h observation window with defined full-rollback path (transfer back, freeze releases, post-mortem required before retry).
- `README.md` — short planned-migration note using approved wording; marketplace deferral reworded to "deferred pending org migration completion + post-pristine signoff."
- `ROADMAP.md` — migration folded into existing Phase 9 as a "Remaining" bullet; no new phase added.

## Guardrail

Migration execution is explicitly blocked until:

- [ ] All pristine-signoff PRs merged (PR #134 and this PR).
- [ ] Maintainer gives explicit written "migration go" approval.

## Test plan

- [ ] CI green (docs-only; standard jobs should pass unchanged).
- [ ] Reviewer walks the checklist against the current repo state and confirms each pre-flight capture item matches reality.
- [ ] Reviewer confirms README wording matches approved phrasing and no hardcoded URL flip has been performed.