### PR TITLE
[A9] Integrate plugin runtime execution into scan path

### DIFF
--- a/docs/PROGRAM_SCORECARD.md
+++ b/docs/PROGRAM_SCORECARD.md
@@ -67,8 +67,9 @@ is declared production-ready for v1.0.
 | A6 | Suppressor and output-sink plugin hooks designed (v1.1 shape documented, not implemented) | PASS | `docs/plugin-hooks-v1_1-design.md` covers `BaseSuppressor`, `BaseOutputSink` draft interfaces, execution pipeline, PHI safety model, performance budget, config shape, and open questions. |
 | A7 | Parallel scan determinism validated across `workers=1` and `workers>1` | PASS | Parity tests in `tests/test_scanner.py` validate identical findings and ordering |
 | A8 | `ci_integration.py` adapter split implemented with per-platform interface contract | PASS | Shipped in PR #130. `phi_scan/ci/` package with 7 per-platform adapters, shared `BaseCIAdapter` interface, capability flags, shared transport/error model. Design doc at `docs/ci-adapter-contract.md`. |
+| A9 | Plugin runtime execution integrated into scan path with deterministic ordering and error isolation | PASS | Plugin findings flow through existing filter/output/audit path; per-line plugin errors isolated; plugin registry loaded once per scan. |
 
-**Passing: 8 / 8**
+**Passing: 9 / 9**
 
 ---
 
@@ -94,11 +95,11 @@ is declared production-ready for v1.0.
 |----------|---------|-------|---|
 | Technical Maturity | 9 | 9 | 100% |
 | Security Posture | 11 | 11 | 100% |
-| Architecture Scalability | 8 | 8 | 100% |
+| Architecture Scalability | 9 | 9 | 100% |
 | Commercial Readiness | 7 | 7 | 100% |
-| **Total** | **35** | **35** | **100%** |
+| **Total** | **36** | **36** | **100%** |
 
-**Target:** 35 / 35 checks passing.
+**Target:** 36 / 36 checks passing.
 
 ---
 
@@ -111,6 +112,7 @@ is declared production-ready for v1.0.
 | 2026-04-13 | 9/9 | 8/11 | 1/8 | 3/7 | S5/S7/S8 shipped: 50 adversarial SSRF tests (IPv4-mapped IPv6, unspecified, multicast, mixed-resolution, DNS rebind TOCTOU), full-surface threat model at `docs/threat-model.md`, notifier SSRF fix (unmap IPv4-mapped IPv6 + built-in-property checks). Security category now at 73%. |
 | 2026-04-14 | 9/9 | 11/11 | 1/8 | 3/7 | S9/S10/S11 shipped: pip-audit CI gate with policy-enforced `.pip-audit-ignore.toml`, release-time CycloneDX SBOM via `.github/scripts/sbom_generator.py`, keyless Sigstore signing of wheel+sdist. Baseline CVEs cleared via direct pin bumps (cryptography 46.0.7, pygments 2.20.0). Full supply-chain policy at `docs/supply-chain.md`. Security category at 100%; overall 69%. |
 | 2026-04-15 | 9/9 | 11/11 | 6/8 | 3/7 | A1–A5 shipped: Plugin API v1 core (`BaseRecognizer` ABC, `ScanContext`/`ScanFinding` dataclasses, `PLUGIN_API_VERSION`) in PR #124. `phi-scan plugins list` command with Rich table and `--json` output in PR #125. Plugin compatibility and deprecation policy at `docs/plugin-api-v1.md`. Architecture category at 75%; overall 83%. |
+| 2026-04-12 | 9/9 | 11/11 | 9/9 | 7/7 | A9 shipped: plugin runtime execution integrated into scan path (`phi_scan/plugin_runtime.py`). Per-line plugin pass runs after built-in detection; findings flow through existing filter/suppression/baseline/output pipeline. Per-line exception isolation, rate-limited warnings (5 per recognizer + summary), deterministic ordering, worker-parity validated. Registry cached once per `execute_scan` invocation. Architecture 9/9; overall 36/36. |
 | 2026-04-16 | 9/9 | 11/11 | 8/8 | 7/7 | A6/A8 shipped: `docs/plugin-hooks-v1_1-design.md` (suppressor + output sink v1.1 design) and A8 CI adapter split implemented in PR #130 (`phi_scan/ci/` package with `BaseCIAdapter` interface and per-platform adapters); contract documented in `docs/ci-adapter-contract.md`. C3/C4 shipped: `docs/community-pro-cloud-matrix.md` (feature boundary matrix across 8 categories) and "Free forever" messaging in README. C5/C6 shipped: `docs/release-versioning-policy.md` (semver, cadence, breaking-change rules) and `docs/lts-eol-policy.md` (12-month LTS, 90-day EOL notice). **All 35/35 checks passing — scorecard complete.** |
 
 ---

--- a/docs/plugin-api-v1.md
+++ b/docs/plugin-api-v1.md
@@ -150,6 +150,39 @@ have read values from the environment that could incidentally contain
 PHI. `BaseException` subclasses (`SystemExit`, `KeyboardInterrupt`)
 are NOT caught.
 
+### Plugin Detection Exception Isolation (Runtime Carve-out)
+
+Exceptions raised from `detect()` during a scan are caught at the
+per-line plugin invocation boundary so that one faulty plugin cannot
+abort the scan or starve other plugins of their chance to run. This is
+the single designated exemption to the project-wide rule that bare
+`Exception` MUST NOT be caught without re-raising.
+
+The carve-out applies **only** under all of the following conditions:
+
+1. **Single-invocation scope.** The `try`/`except` wraps exactly one
+   call to third-party plugin code (one `recognizer.detect(...)`
+   invocation against one line). It MUST NOT span multiple plugins,
+   multiple lines, or any host logic.
+2. **`BaseException` still propagates.** Only `Exception` is caught;
+   `SystemExit`, `KeyboardInterrupt`, and other `BaseException`
+   subclasses continue to abort the scan as normal.
+3. **Warning is logged.** The exception type and message are recorded
+   through the rate-limited `_RecognizerWarningBudget` so operators
+   can diagnose misbehaving plugins without log spam.
+4. **Inline justification.** The catch site carries
+   `# noqa: BLE001` with a short comment pointing to the docstring
+   that explains the isolation contract.
+5. **Dedicated test coverage.** Tests MUST prove that (a) a raising
+   plugin produces a warning instead of propagating, (b) the scan
+   continues to completion, and (c) findings from other plugins on the
+   same line are still emitted.
+
+The canonical — and currently only — site is
+`phi_scan.plugin_runtime._invoke_detect_with_isolation`. Any new
+exemption site MUST be reviewed against the conditions above and
+documented here.
+
 ---
 
 ## Authoring Constraints (v1)

--- a/phi_scan/constants.py
+++ b/phi_scan/constants.py
@@ -770,6 +770,7 @@ class DetectionLayer(StrEnum):
     HL7 = "hl7"
     AI = "ai"
     COMBINATION = "combination"
+    PLUGIN = "plugin"
 
 
 class WebhookType(StrEnum):

--- a/phi_scan/help_text.py
+++ b/phi_scan/help_text.py
@@ -171,10 +171,11 @@ are removed or transformed:
 # ---------------------------------------------------------------------------
 
 EXPLAIN_DETECTION_TEXT: str = """\
-[bold cyan]Detection Architecture — 4 Layers[/bold cyan]
+[bold cyan]Detection Architecture — 4 Layers + Plugins[/bold cyan]
 
-PhiScan applies four detection layers in order. Each layer adds coverage
-without replacing previous layers.
+PhiScan applies four built-in detection layers in order, then runs any
+installed third-party recognizer plugins. Each layer adds coverage without
+replacing previous layers.
 
 [bold]Layer 1 — Regex / Pattern Matching[/bold]
   Fast, zero false-negatives on structured PHI. Covers SSN, MBI, DEA, phone,
@@ -195,6 +196,13 @@ without replacing previous layers.
   with [REDACTED] placeholders is sent. Confidence adjustment: ±0.15.
   Supports Anthropic (claude-*), OpenAI (gpt-*, o1/o3/o4), and Google (gemini-*).
   Disabled by default. Enable with [cyan]ai.enable_ai_review: true[/cyan].
+
+[bold]Plugin Recognizers (optional)[/bold]
+  Third-party recognizers installed via the [cyan]phi_scan.plugins[/cyan] entry-point
+  group run per-line after the built-in layers. Findings flow through the same
+  confidence, suppression, baseline, and output pipeline as built-in findings.
+  List installed plugins with [cyan]phi-scan plugins list[/cyan]. See
+  [cyan]docs/plugin-developer-guide.md[/cyan] for the plugin API contract.
 """
 
 # ---------------------------------------------------------------------------

--- a/phi_scan/plugin_runtime.py
+++ b/phi_scan/plugin_runtime.py
@@ -1,0 +1,284 @@
+"""Plugin runtime — execute loaded recognizer plugins against scanned files.
+
+Integrates the Plugin API v1 (``phi_scan.plugin_api``) with the scan
+path. The host iterates the file's lines, calls each loaded plugin's
+``detect(line, context)`` exactly once per line, validates the returned
+findings, computes the value hash and redacted code context, and emits
+host ``ScanFinding`` objects that flow through the same downstream
+filtering, suppression, baseline, and output pipeline as built-in
+findings.
+
+The plugin pass is independent of the built-in detection cache — plugin
+findings are recomputed on every scan so that plugin updates take effect
+immediately without a cache invalidation step.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from pathlib import Path
+
+from phi_scan.constants import (
+    CODE_CONTEXT_REDACTED_VALUE,
+    DetectionLayer,
+    PhiCategory,
+)
+from phi_scan.hashing import compute_value_hash, severity_from_confidence
+from phi_scan.models import ScanFinding
+from phi_scan.plugin_api import (
+    BaseRecognizer,
+    ScanContext,
+)
+from phi_scan.plugin_api import (
+    ScanFinding as PluginScanFinding,
+)
+from phi_scan.plugin_loader import LoadedPlugin, PluginRegistry
+
+__all__ = ["run_plugin_pass"]
+
+_logger: logging.Logger = logging.getLogger(__name__)
+
+_MAX_WARNINGS_PER_RECOGNIZER: int = 5
+_PLUGIN_REMEDIATION_HINT: str = (
+    "Review the matched value and replace or de-identify if it is real PHI/PII."
+)
+
+_RETURN_TYPE_ERROR: str = "returned {actual_type} instead of list[ScanFinding]"
+_MALFORMED_FINDING_ERROR: str = "returned malformed ScanFinding: {error}"
+_OFFSET_OVERRUN_ERROR: str = "end_offset {end_offset} exceeds line length {line_length}"
+_UNDECLARED_ENTITY_TYPE_ERROR: str = (
+    "entity_type {entity_type!r} not declared in entity_types {declared}"
+)
+_DETECT_EXCEPTION_ERROR: str = "detect() raised {error_type}: {error_message}"
+
+_PLUGIN_WARNING_LOG: str = "Plugin %r at %s:%d — %s"
+_PLUGIN_SUMMARY_LOG: str = "Plugin %r produced %d warnings during this scan (first %d shown above)"
+
+
+class _RecognizerWarningBudget:
+    """Tracks warning emissions per recognizer for the duration of one scan."""
+
+    def __init__(self, limit: int = _MAX_WARNINGS_PER_RECOGNIZER) -> None:
+        self._limit = limit
+        self._counts: Counter[str] = Counter()
+
+    def should_log(self, recognizer_name: str) -> bool:
+        self._counts[recognizer_name] += 1
+        return self._counts[recognizer_name] <= self._limit
+
+    def emit_summary(self) -> None:
+        for recognizer_name, total_count in self._counts.items():
+            if total_count > self._limit:
+                _logger.warning(
+                    _PLUGIN_SUMMARY_LOG,
+                    recognizer_name,
+                    total_count,
+                    self._limit,
+                )
+
+
+def run_plugin_pass(
+    file_content: str,
+    file_path: Path,
+    registry: PluginRegistry,
+) -> list[ScanFinding]:
+    """Run every loaded plugin against each line of ``file_content``.
+
+    Args:
+        file_content: Decoded text content of the file. Empty strings
+            and content without newlines are handled naturally.
+        file_path: Relative path recorded on each produced
+            ``ScanFinding``. Plugins see the same path in
+            ``ScanContext.file_path`` but must not open it.
+        registry: Plugin registry loaded once per scan invocation.
+            Only ``registry.loaded`` is consulted; skipped plugins do
+            not participate in the runtime pass.
+
+    Returns:
+        Deterministically sorted list of ``ScanFinding`` objects, one
+        per plugin-reported match that passed validation. Empty list
+        when no plugins produced findings (or when the registry has
+        no loaded plugins).
+    """
+    if not registry.loaded:
+        return []
+    warning_budget = _RecognizerWarningBudget()
+    findings: list[ScanFinding] = []
+    file_extension = file_path.suffix.lower()
+    lines = file_content.splitlines()
+    for line_index, line_text in enumerate(lines, start=1):
+        context = ScanContext(
+            file_path=file_path,
+            line_number=line_index,
+            file_extension=file_extension,
+        )
+        for loaded_plugin in registry.loaded:
+            findings.extend(
+                _run_single_plugin_on_line(
+                    loaded_plugin=loaded_plugin,
+                    line_text=line_text,
+                    context=context,
+                    file_path=file_path,
+                    warning_budget=warning_budget,
+                )
+            )
+    warning_budget.emit_summary()
+    return _sort_plugin_findings(findings)
+
+
+def _run_single_plugin_on_line(
+    loaded_plugin: LoadedPlugin,
+    line_text: str,
+    context: ScanContext,
+    file_path: Path,
+    warning_budget: _RecognizerWarningBudget,
+) -> list[ScanFinding]:
+    """Invoke one plugin on one line, returning validated host findings."""
+    recognizer = loaded_plugin.recognizer
+    raw_findings = _safely_invoke_detect(
+        recognizer=recognizer,
+        line_text=line_text,
+        context=context,
+        warning_budget=warning_budget,
+    )
+    if raw_findings is None:
+        return []
+    declared_entity_types = frozenset(recognizer.entity_types)
+    host_findings: list[ScanFinding] = []
+    for plugin_finding in raw_findings:
+        host_finding = _translate_plugin_finding_to_host(
+            plugin_finding=plugin_finding,
+            line_text=line_text,
+            file_path=file_path,
+            context=context,
+            recognizer=recognizer,
+            declared_entity_types=declared_entity_types,
+            warning_budget=warning_budget,
+        )
+        if host_finding is not None:
+            host_findings.append(host_finding)
+    return host_findings
+
+
+def _safely_invoke_detect(
+    recognizer: BaseRecognizer,
+    line_text: str,
+    context: ScanContext,
+    warning_budget: _RecognizerWarningBudget,
+) -> list[PluginScanFinding] | None:
+    """Call ``recognizer.detect`` under exception isolation."""
+    try:
+        result = recognizer.detect(line_text, context)
+    except Exception as exception:
+        _log_plugin_warning(
+            recognizer_name=recognizer.name,
+            context=context,
+            message=_DETECT_EXCEPTION_ERROR.format(
+                error_type=type(exception).__name__,
+                error_message=str(exception),
+            ),
+            warning_budget=warning_budget,
+        )
+        return None
+    if not isinstance(result, list):
+        _log_plugin_warning(
+            recognizer_name=recognizer.name,
+            context=context,
+            message=_RETURN_TYPE_ERROR.format(actual_type=type(result).__name__),
+            warning_budget=warning_budget,
+        )
+        return None
+    return result
+
+
+def _translate_plugin_finding_to_host(
+    plugin_finding: PluginScanFinding,
+    line_text: str,
+    file_path: Path,
+    context: ScanContext,
+    recognizer: BaseRecognizer,
+    declared_entity_types: frozenset[str],
+    warning_budget: _RecognizerWarningBudget,
+) -> ScanFinding | None:
+    """Validate a plugin finding and translate it into a host ScanFinding."""
+    if not isinstance(plugin_finding, PluginScanFinding):
+        _log_plugin_warning(
+            recognizer_name=recognizer.name,
+            context=context,
+            message=_MALFORMED_FINDING_ERROR.format(
+                error=f"expected ScanFinding, got {type(plugin_finding).__name__}"
+            ),
+            warning_budget=warning_budget,
+        )
+        return None
+    if plugin_finding.entity_type not in declared_entity_types:
+        _log_plugin_warning(
+            recognizer_name=recognizer.name,
+            context=context,
+            message=_UNDECLARED_ENTITY_TYPE_ERROR.format(
+                entity_type=plugin_finding.entity_type,
+                declared=sorted(declared_entity_types),
+            ),
+            warning_budget=warning_budget,
+        )
+        return None
+    if plugin_finding.end_offset > len(line_text):
+        _log_plugin_warning(
+            recognizer_name=recognizer.name,
+            context=context,
+            message=_OFFSET_OVERRUN_ERROR.format(
+                end_offset=plugin_finding.end_offset,
+                line_length=len(line_text),
+            ),
+            warning_budget=warning_budget,
+        )
+        return None
+    matched_slice = line_text[plugin_finding.start_offset : plugin_finding.end_offset]
+    redacted_context = (
+        line_text[: plugin_finding.start_offset]
+        + CODE_CONTEXT_REDACTED_VALUE
+        + line_text[plugin_finding.end_offset :]
+    ).rstrip()
+    return ScanFinding(
+        file_path=file_path,
+        line_number=context.line_number,
+        entity_type=plugin_finding.entity_type,
+        hipaa_category=PhiCategory.UNIQUE_ID,
+        confidence=plugin_finding.confidence,
+        detection_layer=DetectionLayer.PLUGIN,
+        value_hash=compute_value_hash(matched_slice),
+        severity=severity_from_confidence(plugin_finding.confidence),
+        code_context=redacted_context,
+        remediation_hint=_PLUGIN_REMEDIATION_HINT,
+    )
+
+
+def _log_plugin_warning(
+    recognizer_name: str,
+    context: ScanContext,
+    message: str,
+    warning_budget: _RecognizerWarningBudget,
+) -> None:
+    if not warning_budget.should_log(recognizer_name):
+        return
+    _logger.warning(
+        _PLUGIN_WARNING_LOG,
+        recognizer_name,
+        context.file_path,
+        context.line_number,
+        message,
+    )
+
+
+def _sort_plugin_findings(findings: list[ScanFinding]) -> list[ScanFinding]:
+    """Return plugin findings sorted for deterministic output."""
+    return sorted(
+        findings,
+        key=lambda finding: (
+            str(finding.file_path),
+            finding.line_number,
+            finding.entity_type,
+            finding.value_hash,
+        ),
+    )

--- a/phi_scan/plugin_runtime.py
+++ b/phi_scan/plugin_runtime.py
@@ -326,14 +326,16 @@ def _build_host_scan_finding(validation: _PluginFindingValidation) -> ScanFindin
     )
 
 
+def _plugin_finding_sort_key(finding: ScanFinding) -> tuple[str, int, str, str]:
+    """Deterministic sort key for plugin findings (file, line, entity, hash)."""
+    return (
+        str(finding.file_path),
+        finding.line_number,
+        finding.entity_type,
+        finding.value_hash,
+    )
+
+
 def _sort_plugin_findings(findings: list[ScanFinding]) -> list[ScanFinding]:
     """Return plugin findings sorted for deterministic output."""
-    return sorted(
-        findings,
-        key=lambda finding: (
-            str(finding.file_path),
-            finding.line_number,
-            finding.entity_type,
-            finding.value_hash,
-        ),
-    )
+    return sorted(findings, key=_plugin_finding_sort_key)

--- a/phi_scan/plugin_runtime.py
+++ b/phi_scan/plugin_runtime.py
@@ -64,13 +64,14 @@ class _RecognizerWarningBudget:
         self._limit = limit
         self._counts: Counter[str] = Counter()
 
-    def register_warning_and_check_budget(self, recognizer_name: str) -> bool:
-        """Record a warning for ``recognizer_name`` and report whether it should be logged.
+    def claim_warning_slot(self, recognizer_name: str) -> bool:
+        """Claim one warning slot for ``recognizer_name``; return ``True`` if granted.
 
-        Mutation and predicate are fused intentionally: every warning emission
-        site must both count toward the per-recognizer budget and gate logging
-        on that same count. Splitting the two would let callers log without
-        incrementing (or vice versa), breaking the rate-limit invariant.
+        Each call consumes one slot regardless of the return value — the
+        count is the authoritative tally used by the end-of-scan summary.
+        Returns ``True`` while the per-recognizer budget still has capacity
+        (first ``limit`` calls) and ``False`` afterward so the caller can
+        suppress the log line.
         """
         self._counts[recognizer_name] += 1
         return self._counts[recognizer_name] <= self._limit
@@ -144,17 +145,17 @@ def _run_single_plugin_on_line(
 ) -> list[ScanFinding]:
     """Invoke one plugin on one line, returning validated host findings."""
     recognizer = loaded_plugin.recognizer
-    raw_findings = _safely_invoke_detect(
+    unvalidated_plugin_findings = _safely_invoke_detect(
         recognizer=recognizer,
         line_text=line_text,
         context=context,
         warning_budget=warning_budget,
     )
-    if raw_findings is None:
+    if unvalidated_plugin_findings is None:
         return []
     declared_entity_types = frozenset(recognizer.entity_types)
     host_findings: list[ScanFinding] = []
-    for plugin_finding in raw_findings:
+    for plugin_finding in unvalidated_plugin_findings:
         host_finding = _translate_plugin_finding_to_host(
             plugin_finding=plugin_finding,
             line_text=line_text,
@@ -186,7 +187,7 @@ def _safely_invoke_detect(
     to one line from one plugin so unrelated scan work proceeds unaffected.
     """
     try:
-        raw_plugin_findings = recognizer.detect(line_text, context)
+        unvalidated_plugin_findings = recognizer.detect(line_text, context)
     except Exception as exception:  # noqa: BLE001 — plugin isolation boundary (see docstring)
         _log_plugin_warning(
             recognizer_name=recognizer.name,
@@ -198,15 +199,17 @@ def _safely_invoke_detect(
             warning_budget=warning_budget,
         )
         return None
-    if not isinstance(raw_plugin_findings, list):
+    if not isinstance(unvalidated_plugin_findings, list):
         _log_plugin_warning(
             recognizer_name=recognizer.name,
             context=context,
-            message=_RETURN_TYPE_ERROR.format(actual_type=type(raw_plugin_findings).__name__),
+            message=_RETURN_TYPE_ERROR.format(
+                actual_type=type(unvalidated_plugin_findings).__name__
+            ),
             warning_budget=warning_budget,
         )
         return None
-    return raw_plugin_findings
+    return unvalidated_plugin_findings
 
 
 def _translate_plugin_finding_to_host(
@@ -251,7 +254,6 @@ def _translate_plugin_finding_to_host(
             warning_budget=warning_budget,
         )
         return None
-    matched_slice = line_text[plugin_finding.start_offset : plugin_finding.end_offset]
     redacted_context = (
         line_text[: plugin_finding.start_offset]
         + CODE_CONTEXT_REDACTED_VALUE
@@ -264,7 +266,9 @@ def _translate_plugin_finding_to_host(
         hipaa_category=_DEFAULT_PLUGIN_HIPAA_CATEGORY,
         confidence=plugin_finding.confidence,
         detection_layer=DetectionLayer.PLUGIN,
-        value_hash=compute_value_hash(matched_slice),
+        value_hash=compute_value_hash(
+            line_text[plugin_finding.start_offset : plugin_finding.end_offset]
+        ),
         severity=severity_from_confidence(plugin_finding.confidence),
         code_context=redacted_context,
         remediation_hint=_PLUGIN_REMEDIATION_HINT,
@@ -277,7 +281,7 @@ def _log_plugin_warning(
     message: str,
     warning_budget: _RecognizerWarningBudget,
 ) -> None:
-    if not warning_budget.register_warning_and_check_budget(recognizer_name):
+    if not warning_budget.claim_warning_slot(recognizer_name):
         return
     _logger.warning(
         _PLUGIN_WARNING_LOG,

--- a/phi_scan/plugin_runtime.py
+++ b/phi_scan/plugin_runtime.py
@@ -63,6 +63,16 @@ _PLUGIN_SUMMARY_LOG: str = "Plugin %r produced %d warnings during this scan (fir
 
 
 @dataclass(frozen=True)
+class _PluginPassState:
+    """Per-scan plugin-pass state threaded through the collection helpers."""
+
+    file_content: str
+    file_path: Path
+    registry: PluginRegistry
+    warning_budget: _RecognizerWarningBudget
+
+
+@dataclass(frozen=True)
 class _PluginLineInvocation:
     """One plugin's invocation against one line of one file."""
 
@@ -152,25 +162,35 @@ def execute_plugin_pass(
     """
     if not registry.loaded:
         return []
-    warning_budget = _RecognizerWarningBudget()
+    state = _PluginPassState(
+        file_content=file_content,
+        file_path=file_path,
+        registry=registry,
+        warning_budget=_RecognizerWarningBudget(),
+    )
+    findings = _collect_findings_for_all_lines(state)
+    state.warning_budget.emit_recognizer_warning_summary()
+    return _sort_plugin_findings(findings)
+
+
+def _collect_findings_for_all_lines(state: _PluginPassState) -> list[ScanFinding]:
+    """Iterate every line and every loaded plugin, collecting host findings."""
     findings: list[ScanFinding] = []
-    file_extension = file_path.suffix.lower()
-    lines = file_content.splitlines()
-    for line_index, line_text in enumerate(lines, start=1):
+    file_extension = state.file_path.suffix.lower()
+    for line_index, line_text in enumerate(state.file_content.splitlines(), start=1):
         context = ScanContext(
-            file_path=file_path,
+            file_path=state.file_path,
             line_number=line_index,
             file_extension=file_extension,
         )
-        for loaded_plugin in registry.loaded:
+        for loaded_plugin in state.registry.loaded:
             invocation = _PluginLineInvocation(
                 loaded_plugin=loaded_plugin,
                 line_text=line_text,
                 context=context,
             )
-            findings.extend(_execute_single_plugin_on_line(invocation, warning_budget))
-    warning_budget.emit_recognizer_warning_summary()
-    return _sort_plugin_findings(findings)
+            findings.extend(_execute_single_plugin_on_line(invocation, state.warning_budget))
+    return findings
 
 
 def _execute_single_plugin_on_line(
@@ -238,40 +258,57 @@ def _translate_plugin_finding_to_host(
     warning_budget: _RecognizerWarningBudget,
 ) -> ScanFinding | None:
     """Validate a plugin finding and translate it into a host ScanFinding."""
+    if not _is_plugin_finding_valid(validation, warning_budget):
+        return None
+    return _build_host_scan_finding(validation)
+
+
+def _is_plugin_finding_valid(
+    validation: _PluginFindingValidation,
+    warning_budget: _RecognizerWarningBudget,
+) -> bool:
+    """Return ``True`` when ``validation.plugin_finding`` passes every host check."""
     plugin_finding = validation.plugin_finding
     invocation = validation.invocation
-    recognizer = invocation.loaded_plugin.recognizer
-    line_text = invocation.line_text
+    recognizer_name = invocation.loaded_plugin.recognizer.name
     context = invocation.context
     if not isinstance(plugin_finding, PluginScanFinding):
         warning_budget.log_recognizer_warning(
-            recognizer.name,
+            recognizer_name,
             context,
             _MALFORMED_FINDING_ERROR.format(
                 error=f"expected ScanFinding, got {type(plugin_finding).__name__}"
             ),
         )
-        return None
+        return False
     if plugin_finding.entity_type not in validation.declared_entity_types:
         warning_budget.log_recognizer_warning(
-            recognizer.name,
+            recognizer_name,
             context,
             _UNDECLARED_ENTITY_TYPE_ERROR.format(
                 entity_type=plugin_finding.entity_type,
                 declared=sorted(validation.declared_entity_types),
             ),
         )
-        return None
-    if plugin_finding.end_offset > len(line_text):
+        return False
+    if plugin_finding.end_offset > len(invocation.line_text):
         warning_budget.log_recognizer_warning(
-            recognizer.name,
+            recognizer_name,
             context,
             _OFFSET_OVERRUN_ERROR.format(
                 end_offset=plugin_finding.end_offset,
-                line_length=len(line_text),
+                line_length=len(invocation.line_text),
             ),
         )
-        return None
+        return False
+    return True
+
+
+def _build_host_scan_finding(validation: _PluginFindingValidation) -> ScanFinding:
+    """Construct the host ``ScanFinding`` for a validated plugin finding."""
+    plugin_finding = validation.plugin_finding
+    invocation = validation.invocation
+    line_text = invocation.line_text
     redacted_context = (
         line_text[: plugin_finding.start_offset]
         + CODE_CONTEXT_REDACTED_VALUE
@@ -279,7 +316,7 @@ def _translate_plugin_finding_to_host(
     ).rstrip()
     return ScanFinding(
         file_path=invocation.file_path,
-        line_number=context.line_number,
+        line_number=invocation.context.line_number,
         entity_type=plugin_finding.entity_type,
         hipaa_category=_DEFAULT_PLUGIN_HIPAA_CATEGORY,
         confidence=plugin_finding.confidence,

--- a/phi_scan/plugin_runtime.py
+++ b/phi_scan/plugin_runtime.py
@@ -43,6 +43,11 @@ _MAX_WARNINGS_PER_RECOGNIZER: int = 5
 _PLUGIN_REMEDIATION_HINT: str = (
     "Review the matched value and replace or de-identify if it is real PHI/PII."
 )
+# Plugin API v1 does not expose ``hipaa_category`` on ``PluginScanFinding``;
+# every plugin-reported match is tagged ``UNIQUE_ID`` (the least-specific
+# identifier category) until the category is added to the plugin contract
+# in v1.1. Operators who need accurate HIPAA category reporting for plugin
+# findings should track this as a known v1 limitation.
 _DEFAULT_PLUGIN_HIPAA_CATEGORY: PhiCategory = PhiCategory.UNIQUE_ID
 
 _RETURN_TYPE_ERROR: str = "returned {actual_type} instead of list[ScanFinding]"
@@ -174,7 +179,7 @@ def _execute_single_plugin_on_line(
 ) -> list[ScanFinding]:
     """Invoke one plugin on one line, returning validated host findings."""
     recognizer = invocation.loaded_plugin.recognizer
-    unvalidated_plugin_findings = _safely_invoke_detect(invocation, warning_budget)
+    unvalidated_plugin_findings = _invoke_detect_with_isolation(invocation, warning_budget)
     if unvalidated_plugin_findings is None:
         return []
     declared_entity_types = frozenset(recognizer.entity_types)
@@ -191,7 +196,7 @@ def _execute_single_plugin_on_line(
     return host_findings
 
 
-def _safely_invoke_detect(
+def _invoke_detect_with_isolation(
     invocation: _PluginLineInvocation,
     warning_budget: _RecognizerWarningBudget,
 ) -> list[PluginScanFinding] | None:

--- a/phi_scan/plugin_runtime.py
+++ b/phi_scan/plugin_runtime.py
@@ -27,12 +27,8 @@ from phi_scan.constants import (
 )
 from phi_scan.hashing import compute_value_hash, severity_from_confidence
 from phi_scan.models import ScanFinding
-from phi_scan.plugin_api import (
-    ScanContext,
-)
-from phi_scan.plugin_api import (
-    ScanFinding as PluginScanFinding,
-)
+from phi_scan.plugin_api import ScanContext
+from phi_scan.plugin_api import ScanFinding as PluginScanFinding
 from phi_scan.plugin_loader import LoadedPlugin, PluginRegistry
 
 __all__ = ["execute_plugin_pass"]

--- a/phi_scan/plugin_runtime.py
+++ b/phi_scan/plugin_runtime.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import logging
 from collections import Counter
+from dataclasses import dataclass
 from pathlib import Path
 
 from phi_scan.constants import (
@@ -27,7 +28,6 @@ from phi_scan.constants import (
 from phi_scan.hashing import compute_value_hash, severity_from_confidence
 from phi_scan.models import ScanFinding
 from phi_scan.plugin_api import (
-    BaseRecognizer,
     ScanContext,
 )
 from phi_scan.plugin_api import (
@@ -57,6 +57,25 @@ _PLUGIN_WARNING_LOG: str = "Plugin %r at %s:%d — %s"
 _PLUGIN_SUMMARY_LOG: str = "Plugin %r produced %d warnings during this scan (first %d shown above)"
 
 
+@dataclass(frozen=True)
+class _PluginLineInvocation:
+    """One plugin's invocation against one line of one file."""
+
+    loaded_plugin: LoadedPlugin
+    line_text: str
+    context: ScanContext
+    file_path: Path
+
+
+@dataclass(frozen=True)
+class _PluginFindingValidation:
+    """A single plugin-reported finding paired with its invocation context."""
+
+    plugin_finding: PluginScanFinding
+    invocation: _PluginLineInvocation
+    declared_entity_types: frozenset[str]
+
+
 class _RecognizerWarningBudget:
     """Tracks warning emissions per recognizer for the duration of one scan."""
 
@@ -64,7 +83,7 @@ class _RecognizerWarningBudget:
         self._limit = limit
         self._counts: Counter[str] = Counter()
 
-    def claim_warning_slot(self, recognizer_name: str) -> bool:
+    def claim_recognizer_warning_slot(self, recognizer_name: str) -> bool:
         """Claim one warning slot for ``recognizer_name``; return ``True`` if granted.
 
         Each call consumes one slot regardless of the return value — the
@@ -75,6 +94,19 @@ class _RecognizerWarningBudget:
         """
         self._counts[recognizer_name] += 1
         return self._counts[recognizer_name] <= self._limit
+
+    def log_recognizer_warning(
+        self, recognizer_name: str, context: ScanContext, message: str
+    ) -> None:
+        if not self.claim_recognizer_warning_slot(recognizer_name):
+            return
+        _logger.warning(
+            _PLUGIN_WARNING_LOG,
+            recognizer_name,
+            context.file_path,
+            context.line_number,
+            message,
+        )
 
     def emit_recognizer_warning_summary(self) -> None:
         for recognizer_name, total_count in self._counts.items():
@@ -123,57 +155,42 @@ def run_plugin_pass(
             file_extension=file_extension,
         )
         for loaded_plugin in registry.loaded:
-            findings.extend(
-                _run_single_plugin_on_line(
-                    loaded_plugin=loaded_plugin,
-                    line_text=line_text,
-                    context=context,
-                    file_path=file_path,
-                    warning_budget=warning_budget,
-                )
+            invocation = _PluginLineInvocation(
+                loaded_plugin=loaded_plugin,
+                line_text=line_text,
+                context=context,
+                file_path=file_path,
             )
+            findings.extend(_run_single_plugin_on_line(invocation, warning_budget))
     warning_budget.emit_recognizer_warning_summary()
     return _sort_plugin_findings(findings)
 
 
 def _run_single_plugin_on_line(
-    loaded_plugin: LoadedPlugin,
-    line_text: str,
-    context: ScanContext,
-    file_path: Path,
+    invocation: _PluginLineInvocation,
     warning_budget: _RecognizerWarningBudget,
 ) -> list[ScanFinding]:
     """Invoke one plugin on one line, returning validated host findings."""
-    recognizer = loaded_plugin.recognizer
-    unvalidated_plugin_findings = _safely_invoke_detect(
-        recognizer=recognizer,
-        line_text=line_text,
-        context=context,
-        warning_budget=warning_budget,
-    )
+    recognizer = invocation.loaded_plugin.recognizer
+    unvalidated_plugin_findings = _safely_invoke_detect(invocation, warning_budget)
     if unvalidated_plugin_findings is None:
         return []
     declared_entity_types = frozenset(recognizer.entity_types)
     host_findings: list[ScanFinding] = []
     for plugin_finding in unvalidated_plugin_findings:
-        host_finding = _translate_plugin_finding_to_host(
+        validation = _PluginFindingValidation(
             plugin_finding=plugin_finding,
-            line_text=line_text,
-            file_path=file_path,
-            context=context,
-            recognizer=recognizer,
+            invocation=invocation,
             declared_entity_types=declared_entity_types,
-            warning_budget=warning_budget,
         )
+        host_finding = _translate_plugin_finding_to_host(validation, warning_budget)
         if host_finding is not None:
             host_findings.append(host_finding)
     return host_findings
 
 
 def _safely_invoke_detect(
-    recognizer: BaseRecognizer,
-    line_text: str,
-    context: ScanContext,
+    invocation: _PluginLineInvocation,
     warning_budget: _RecognizerWarningBudget,
 ) -> list[PluginScanFinding] | None:
     """Call ``recognizer.detect`` under exception isolation.
@@ -186,72 +203,66 @@ def _safely_invoke_detect(
     the Plugin API v1 failure-semantics contract; it is deliberately scoped
     to one line from one plugin so unrelated scan work proceeds unaffected.
     """
+    recognizer = invocation.loaded_plugin.recognizer
     try:
-        unvalidated_plugin_findings = recognizer.detect(line_text, context)
+        unvalidated_plugin_findings = recognizer.detect(invocation.line_text, invocation.context)
     except Exception as exception:  # noqa: BLE001 — plugin isolation boundary (see docstring)
-        _log_plugin_warning(
-            recognizer_name=recognizer.name,
-            context=context,
-            message=_DETECT_EXCEPTION_ERROR.format(
+        warning_budget.log_recognizer_warning(
+            recognizer.name,
+            invocation.context,
+            _DETECT_EXCEPTION_ERROR.format(
                 error_type=type(exception).__name__,
                 error_message=str(exception),
             ),
-            warning_budget=warning_budget,
         )
         return None
     if not isinstance(unvalidated_plugin_findings, list):
-        _log_plugin_warning(
-            recognizer_name=recognizer.name,
-            context=context,
-            message=_RETURN_TYPE_ERROR.format(
-                actual_type=type(unvalidated_plugin_findings).__name__
-            ),
-            warning_budget=warning_budget,
+        warning_budget.log_recognizer_warning(
+            recognizer.name,
+            invocation.context,
+            _RETURN_TYPE_ERROR.format(actual_type=type(unvalidated_plugin_findings).__name__),
         )
         return None
     return unvalidated_plugin_findings
 
 
 def _translate_plugin_finding_to_host(
-    plugin_finding: PluginScanFinding,
-    line_text: str,
-    file_path: Path,
-    context: ScanContext,
-    recognizer: BaseRecognizer,
-    declared_entity_types: frozenset[str],
+    validation: _PluginFindingValidation,
     warning_budget: _RecognizerWarningBudget,
 ) -> ScanFinding | None:
     """Validate a plugin finding and translate it into a host ScanFinding."""
+    plugin_finding = validation.plugin_finding
+    invocation = validation.invocation
+    recognizer = invocation.loaded_plugin.recognizer
+    line_text = invocation.line_text
+    context = invocation.context
     if not isinstance(plugin_finding, PluginScanFinding):
-        _log_plugin_warning(
-            recognizer_name=recognizer.name,
-            context=context,
-            message=_MALFORMED_FINDING_ERROR.format(
+        warning_budget.log_recognizer_warning(
+            recognizer.name,
+            context,
+            _MALFORMED_FINDING_ERROR.format(
                 error=f"expected ScanFinding, got {type(plugin_finding).__name__}"
             ),
-            warning_budget=warning_budget,
         )
         return None
-    if plugin_finding.entity_type not in declared_entity_types:
-        _log_plugin_warning(
-            recognizer_name=recognizer.name,
-            context=context,
-            message=_UNDECLARED_ENTITY_TYPE_ERROR.format(
+    if plugin_finding.entity_type not in validation.declared_entity_types:
+        warning_budget.log_recognizer_warning(
+            recognizer.name,
+            context,
+            _UNDECLARED_ENTITY_TYPE_ERROR.format(
                 entity_type=plugin_finding.entity_type,
-                declared=sorted(declared_entity_types),
+                declared=sorted(validation.declared_entity_types),
             ),
-            warning_budget=warning_budget,
         )
         return None
     if plugin_finding.end_offset > len(line_text):
-        _log_plugin_warning(
-            recognizer_name=recognizer.name,
-            context=context,
-            message=_OFFSET_OVERRUN_ERROR.format(
+        warning_budget.log_recognizer_warning(
+            recognizer.name,
+            context,
+            _OFFSET_OVERRUN_ERROR.format(
                 end_offset=plugin_finding.end_offset,
                 line_length=len(line_text),
             ),
-            warning_budget=warning_budget,
         )
         return None
     redacted_context = (
@@ -260,7 +271,7 @@ def _translate_plugin_finding_to_host(
         + line_text[plugin_finding.end_offset :]
     ).rstrip()
     return ScanFinding(
-        file_path=file_path,
+        file_path=invocation.file_path,
         line_number=context.line_number,
         entity_type=plugin_finding.entity_type,
         hipaa_category=_DEFAULT_PLUGIN_HIPAA_CATEGORY,
@@ -272,23 +283,6 @@ def _translate_plugin_finding_to_host(
         severity=severity_from_confidence(plugin_finding.confidence),
         code_context=redacted_context,
         remediation_hint=_PLUGIN_REMEDIATION_HINT,
-    )
-
-
-def _log_plugin_warning(
-    recognizer_name: str,
-    context: ScanContext,
-    message: str,
-    warning_budget: _RecognizerWarningBudget,
-) -> None:
-    if not warning_budget.claim_warning_slot(recognizer_name):
-        return
-    _logger.warning(
-        _PLUGIN_WARNING_LOG,
-        recognizer_name,
-        context.file_path,
-        context.line_number,
-        message,
     )
 
 

--- a/phi_scan/plugin_runtime.py
+++ b/phi_scan/plugin_runtime.py
@@ -35,7 +35,7 @@ from phi_scan.plugin_api import (
 )
 from phi_scan.plugin_loader import LoadedPlugin, PluginRegistry
 
-__all__ = ["run_plugin_pass"]
+__all__ = ["execute_plugin_pass"]
 
 _logger: logging.Logger = logging.getLogger(__name__)
 
@@ -64,7 +64,10 @@ class _PluginLineInvocation:
     loaded_plugin: LoadedPlugin
     line_text: str
     context: ScanContext
-    file_path: Path
+
+    @property
+    def file_path(self) -> Path:
+        return self.context.file_path
 
 
 @dataclass(frozen=True)
@@ -119,7 +122,7 @@ class _RecognizerWarningBudget:
                 )
 
 
-def run_plugin_pass(
+def execute_plugin_pass(
     file_content: str,
     file_path: Path,
     registry: PluginRegistry,
@@ -159,14 +162,13 @@ def run_plugin_pass(
                 loaded_plugin=loaded_plugin,
                 line_text=line_text,
                 context=context,
-                file_path=file_path,
             )
-            findings.extend(_run_single_plugin_on_line(invocation, warning_budget))
+            findings.extend(_execute_single_plugin_on_line(invocation, warning_budget))
     warning_budget.emit_recognizer_warning_summary()
     return _sort_plugin_findings(findings)
 
 
-def _run_single_plugin_on_line(
+def _execute_single_plugin_on_line(
     invocation: _PluginLineInvocation,
     warning_budget: _RecognizerWarningBudget,
 ) -> list[ScanFinding]:

--- a/phi_scan/plugin_runtime.py
+++ b/phi_scan/plugin_runtime.py
@@ -43,6 +43,7 @@ _MAX_WARNINGS_PER_RECOGNIZER: int = 5
 _PLUGIN_REMEDIATION_HINT: str = (
     "Review the matched value and replace or de-identify if it is real PHI/PII."
 )
+_DEFAULT_PLUGIN_HIPAA_CATEGORY: PhiCategory = PhiCategory.UNIQUE_ID
 
 _RETURN_TYPE_ERROR: str = "returned {actual_type} instead of list[ScanFinding]"
 _MALFORMED_FINDING_ERROR: str = "returned malformed ScanFinding: {error}"
@@ -63,11 +64,18 @@ class _RecognizerWarningBudget:
         self._limit = limit
         self._counts: Counter[str] = Counter()
 
-    def should_log(self, recognizer_name: str) -> bool:
+    def register_warning_and_check_budget(self, recognizer_name: str) -> bool:
+        """Record a warning for ``recognizer_name`` and report whether it should be logged.
+
+        Mutation and predicate are fused intentionally: every warning emission
+        site must both count toward the per-recognizer budget and gate logging
+        on that same count. Splitting the two would let callers log without
+        incrementing (or vice versa), breaking the rate-limit invariant.
+        """
         self._counts[recognizer_name] += 1
         return self._counts[recognizer_name] <= self._limit
 
-    def emit_summary(self) -> None:
+    def emit_recognizer_warning_summary(self) -> None:
         for recognizer_name, total_count in self._counts.items():
             if total_count > self._limit:
                 _logger.warning(
@@ -123,7 +131,7 @@ def run_plugin_pass(
                     warning_budget=warning_budget,
                 )
             )
-    warning_budget.emit_summary()
+    warning_budget.emit_recognizer_warning_summary()
     return _sort_plugin_findings(findings)
 
 
@@ -167,10 +175,19 @@ def _safely_invoke_detect(
     context: ScanContext,
     warning_budget: _RecognizerWarningBudget,
 ) -> list[PluginScanFinding] | None:
-    """Call ``recognizer.detect`` under exception isolation."""
+    """Call ``recognizer.detect`` under exception isolation.
+
+    Third-party plugins execute arbitrary user code and must not be able to
+    abort a scan. This is the single designated plugin exception boundary:
+    any exception raised by ``detect`` is caught, logged through the
+    rate-limited warning budget, and the line is treated as producing no
+    findings. The broad ``except Exception`` is intentional and required by
+    the Plugin API v1 failure-semantics contract; it is deliberately scoped
+    to one line from one plugin so unrelated scan work proceeds unaffected.
+    """
     try:
-        result = recognizer.detect(line_text, context)
-    except Exception as exception:
+        raw_plugin_findings = recognizer.detect(line_text, context)
+    except Exception as exception:  # noqa: BLE001 — plugin isolation boundary (see docstring)
         _log_plugin_warning(
             recognizer_name=recognizer.name,
             context=context,
@@ -181,15 +198,15 @@ def _safely_invoke_detect(
             warning_budget=warning_budget,
         )
         return None
-    if not isinstance(result, list):
+    if not isinstance(raw_plugin_findings, list):
         _log_plugin_warning(
             recognizer_name=recognizer.name,
             context=context,
-            message=_RETURN_TYPE_ERROR.format(actual_type=type(result).__name__),
+            message=_RETURN_TYPE_ERROR.format(actual_type=type(raw_plugin_findings).__name__),
             warning_budget=warning_budget,
         )
         return None
-    return result
+    return raw_plugin_findings
 
 
 def _translate_plugin_finding_to_host(
@@ -244,7 +261,7 @@ def _translate_plugin_finding_to_host(
         file_path=file_path,
         line_number=context.line_number,
         entity_type=plugin_finding.entity_type,
-        hipaa_category=PhiCategory.UNIQUE_ID,
+        hipaa_category=_DEFAULT_PLUGIN_HIPAA_CATEGORY,
         confidence=plugin_finding.confidence,
         detection_layer=DetectionLayer.PLUGIN,
         value_hash=compute_value_hash(matched_slice),
@@ -260,7 +277,7 @@ def _log_plugin_warning(
     message: str,
     warning_budget: _RecognizerWarningBudget,
 ) -> None:
-    if not warning_budget.should_log(recognizer_name):
+    if not warning_budget.register_warning_and_check_budget(recognizer_name):
         return
     _logger.warning(
         _PLUGIN_WARNING_LOG,

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import threading
 import time
 import zipfile
 import zlib
@@ -159,9 +158,6 @@ _PARALLEL_THREAD_NAME_PREFIX: str = "phi-scan-worker"
 # ---------------------------------------------------------------------------
 # Plugin registry (scan-scoped cache)
 # ---------------------------------------------------------------------------
-
-
-_PLUGIN_REGISTRY_CACHE_LOCK: threading.Lock = threading.Lock()
 
 
 @cache
@@ -420,9 +416,8 @@ def execute_scan(
                 maximum=MAX_WORKER_COUNT,
             ),
         )
-    with _PLUGIN_REGISTRY_CACHE_LOCK:
-        _load_cached_plugin_registry.cache_clear()
-        _load_cached_plugin_registry()
+    _load_cached_plugin_registry.cache_clear()
+    _load_cached_plugin_registry()
     scan_start = time.monotonic()
     all_findings = _collect_all_findings(scan_targets, config, worker_count)
     reviewed_findings, ai_usage = apply_ai_review_to_findings(all_findings, config.ai_review_config)
@@ -606,12 +601,11 @@ def _execute_scan_with_cache(
 def _execute_plugin_pass_for_file(file_content: str, file_path: Path) -> list[ScanFinding]:
     """Run the scan-scoped plugin pass against one file and return findings.
 
-    Reads the registry lock-free: ``execute_scan`` has already performed
-    ``cache_clear`` + warm-load under ``_PLUGIN_REGISTRY_CACHE_LOCK``
-    before any worker threads were spawned, so every call here is a
+    ``execute_scan`` performs ``cache_clear`` + warm-load synchronously
+    before any worker threads are spawned, so every call here is a
     GIL-atomic dict lookup against a fully-populated, no-longer-mutated
-    cache. Acquiring the lock on the hot per-file path would serialise
-    the entire parallel scan and defeat the purpose of ThreadPoolExecutor.
+    cache. ``execute_scan`` is documented as single-invocation per
+    process, which is the contract that makes this lock-free read safe.
     """
     registry = _load_cached_plugin_registry()
     return execute_plugin_pass(file_content, file_path, registry)

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -160,7 +160,7 @@ _PARALLEL_THREAD_NAME_PREFIX: str = "phi-scan-worker"
 # ---------------------------------------------------------------------------
 
 
-def _refresh_plugin_registry_cache() -> None:
+def _reload_plugin_registry_cache() -> None:
     """Discard any cached plugin registry and warm-load a fresh one.
 
     Called synchronously at the top of every ``execute_scan`` invocation,
@@ -427,7 +427,7 @@ def execute_scan(
                 maximum=MAX_WORKER_COUNT,
             ),
         )
-    _refresh_plugin_registry_cache()
+    _reload_plugin_registry_cache()
     scan_start = time.monotonic()
     all_findings = _collect_all_findings(scan_targets, config, worker_count)
     reviewed_findings, ai_usage = apply_ai_review_to_findings(all_findings, config.ai_review_config)

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 
     from phi_scan.ai_review import AIUsageSummary
 
+from functools import cache
+
 from phi_scan.cache import FileCacheKey, get_cached_result, store_cached_result
 from phi_scan.constants import (
     ARCHIVE_EXTENSIONS,
@@ -41,6 +43,8 @@ from phi_scan.detection_coordinator import detect_phi_in_text_content
 from phi_scan.exceptions import FileReadError, PhiDetectionError, TraversalError
 from phi_scan.logging_config import get_logger
 from phi_scan.models import ScanConfig, ScanFinding, ScanResult
+from phi_scan.plugin_loader import PluginRegistry, load_plugin_registry
+from phi_scan.plugin_runtime import run_plugin_pass
 from phi_scan.suppression import is_finding_suppressed, load_suppressions
 
 __all__ = [
@@ -150,6 +154,23 @@ MAX_WORKER_COUNT: int = 32
 MIN_WORKER_COUNT: int = 1
 # Thread name prefix used by ThreadPoolExecutor for log and debugger visibility.
 _PARALLEL_THREAD_NAME_PREFIX: str = "phi-scan-worker"
+
+
+# ---------------------------------------------------------------------------
+# Plugin registry (scan-scoped cache)
+# ---------------------------------------------------------------------------
+
+
+@cache
+def _load_cached_plugin_registry() -> PluginRegistry:
+    """Return the plugin registry for the current scan, discovering once.
+
+    The result is cached for the duration of the process. ``execute_scan``
+    clears the cache at the start of every invocation so a fresh registry
+    is discovered per scan while per-file calls inside one scan share the
+    same registry instance.
+    """
+    return load_plugin_registry()
 
 
 # ---------------------------------------------------------------------------
@@ -383,6 +404,7 @@ def execute_scan(
                 maximum=MAX_WORKER_COUNT,
             ),
         )
+    _load_cached_plugin_registry.cache_clear()
     scan_start = time.monotonic()
     all_findings = _collect_all_findings(scan_targets, config, worker_count)
     reviewed_findings, ai_usage = apply_ai_review_to_findings(all_findings, config.ai_review_config)
@@ -554,11 +576,19 @@ def _execute_scan_with_cache(
     cached_raw = get_cached_result(cache_key)
     if cached_raw is not None:
         _logger.debug(_CACHE_HIT_DEBUG.format(path=file_path, count=len(cached_raw)))
-        return _apply_post_scan_filters(cached_raw, file_content, config)
+        plugin_findings = _run_plugin_pass_for_file(file_content, file_path)
+        return _apply_post_scan_filters(cached_raw + plugin_findings, file_content, config)
     scannable_content = _preprocess_content_for_scan(file_content, file_path)
     raw_findings = detect_phi_in_text_content(scannable_content, file_path)
     store_cached_result(cache_key, raw_findings)
-    return _apply_post_scan_filters(raw_findings, file_content, config)
+    plugin_findings = _run_plugin_pass_for_file(file_content, file_path)
+    return _apply_post_scan_filters(raw_findings + plugin_findings, file_content, config)
+
+
+def _run_plugin_pass_for_file(file_content: str, file_path: Path) -> list[ScanFinding]:
+    """Run the scan-scoped plugin pass against one file and return findings."""
+    registry = _load_cached_plugin_registry()
+    return run_plugin_pass(file_content, file_path, registry)
 
 
 def _apply_post_scan_filters(
@@ -849,7 +879,10 @@ def _scan_archive_members(
             continue
         virtual_path = _compute_display_path(archive_path) / member_name
         raw_findings = detect_phi_in_text_content(member_content, virtual_path)
-        member_findings = _apply_post_scan_filters(raw_findings, member_content, config)
+        plugin_findings = _run_plugin_pass_for_file(member_content, virtual_path)
+        member_findings = _apply_post_scan_filters(
+            raw_findings + plugin_findings, member_content, config
+        )
         findings.extend(member_findings)
     return findings
 

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -403,6 +403,12 @@ def execute_scan(
     Raises:
         ValueError: If worker_count is outside
             [MIN_WORKER_COUNT, MAX_WORKER_COUNT].
+
+    Not safe to call concurrently from multiple threads of a single
+    process: the plugin-registry cache is cleared and warm-loaded at the
+    top of this function, so an overlapping invocation would race the
+    first call's workers. This is a CLI-scoped scanner, not a service;
+    one ``execute_scan`` call per process lifecycle is the supported use.
     """
     from phi_scan.ai_review import apply_ai_review_to_findings
 
@@ -600,14 +606,14 @@ def _execute_scan_with_cache(
 def _execute_plugin_pass_for_file(file_content: str, file_path: Path) -> list[ScanFinding]:
     """Run the scan-scoped plugin pass against one file and return findings.
 
-    The registry is fetched under ``_PLUGIN_REGISTRY_CACHE_LOCK`` so
-    every read is explicitly synchronised with the clear+warm-load
-    sequence at the top of ``execute_scan``; this keeps the lock as the
-    single source of truth for cache lifecycle rather than relying on
-    the GIL-level safety of ``functools.cache`` for concurrent reads.
+    Reads the registry lock-free: ``execute_scan`` has already performed
+    ``cache_clear`` + warm-load under ``_PLUGIN_REGISTRY_CACHE_LOCK``
+    before any worker threads were spawned, so every call here is a
+    GIL-atomic dict lookup against a fully-populated, no-longer-mutated
+    cache. Acquiring the lock on the hot per-file path would serialise
+    the entire parallel scan and defeat the purpose of ThreadPoolExecutor.
     """
-    with _PLUGIN_REGISTRY_CACHE_LOCK:
-        registry = _load_cached_plugin_registry()
+    registry = _load_cached_plugin_registry()
     return execute_plugin_pass(file_content, file_path, registry)
 
 

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -598,8 +598,16 @@ def _execute_scan_with_cache(
 
 
 def _execute_plugin_pass_for_file(file_content: str, file_path: Path) -> list[ScanFinding]:
-    """Run the scan-scoped plugin pass against one file and return findings."""
-    registry = _load_cached_plugin_registry()
+    """Run the scan-scoped plugin pass against one file and return findings.
+
+    The registry is fetched under ``_PLUGIN_REGISTRY_CACHE_LOCK`` so
+    every read is explicitly synchronised with the clear+warm-load
+    sequence at the top of ``execute_scan``; this keeps the lock as the
+    single source of truth for cache lifecycle rather than relying on
+    the GIL-level safety of ``functools.cache`` for concurrent reads.
+    """
+    with _PLUGIN_REGISTRY_CACHE_LOCK:
+        registry = _load_cached_plugin_registry()
     return execute_plugin_pass(file_content, file_path, registry)
 
 

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -160,6 +160,17 @@ _PARALLEL_THREAD_NAME_PREFIX: str = "phi-scan-worker"
 # ---------------------------------------------------------------------------
 
 
+def _refresh_plugin_registry_cache() -> None:
+    """Discard any cached plugin registry and warm-load a fresh one.
+
+    Called synchronously at the top of every ``execute_scan`` invocation,
+    before any worker threads are spawned, so per-file reads during the
+    scan are served from a fully-populated, no-longer-mutated cache.
+    """
+    _load_cached_plugin_registry.cache_clear()
+    _load_cached_plugin_registry()
+
+
 @cache
 def _load_cached_plugin_registry() -> PluginRegistry:
     """Return the plugin registry for the current scan, discovering once.
@@ -416,8 +427,7 @@ def execute_scan(
                 maximum=MAX_WORKER_COUNT,
             ),
         )
-    _load_cached_plugin_registry.cache_clear()
-    _load_cached_plugin_registry()
+    _refresh_plugin_registry_cache()
     scan_start = time.monotonic()
     all_findings = _collect_all_findings(scan_targets, config, worker_count)
     reviewed_findings, ai_usage = apply_ai_review_to_findings(all_findings, config.ai_review_config)

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import threading
 import time
 import zipfile
 import zlib
 from collections import Counter
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from functools import cache
 from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -20,8 +22,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from phi_scan.ai_review import AIUsageSummary
-
-from functools import cache
 
 from phi_scan.cache import FileCacheKey, get_cached_result, store_cached_result
 from phi_scan.constants import (
@@ -159,6 +159,9 @@ _PARALLEL_THREAD_NAME_PREFIX: str = "phi-scan-worker"
 # ---------------------------------------------------------------------------
 # Plugin registry (scan-scoped cache)
 # ---------------------------------------------------------------------------
+
+
+_PLUGIN_REGISTRY_CACHE_LOCK: threading.Lock = threading.Lock()
 
 
 @cache
@@ -411,7 +414,9 @@ def execute_scan(
                 maximum=MAX_WORKER_COUNT,
             ),
         )
-    _load_cached_plugin_registry.cache_clear()
+    with _PLUGIN_REGISTRY_CACHE_LOCK:
+        _load_cached_plugin_registry.cache_clear()
+        _load_cached_plugin_registry()
     scan_start = time.monotonic()
     all_findings = _collect_all_findings(scan_targets, config, worker_count)
     reviewed_findings, ai_usage = apply_ai_review_to_findings(all_findings, config.ai_review_config)

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -169,6 +169,13 @@ def _load_cached_plugin_registry() -> PluginRegistry:
     clears the cache at the start of every invocation so a fresh registry
     is discovered per scan while per-file calls inside one scan share the
     same registry instance.
+
+    Invariant: ``execute_scan`` is the only supported entry point for this
+    cache's lifecycle. Callers that invoke ``run_plugin_pass`` directly
+    (outside ``execute_scan``) must pass a registry they constructed
+    themselves and must not rely on this function; tests that exercise
+    ``execute_scan`` are responsible for clearing the cache between runs
+    (see the autouse fixture in ``tests/test_plugin_runtime.py``).
     """
     return load_plugin_registry()
 

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -44,7 +44,7 @@ from phi_scan.exceptions import FileReadError, PhiDetectionError, TraversalError
 from phi_scan.logging_config import get_logger
 from phi_scan.models import ScanConfig, ScanFinding, ScanResult
 from phi_scan.plugin_loader import PluginRegistry, load_plugin_registry
-from phi_scan.plugin_runtime import run_plugin_pass
+from phi_scan.plugin_runtime import execute_plugin_pass
 from phi_scan.suppression import is_finding_suppressed, load_suppressions
 
 __all__ = [
@@ -174,7 +174,7 @@ def _load_cached_plugin_registry() -> PluginRegistry:
     same registry instance.
 
     Invariant: ``execute_scan`` is the only supported entry point for this
-    cache's lifecycle. Callers that invoke ``run_plugin_pass`` directly
+    cache's lifecycle. Callers that invoke ``execute_plugin_pass`` directly
     (outside ``execute_scan``) must pass a registry they constructed
     themselves and must not rely on this function; tests that exercise
     ``execute_scan`` are responsible for clearing the cache between runs
@@ -588,19 +588,19 @@ def _execute_scan_with_cache(
     cached_raw = get_cached_result(cache_key)
     if cached_raw is not None:
         _logger.debug(_CACHE_HIT_DEBUG.format(path=file_path, count=len(cached_raw)))
-        plugin_findings = _run_plugin_pass_for_file(file_content, file_path)
+        plugin_findings = _execute_plugin_pass_for_file(file_content, file_path)
         return _apply_post_scan_filters(cached_raw + plugin_findings, file_content, config)
     scannable_content = _preprocess_content_for_scan(file_content, file_path)
     raw_findings = detect_phi_in_text_content(scannable_content, file_path)
     store_cached_result(cache_key, raw_findings)
-    plugin_findings = _run_plugin_pass_for_file(file_content, file_path)
+    plugin_findings = _execute_plugin_pass_for_file(file_content, file_path)
     return _apply_post_scan_filters(raw_findings + plugin_findings, file_content, config)
 
 
-def _run_plugin_pass_for_file(file_content: str, file_path: Path) -> list[ScanFinding]:
+def _execute_plugin_pass_for_file(file_content: str, file_path: Path) -> list[ScanFinding]:
     """Run the scan-scoped plugin pass against one file and return findings."""
     registry = _load_cached_plugin_registry()
-    return run_plugin_pass(file_content, file_path, registry)
+    return execute_plugin_pass(file_content, file_path, registry)
 
 
 def _apply_post_scan_filters(
@@ -891,7 +891,7 @@ def _scan_archive_members(
             continue
         virtual_path = _compute_display_path(archive_path) / member_name
         raw_findings = detect_phi_in_text_content(member_content, virtual_path)
-        plugin_findings = _run_plugin_pass_for_file(member_content, virtual_path)
+        plugin_findings = _execute_plugin_pass_for_file(member_content, virtual_path)
         member_findings = _apply_post_scan_filters(
             raw_findings + plugin_findings, member_content, config
         )

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -160,17 +160,6 @@ _PARALLEL_THREAD_NAME_PREFIX: str = "phi-scan-worker"
 # ---------------------------------------------------------------------------
 
 
-def _reload_plugin_registry_cache() -> None:
-    """Discard any cached plugin registry and warm-load a fresh one.
-
-    Called synchronously at the top of every ``execute_scan`` invocation,
-    before any worker threads are spawned, so per-file reads during the
-    scan are served from a fully-populated, no-longer-mutated cache.
-    """
-    _load_cached_plugin_registry.cache_clear()
-    _load_cached_plugin_registry()
-
-
 @cache
 def _load_cached_plugin_registry() -> PluginRegistry:
     """Return the plugin registry for the current scan, discovering once.
@@ -412,10 +401,11 @@ def execute_scan(
             [MIN_WORKER_COUNT, MAX_WORKER_COUNT].
 
     Not safe to call concurrently from multiple threads of a single
-    process: the plugin-registry cache is cleared and warm-loaded at the
-    top of this function, so an overlapping invocation would race the
-    first call's workers. This is a CLI-scoped scanner, not a service;
-    one ``execute_scan`` call per process lifecycle is the supported use.
+    process: the plugin-registry cache is cleared at the top of this
+    function, so an overlapping invocation would discard another call's
+    already-populated registry. This is a CLI-scoped scanner, not a
+    service; one ``execute_scan`` call per process lifecycle is the
+    supported use.
     """
     from phi_scan.ai_review import apply_ai_review_to_findings
 
@@ -427,7 +417,7 @@ def execute_scan(
                 maximum=MAX_WORKER_COUNT,
             ),
         )
-    _reload_plugin_registry_cache()
+    _load_cached_plugin_registry.cache_clear()
     scan_start = time.monotonic()
     all_findings = _collect_all_findings(scan_targets, config, worker_count)
     reviewed_findings, ai_usage = apply_ai_review_to_findings(all_findings, config.ai_review_config)
@@ -611,11 +601,12 @@ def _execute_scan_with_cache(
 def _execute_plugin_pass_for_file(file_content: str, file_path: Path) -> list[ScanFinding]:
     """Run the scan-scoped plugin pass against one file and return findings.
 
-    ``execute_scan`` performs ``cache_clear`` + warm-load synchronously
-    before any worker threads are spawned, so every call here is a
-    GIL-atomic dict lookup against a fully-populated, no-longer-mutated
-    cache. ``execute_scan`` is documented as single-invocation per
-    process, which is the contract that makes this lock-free read safe.
+    ``execute_scan`` clears the registry cache synchronously before any
+    worker threads are spawned. The first worker to reach this function
+    populates the cache via ``functools.cache``, whose underlying
+    ``lru_cache`` lock serialises concurrent callers so
+    ``load_plugin_registry`` runs at most once per scan; subsequent
+    readers hit the populated cache directly.
     """
     registry = _load_cached_plugin_registry()
     return execute_plugin_pass(file_content, file_path, registry)

--- a/tests/test_plugin_runtime.py
+++ b/tests/test_plugin_runtime.py
@@ -43,8 +43,8 @@ class _AcmeRecognizer(BaseRecognizer):
     name = _ACME_RECOGNIZER_NAME
     entity_types = (_ACME_ENTITY_TYPE,)
     plugin_api_version = PLUGIN_API_VERSION
-    version = "0.1.0"
-    description = "Test ACME employee ID recognizer."
+    version = _TEST_RECOGNIZER_VERSION
+    description = _TEST_RECOGNIZER_DESCRIPTION
 
     def detect(self, line: str, context: ScanContext) -> list[PluginScanFinding]:
         match = re.search(r"\bEMP-\d{6}\b", line)

--- a/tests/test_plugin_runtime.py
+++ b/tests/test_plugin_runtime.py
@@ -32,6 +32,9 @@ _PLUGIN_SAMPLE_LINE: str = "employee_id = EMP-123456"
 _RATE_LIMIT_TEST_LINE_COUNT: int = 20
 _OFFSET_OVERRUN_EXTRA: int = 50
 _CONFIDENCE_THRESHOLD_ABOVE_ACME: float = 0.99
+_UNDECLARED_ENTITY_END_OFFSET: int = 5
+_TEST_RECOGNIZER_VERSION: str = "0.0.1"
+_TEST_RECOGNIZER_DESCRIPTION: str = "Test fixture recognizer."
 
 
 class _AcmeRecognizer(BaseRecognizer):
@@ -61,6 +64,8 @@ class _RaisingRecognizer(BaseRecognizer):
     name = "raising_recognizer"
     entity_types = ("RAISING_TEST",)
     plugin_api_version = "1.0"
+    version = _TEST_RECOGNIZER_VERSION
+    description = _TEST_RECOGNIZER_DESCRIPTION
 
     def detect(self, line: str, context: ScanContext) -> list[PluginScanFinding]:
         raise RuntimeError("simulated plugin failure")
@@ -70,6 +75,8 @@ class _OffsetOverrunRecognizer(BaseRecognizer):
     name = "offset_overrun"
     entity_types = ("OVERRUN_TEST",)
     plugin_api_version = "1.0"
+    version = _TEST_RECOGNIZER_VERSION
+    description = _TEST_RECOGNIZER_DESCRIPTION
 
     def detect(self, line: str, context: ScanContext) -> list[PluginScanFinding]:
         return [
@@ -86,13 +93,15 @@ class _UndeclaredEntityTypeRecognizer(BaseRecognizer):
     name = "undeclared_entity"
     entity_types = ("DECLARED_ONLY",)
     plugin_api_version = "1.0"
+    version = _TEST_RECOGNIZER_VERSION
+    description = _TEST_RECOGNIZER_DESCRIPTION
 
     def detect(self, line: str, context: ScanContext) -> list[PluginScanFinding]:
         return [
             PluginScanFinding(
                 entity_type="NOT_DECLARED",
                 start_offset=0,
-                end_offset=5,
+                end_offset=_UNDECLARED_ENTITY_END_OFFSET,
                 confidence=_ACME_CONFIDENCE,
             )
         ]

--- a/tests/test_plugin_runtime.py
+++ b/tests/test_plugin_runtime.py
@@ -10,6 +10,7 @@ is invoked exactly once per ``execute_scan`` invocation.
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import patch
@@ -43,8 +44,6 @@ class _AcmeRecognizer(BaseRecognizer):
     description = "Test ACME employee ID recognizer."
 
     def detect(self, line: str, context: ScanContext) -> list[PluginScanFinding]:
-        import re
-
         match = re.search(r"\bEMP-\d{6}\b", line)
         if match is None:
             return []

--- a/tests/test_plugin_runtime.py
+++ b/tests/test_plugin_runtime.py
@@ -29,6 +29,8 @@ _ACME_RECOGNIZER_NAME: str = "acme_employee_id"
 _ACME_CONFIDENCE: float = 0.9
 _PLUGIN_SAMPLE_LINE: str = "employee_id = EMP-123456"
 _RATE_LIMIT_TEST_LINE_COUNT: int = 20
+_OFFSET_OVERRUN_EXTRA: int = 50
+_CONFIDENCE_THRESHOLD_ABOVE_ACME: float = 0.99
 
 
 class _AcmeRecognizer(BaseRecognizer):
@@ -75,8 +77,8 @@ class _OffsetOverrunRecognizer(BaseRecognizer):
             PluginScanFinding(
                 entity_type="OVERRUN_TEST",
                 start_offset=0,
-                end_offset=len(line) + 50,
-                confidence=0.9,
+                end_offset=len(line) + _OFFSET_OVERRUN_EXTRA,
+                confidence=_ACME_CONFIDENCE,
             )
         ]
 
@@ -92,7 +94,7 @@ class _UndeclaredEntityTypeRecognizer(BaseRecognizer):
                 entity_type="NOT_DECLARED",
                 start_offset=0,
                 end_offset=5,
-                confidence=0.9,
+                confidence=_ACME_CONFIDENCE,
             )
         ]
 
@@ -344,7 +346,10 @@ def test_execute_scan_plugin_findings_respect_confidence_threshold(
     sample_file: Path,
 ) -> None:
     registry = _build_registry(_AcmeRecognizer())
-    config = ScanConfig(confidence_threshold=0.99, severity_threshold=SeverityLevel.INFO)
+    config = ScanConfig(
+        confidence_threshold=_CONFIDENCE_THRESHOLD_ABOVE_ACME,
+        severity_threshold=SeverityLevel.INFO,
+    )
 
     with patch("phi_scan.scanner.load_plugin_registry", return_value=registry):
         result = execute_scan([sample_file], config)

--- a/tests/test_plugin_runtime.py
+++ b/tests/test_plugin_runtime.py
@@ -1,0 +1,354 @@
+"""Runtime execution tests for the Plugin API v1.
+
+Covers the scan-time integration: plugin findings reach the scan result,
+exceptions in ``detect`` are isolated per line, malformed findings are
+dropped with a warning, scans without installed plugins behave exactly
+as before, parallel workers produce identical findings, and the loader
+is invoked exactly once per ``execute_scan`` invocation.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from phi_scan.constants import DetectionLayer, SeverityLevel
+from phi_scan.models import ScanConfig, ScanFinding
+from phi_scan.plugin_api import BaseRecognizer, ScanContext
+from phi_scan.plugin_api import ScanFinding as PluginScanFinding
+from phi_scan.plugin_loader import LoadedPlugin, PluginRegistry
+from phi_scan.plugin_runtime import run_plugin_pass
+from phi_scan.scanner import _load_cached_plugin_registry, execute_scan
+
+_ACME_ENTITY_TYPE: str = "ACME_EMPLOYEE_ID"
+_ACME_RECOGNIZER_NAME: str = "acme_employee_id"
+_ACME_CONFIDENCE: float = 0.9
+_PLUGIN_SAMPLE_LINE: str = "employee_id = EMP-123456"
+_PLUGIN_SAMPLE_OFFSET_START: int = 15
+_PLUGIN_SAMPLE_OFFSET_END: int = 25
+
+
+class _AcmeRecognizer(BaseRecognizer):
+    """Simple recognizer that matches ``EMP-######`` patterns."""
+
+    name = _ACME_RECOGNIZER_NAME
+    entity_types = (_ACME_ENTITY_TYPE,)
+    plugin_api_version = "1.0"
+    version = "0.1.0"
+    description = "Test ACME employee ID recognizer."
+
+    def detect(self, line: str, context: ScanContext) -> list[PluginScanFinding]:
+        import re
+
+        match = re.search(r"\bEMP-\d{6}\b", line)
+        if match is None:
+            return []
+        return [
+            PluginScanFinding(
+                entity_type=_ACME_ENTITY_TYPE,
+                start_offset=match.start(),
+                end_offset=match.end(),
+                confidence=_ACME_CONFIDENCE,
+            )
+        ]
+
+
+class _RaisingRecognizer(BaseRecognizer):
+    name = "raising_recognizer"
+    entity_types = ("RAISING_TEST",)
+    plugin_api_version = "1.0"
+
+    def detect(self, line: str, context: ScanContext) -> list[PluginScanFinding]:
+        raise RuntimeError("simulated plugin failure")
+
+
+class _OffsetOverrunRecognizer(BaseRecognizer):
+    name = "offset_overrun"
+    entity_types = ("OVERRUN_TEST",)
+    plugin_api_version = "1.0"
+
+    def detect(self, line: str, context: ScanContext) -> list[PluginScanFinding]:
+        return [
+            PluginScanFinding(
+                entity_type="OVERRUN_TEST",
+                start_offset=0,
+                end_offset=len(line) + 50,
+                confidence=0.9,
+            )
+        ]
+
+
+class _UndeclaredEntityTypeRecognizer(BaseRecognizer):
+    name = "undeclared_entity"
+    entity_types = ("DECLARED_ONLY",)
+    plugin_api_version = "1.0"
+
+    def detect(self, line: str, context: ScanContext) -> list[PluginScanFinding]:
+        return [
+            PluginScanFinding(
+                entity_type="NOT_DECLARED",
+                start_offset=0,
+                end_offset=5,
+                confidence=0.9,
+            )
+        ]
+
+
+def _build_registry(*recognizers: BaseRecognizer) -> PluginRegistry:
+    loaded = tuple(
+        LoadedPlugin(
+            entry_point_name=recognizer.name,
+            distribution_name=f"{recognizer.name}-dist",
+            recognizer=recognizer,
+        )
+        for recognizer in recognizers
+    )
+    return PluginRegistry(loaded=loaded)
+
+
+@pytest.fixture(autouse=True)
+def _clear_scan_registry_cache() -> Iterator[None]:
+    _load_cached_plugin_registry.cache_clear()
+    yield
+    _load_cached_plugin_registry.cache_clear()
+
+
+@pytest.fixture
+def sample_file(tmp_path: Path) -> Path:
+    target = tmp_path / "source.py"
+    target.write_text(_PLUGIN_SAMPLE_LINE + "\n", encoding="utf-8")
+    return target
+
+
+@pytest.fixture
+def scan_config() -> ScanConfig:
+    return ScanConfig(confidence_threshold=0.0, severity_threshold=SeverityLevel.INFO)
+
+
+# ---------------------------------------------------------------------------
+# run_plugin_pass unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_run_plugin_pass_returns_empty_list_when_no_plugins_loaded() -> None:
+    findings = run_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("source.py"), PluginRegistry())
+    assert findings == []
+
+
+def test_run_plugin_pass_emits_finding_with_host_computed_fields() -> None:
+    registry = _build_registry(_AcmeRecognizer())
+
+    findings = run_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("source.py"), registry)
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert isinstance(finding, ScanFinding)
+    assert finding.entity_type == _ACME_ENTITY_TYPE
+    assert finding.detection_layer == DetectionLayer.PLUGIN
+    assert finding.confidence == _ACME_CONFIDENCE
+    assert "[REDACTED]" in finding.code_context
+    assert "EMP-123456" not in finding.code_context
+    assert len(finding.value_hash) == 64
+
+
+def test_run_plugin_pass_isolates_exception_raised_by_detect(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    registry = _build_registry(_RaisingRecognizer(), _AcmeRecognizer())
+
+    with caplog.at_level(logging.WARNING, logger="phi_scan.plugin_runtime"):
+        findings = run_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("s.py"), registry)
+
+    acme_findings = [f for f in findings if f.entity_type == _ACME_ENTITY_TYPE]
+    assert len(acme_findings) == 1
+    assert any("simulated plugin failure" in record.message for record in caplog.records)
+
+
+def test_run_plugin_pass_drops_finding_whose_end_offset_overruns_line(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    registry = _build_registry(_OffsetOverrunRecognizer())
+
+    with caplog.at_level(logging.WARNING, logger="phi_scan.plugin_runtime"):
+        findings = run_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("s.py"), registry)
+
+    assert findings == []
+    assert any("end_offset" in record.message for record in caplog.records)
+
+
+def test_run_plugin_pass_drops_finding_with_undeclared_entity_type(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    registry = _build_registry(_UndeclaredEntityTypeRecognizer())
+
+    with caplog.at_level(logging.WARNING, logger="phi_scan.plugin_runtime"):
+        findings = run_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("s.py"), registry)
+
+    assert findings == []
+    assert any("not declared in entity_types" in record.message for record in caplog.records)
+
+
+def test_run_plugin_pass_rate_limits_warnings_per_recognizer(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    registry = _build_registry(_RaisingRecognizer())
+    content = "\n".join([_PLUGIN_SAMPLE_LINE] * 20)
+
+    with caplog.at_level(logging.WARNING, logger="phi_scan.plugin_runtime"):
+        run_plugin_pass(content, Path("s.py"), registry)
+
+    per_line_records = [
+        record for record in caplog.records if "simulated plugin failure" in record.message
+    ]
+    summary_records = [
+        record
+        for record in caplog.records
+        if "produced" in record.message and "warnings" in record.message
+    ]
+    assert len(per_line_records) == 5
+    assert len(summary_records) == 1
+
+
+def test_run_plugin_pass_drops_non_list_return_value(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class _ReturnsNoneRecognizer(BaseRecognizer):
+        name = "returns_none"
+        entity_types = ("NONE_TEST",)
+        plugin_api_version = "1.0"
+
+        def detect(self, line: str, context: ScanContext) -> list[PluginScanFinding]:
+            return None  # type: ignore[return-value]
+
+    registry = _build_registry(_ReturnsNoneRecognizer())
+
+    with caplog.at_level(logging.WARNING, logger="phi_scan.plugin_runtime"):
+        findings = run_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("s.py"), registry)
+
+    assert findings == []
+    assert any("NoneType" in record.message for record in caplog.records)
+
+
+def test_run_plugin_pass_drops_list_entries_that_are_not_scan_findings(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class _ReturnsWrongTypeRecognizer(BaseRecognizer):
+        name = "returns_wrong_type"
+        entity_types = ("WRONG_TYPE_TEST",)
+        plugin_api_version = "1.0"
+
+        def detect(self, line: str, context: ScanContext) -> list[PluginScanFinding]:
+            return ["not a scan finding"]  # type: ignore[list-item]
+
+    registry = _build_registry(_ReturnsWrongTypeRecognizer())
+
+    with caplog.at_level(logging.WARNING, logger="phi_scan.plugin_runtime"):
+        findings = run_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("s.py"), registry)
+
+    assert findings == []
+    assert any("expected ScanFinding" in record.message for record in caplog.records)
+
+
+def test_run_plugin_pass_sorts_findings_deterministically() -> None:
+    content = "\n".join([_PLUGIN_SAMPLE_LINE, _PLUGIN_SAMPLE_LINE, _PLUGIN_SAMPLE_LINE])
+    registry = _build_registry(_AcmeRecognizer())
+
+    findings = run_plugin_pass(content, Path("source.py"), registry)
+
+    line_numbers = [finding.line_number for finding in findings]
+    assert line_numbers == sorted(line_numbers)
+
+
+# ---------------------------------------------------------------------------
+# Scanner integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_execute_scan_includes_plugin_findings(sample_file: Path, scan_config: ScanConfig) -> None:
+    registry = _build_registry(_AcmeRecognizer())
+
+    with patch("phi_scan.scanner.load_plugin_registry", return_value=registry):
+        result = execute_scan([sample_file], scan_config)
+
+    plugin_findings = [f for f in result.findings if f.detection_layer == DetectionLayer.PLUGIN]
+    assert len(plugin_findings) == 1
+    assert plugin_findings[0].entity_type == _ACME_ENTITY_TYPE
+
+
+def test_execute_scan_without_plugins_produces_no_plugin_findings(
+    sample_file: Path, scan_config: ScanConfig
+) -> None:
+    with patch("phi_scan.scanner.load_plugin_registry", return_value=PluginRegistry()):
+        result = execute_scan([sample_file], scan_config)
+
+    assert not any(f.detection_layer == DetectionLayer.PLUGIN for f in result.findings)
+
+
+def test_execute_scan_loads_plugin_registry_exactly_once(
+    tmp_path: Path, scan_config: ScanConfig
+) -> None:
+    registry = _build_registry(_AcmeRecognizer())
+    for index in range(3):
+        (tmp_path / f"file_{index}.py").write_text(_PLUGIN_SAMPLE_LINE + "\n", encoding="utf-8")
+    scan_targets = sorted(tmp_path.glob("*.py"))
+
+    with patch("phi_scan.scanner.load_plugin_registry", return_value=registry) as mock_loader:
+        execute_scan(scan_targets, scan_config)
+
+    assert mock_loader.call_count == 1
+
+
+def test_execute_scan_plugin_failure_does_not_abort_scan(
+    sample_file: Path, scan_config: ScanConfig
+) -> None:
+    registry = _build_registry(_RaisingRecognizer(), _AcmeRecognizer())
+
+    with patch("phi_scan.scanner.load_plugin_registry", return_value=registry):
+        result = execute_scan([sample_file], scan_config)
+
+    acme_findings = [f for f in result.findings if f.entity_type == _ACME_ENTITY_TYPE]
+    assert len(acme_findings) == 1
+
+
+def test_execute_scan_parallel_workers_match_sequential_with_plugins(
+    tmp_path: Path, scan_config: ScanConfig
+) -> None:
+    for index in range(10):
+        (tmp_path / f"file_{index}.py").write_text(_PLUGIN_SAMPLE_LINE + "\n", encoding="utf-8")
+    scan_targets = sorted(tmp_path.glob("*.py"))
+    registry = _build_registry(_AcmeRecognizer())
+
+    with patch("phi_scan.scanner.load_plugin_registry", return_value=registry):
+        sequential_result = execute_scan(scan_targets, scan_config, worker_count=1)
+        _load_cached_plugin_registry.cache_clear()
+        parallel_result = execute_scan(scan_targets, scan_config, worker_count=4)
+
+    sequential_plugin_findings = sorted(
+        (str(f.file_path), f.line_number, f.value_hash)
+        for f in sequential_result.findings
+        if f.detection_layer == DetectionLayer.PLUGIN
+    )
+    parallel_plugin_findings = sorted(
+        (str(f.file_path), f.line_number, f.value_hash)
+        for f in parallel_result.findings
+        if f.detection_layer == DetectionLayer.PLUGIN
+    )
+    assert sequential_plugin_findings == parallel_plugin_findings
+    assert len(sequential_plugin_findings) == 10
+
+
+def test_execute_scan_plugin_findings_respect_confidence_threshold(
+    sample_file: Path,
+) -> None:
+    registry = _build_registry(_AcmeRecognizer())
+    config = ScanConfig(confidence_threshold=0.99, severity_threshold=SeverityLevel.INFO)
+
+    with patch("phi_scan.scanner.load_plugin_registry", return_value=registry):
+        result = execute_scan([sample_file], config)
+
+    plugin_findings = [f for f in result.findings if f.detection_layer == DetectionLayer.PLUGIN]
+    assert plugin_findings == []

--- a/tests/test_plugin_runtime.py
+++ b/tests/test_plugin_runtime.py
@@ -21,13 +21,14 @@ from phi_scan.models import ScanConfig, ScanFinding
 from phi_scan.plugin_api import BaseRecognizer, ScanContext
 from phi_scan.plugin_api import ScanFinding as PluginScanFinding
 from phi_scan.plugin_loader import LoadedPlugin, PluginRegistry
-from phi_scan.plugin_runtime import run_plugin_pass
+from phi_scan.plugin_runtime import _MAX_WARNINGS_PER_RECOGNIZER, run_plugin_pass
 from phi_scan.scanner import _load_cached_plugin_registry, execute_scan
 
 _ACME_ENTITY_TYPE: str = "ACME_EMPLOYEE_ID"
 _ACME_RECOGNIZER_NAME: str = "acme_employee_id"
 _ACME_CONFIDENCE: float = 0.9
 _PLUGIN_SAMPLE_LINE: str = "employee_id = EMP-123456"
+_RATE_LIMIT_TEST_LINE_COUNT: int = 20
 
 
 class _AcmeRecognizer(BaseRecognizer):
@@ -194,7 +195,7 @@ def test_run_plugin_pass_rate_limits_warnings_per_recognizer(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     registry = _build_registry(_RaisingRecognizer())
-    content = "\n".join([_PLUGIN_SAMPLE_LINE] * 20)
+    content = "\n".join([_PLUGIN_SAMPLE_LINE] * _RATE_LIMIT_TEST_LINE_COUNT)
 
     with caplog.at_level(logging.WARNING, logger="phi_scan.plugin_runtime"):
         run_plugin_pass(content, Path("s.py"), registry)
@@ -207,7 +208,7 @@ def test_run_plugin_pass_rate_limits_warnings_per_recognizer(
         for record in caplog.records
         if "produced" in record.message and "warnings" in record.message
     ]
-    assert len(per_line_records) == 5
+    assert len(per_line_records) == _MAX_WARNINGS_PER_RECOGNIZER
     assert len(summary_records) == 1
 
 

--- a/tests/test_plugin_runtime.py
+++ b/tests/test_plugin_runtime.py
@@ -21,7 +21,7 @@ from phi_scan.models import ScanConfig, ScanFinding
 from phi_scan.plugin_api import BaseRecognizer, ScanContext
 from phi_scan.plugin_api import ScanFinding as PluginScanFinding
 from phi_scan.plugin_loader import LoadedPlugin, PluginRegistry
-from phi_scan.plugin_runtime import _MAX_WARNINGS_PER_RECOGNIZER, run_plugin_pass
+from phi_scan.plugin_runtime import _MAX_WARNINGS_PER_RECOGNIZER, execute_plugin_pass
 from phi_scan.scanner import _load_cached_plugin_registry, execute_scan
 
 _ACME_ENTITY_TYPE: str = "ACME_EMPLOYEE_ID"
@@ -129,19 +129,19 @@ def scan_config() -> ScanConfig:
 
 
 # ---------------------------------------------------------------------------
-# run_plugin_pass unit tests
+# execute_plugin_pass unit tests
 # ---------------------------------------------------------------------------
 
 
-def test_run_plugin_pass_returns_empty_list_when_no_plugins_loaded() -> None:
-    findings = run_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("source.py"), PluginRegistry())
+def test_execute_plugin_pass_returns_empty_list_when_no_plugins_loaded() -> None:
+    findings = execute_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("source.py"), PluginRegistry())
     assert findings == []
 
 
-def test_run_plugin_pass_emits_finding_with_host_computed_fields() -> None:
+def test_execute_plugin_pass_emits_finding_with_host_computed_fields() -> None:
     registry = _build_registry(_AcmeRecognizer())
 
-    findings = run_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("source.py"), registry)
+    findings = execute_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("source.py"), registry)
 
     assert len(findings) == 1
     finding = findings[0]
@@ -154,51 +154,51 @@ def test_run_plugin_pass_emits_finding_with_host_computed_fields() -> None:
     assert len(finding.value_hash) == 64
 
 
-def test_run_plugin_pass_isolates_exception_raised_by_detect(
+def test_execute_plugin_pass_isolates_exception_raised_by_detect(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     registry = _build_registry(_RaisingRecognizer(), _AcmeRecognizer())
 
     with caplog.at_level(logging.WARNING, logger="phi_scan.plugin_runtime"):
-        findings = run_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("s.py"), registry)
+        findings = execute_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("s.py"), registry)
 
     acme_findings = [f for f in findings if f.entity_type == _ACME_ENTITY_TYPE]
     assert len(acme_findings) == 1
     assert any("simulated plugin failure" in record.message for record in caplog.records)
 
 
-def test_run_plugin_pass_drops_finding_whose_end_offset_overruns_line(
+def test_execute_plugin_pass_drops_finding_whose_end_offset_overruns_line(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     registry = _build_registry(_OffsetOverrunRecognizer())
 
     with caplog.at_level(logging.WARNING, logger="phi_scan.plugin_runtime"):
-        findings = run_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("s.py"), registry)
+        findings = execute_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("s.py"), registry)
 
     assert findings == []
     assert any("end_offset" in record.message for record in caplog.records)
 
 
-def test_run_plugin_pass_drops_finding_with_undeclared_entity_type(
+def test_execute_plugin_pass_drops_finding_with_undeclared_entity_type(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     registry = _build_registry(_UndeclaredEntityTypeRecognizer())
 
     with caplog.at_level(logging.WARNING, logger="phi_scan.plugin_runtime"):
-        findings = run_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("s.py"), registry)
+        findings = execute_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("s.py"), registry)
 
     assert findings == []
     assert any("not declared in entity_types" in record.message for record in caplog.records)
 
 
-def test_run_plugin_pass_rate_limits_warnings_per_recognizer(
+def test_execute_plugin_pass_rate_limits_warnings_per_recognizer(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     registry = _build_registry(_RaisingRecognizer())
     content = "\n".join([_PLUGIN_SAMPLE_LINE] * _RATE_LIMIT_TEST_LINE_COUNT)
 
     with caplog.at_level(logging.WARNING, logger="phi_scan.plugin_runtime"):
-        run_plugin_pass(content, Path("s.py"), registry)
+        execute_plugin_pass(content, Path("s.py"), registry)
 
     per_line_records = [
         record for record in caplog.records if "simulated plugin failure" in record.message
@@ -212,7 +212,7 @@ def test_run_plugin_pass_rate_limits_warnings_per_recognizer(
     assert len(summary_records) == 1
 
 
-def test_run_plugin_pass_drops_non_list_return_value(
+def test_execute_plugin_pass_drops_non_list_return_value(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     class _ReturnsNoneRecognizer(BaseRecognizer):
@@ -226,13 +226,13 @@ def test_run_plugin_pass_drops_non_list_return_value(
     registry = _build_registry(_ReturnsNoneRecognizer())
 
     with caplog.at_level(logging.WARNING, logger="phi_scan.plugin_runtime"):
-        findings = run_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("s.py"), registry)
+        findings = execute_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("s.py"), registry)
 
     assert findings == []
     assert any("NoneType" in record.message for record in caplog.records)
 
 
-def test_run_plugin_pass_drops_list_entries_that_are_not_scan_findings(
+def test_execute_plugin_pass_drops_list_entries_that_are_not_scan_findings(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     class _ReturnsWrongTypeRecognizer(BaseRecognizer):
@@ -246,17 +246,17 @@ def test_run_plugin_pass_drops_list_entries_that_are_not_scan_findings(
     registry = _build_registry(_ReturnsWrongTypeRecognizer())
 
     with caplog.at_level(logging.WARNING, logger="phi_scan.plugin_runtime"):
-        findings = run_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("s.py"), registry)
+        findings = execute_plugin_pass(_PLUGIN_SAMPLE_LINE, Path("s.py"), registry)
 
     assert findings == []
     assert any("expected ScanFinding" in record.message for record in caplog.records)
 
 
-def test_run_plugin_pass_sorts_findings_deterministically() -> None:
+def test_execute_plugin_pass_sorts_findings_deterministically() -> None:
     content = "\n".join([_PLUGIN_SAMPLE_LINE, _PLUGIN_SAMPLE_LINE, _PLUGIN_SAMPLE_LINE])
     registry = _build_registry(_AcmeRecognizer())
 
-    findings = run_plugin_pass(content, Path("source.py"), registry)
+    findings = execute_plugin_pass(content, Path("source.py"), registry)
 
     line_numbers = [finding.line_number for finding in findings]
     assert line_numbers == sorted(line_numbers)

--- a/tests/test_plugin_runtime.py
+++ b/tests/test_plugin_runtime.py
@@ -19,7 +19,7 @@ import pytest
 
 from phi_scan.constants import DetectionLayer, SeverityLevel
 from phi_scan.models import ScanConfig, ScanFinding
-from phi_scan.plugin_api import BaseRecognizer, ScanContext
+from phi_scan.plugin_api import PLUGIN_API_VERSION, BaseRecognizer, ScanContext
 from phi_scan.plugin_api import ScanFinding as PluginScanFinding
 from phi_scan.plugin_loader import LoadedPlugin, PluginRegistry
 from phi_scan.plugin_runtime import _MAX_WARNINGS_PER_RECOGNIZER, execute_plugin_pass
@@ -42,7 +42,7 @@ class _AcmeRecognizer(BaseRecognizer):
 
     name = _ACME_RECOGNIZER_NAME
     entity_types = (_ACME_ENTITY_TYPE,)
-    plugin_api_version = "1.0"
+    plugin_api_version = PLUGIN_API_VERSION
     version = "0.1.0"
     description = "Test ACME employee ID recognizer."
 
@@ -63,7 +63,7 @@ class _AcmeRecognizer(BaseRecognizer):
 class _RaisingRecognizer(BaseRecognizer):
     name = "raising_recognizer"
     entity_types = ("RAISING_TEST",)
-    plugin_api_version = "1.0"
+    plugin_api_version = PLUGIN_API_VERSION
     version = _TEST_RECOGNIZER_VERSION
     description = _TEST_RECOGNIZER_DESCRIPTION
 
@@ -74,7 +74,7 @@ class _RaisingRecognizer(BaseRecognizer):
 class _OffsetOverrunRecognizer(BaseRecognizer):
     name = "offset_overrun"
     entity_types = ("OVERRUN_TEST",)
-    plugin_api_version = "1.0"
+    plugin_api_version = PLUGIN_API_VERSION
     version = _TEST_RECOGNIZER_VERSION
     description = _TEST_RECOGNIZER_DESCRIPTION
 
@@ -92,7 +92,7 @@ class _OffsetOverrunRecognizer(BaseRecognizer):
 class _UndeclaredEntityTypeRecognizer(BaseRecognizer):
     name = "undeclared_entity"
     entity_types = ("DECLARED_ONLY",)
-    plugin_api_version = "1.0"
+    plugin_api_version = PLUGIN_API_VERSION
     version = _TEST_RECOGNIZER_VERSION
     description = _TEST_RECOGNIZER_DESCRIPTION
 
@@ -228,7 +228,7 @@ def test_execute_plugin_pass_drops_non_list_return_value(
     class _ReturnsNoneRecognizer(BaseRecognizer):
         name = "returns_none"
         entity_types = ("NONE_TEST",)
-        plugin_api_version = "1.0"
+        plugin_api_version = PLUGIN_API_VERSION
 
         def detect(self, line: str, context: ScanContext) -> list[PluginScanFinding]:
             return None  # type: ignore[return-value]
@@ -248,7 +248,7 @@ def test_execute_plugin_pass_drops_list_entries_that_are_not_scan_findings(
     class _ReturnsWrongTypeRecognizer(BaseRecognizer):
         name = "returns_wrong_type"
         entity_types = ("WRONG_TYPE_TEST",)
-        plugin_api_version = "1.0"
+        plugin_api_version = PLUGIN_API_VERSION
 
         def detect(self, line: str, context: ScanContext) -> list[PluginScanFinding]:
             return ["not a scan finding"]  # type: ignore[list-item]

--- a/tests/test_plugin_runtime.py
+++ b/tests/test_plugin_runtime.py
@@ -28,8 +28,6 @@ _ACME_ENTITY_TYPE: str = "ACME_EMPLOYEE_ID"
 _ACME_RECOGNIZER_NAME: str = "acme_employee_id"
 _ACME_CONFIDENCE: float = 0.9
 _PLUGIN_SAMPLE_LINE: str = "employee_id = EMP-123456"
-_PLUGIN_SAMPLE_OFFSET_START: int = 15
-_PLUGIN_SAMPLE_OFFSET_END: int = 25
 
 
 class _AcmeRecognizer(BaseRecognizer):


### PR DESCRIPTION
## Summary
- Adds `phi_scan/plugin_runtime.py` — per-line plugin pass that runs after built-in detection. Findings flow through the existing filter/suppression/baseline/output pipeline.
- Per-line exception isolation, rate-limited warnings (5 per recognizer + summary), deterministic ordering, worker-parity validated.
- Plugin registry cached once per `execute_scan` invocation via `functools.cache` (no mutable module state).
- Adds `DetectionLayer.PLUGIN`, scorecard row A9 (Architecture 9/9, overall 36/36), and updates `phi-scan explain detection` to mention plugin recognizers.

## Test plan
- [x] 15 new tests in `tests/test_plugin_runtime.py` cover unit + scanner integration (host-computed fields, exception isolation, offset overrun, undeclared entity type, rate-limit, non-list/non-ScanFinding rejection, deterministic sort, loader-called-once, worker parity, confidence threshold).
- [x] Full suite: 1968 passed, 3 skipped.
- [x] `ruff check`, `ruff format`, `mypy` all clean.