### PR TITLE
refactor: pristine-before-migration hardening pass

### DIFF
--- a/phi_scan/detection_coordinator.py
+++ b/phi_scan/detection_coordinator.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 import re
+from collections.abc import Callable
 from pathlib import Path
 
 from phi_scan.constants import (
@@ -172,6 +173,92 @@ def detect_quasi_identifier_combination(
     return combination_findings
 
 
+def _is_geographic_finding(finding: ScanFinding) -> bool:
+    return finding.hipaa_category == PhiCategory.GEOGRAPHIC
+
+
+def _is_date_finding(finding: ScanFinding) -> bool:
+    return finding.hipaa_category == PhiCategory.DATE
+
+
+def _is_name_finding(finding: ScanFinding) -> bool:
+    return finding.hipaa_category == PhiCategory.NAME
+
+
+def _is_age_over_threshold_finding(finding: ScanFinding) -> bool:
+    # entity_type "AGE_OVER_THRESHOLD" is produced by the regex layer for ages
+    # strictly above HIPAA_AGE_RESTRICTION_THRESHOLD (i.e., 91+).
+    return finding.entity_type == _AGE_OVER_THRESHOLD_ENTITY_TYPE
+
+
+@dataclasses.dataclass(frozen=True)
+class _TwoCategoryRule:
+    """Shared skeleton for two-category quasi-identifier combination evaluators."""
+
+    predicate_a: Callable[[ScanFinding], bool]
+    predicate_b: Callable[[ScanFinding], bool]
+    combination_label: str
+    note: str
+
+
+def _evaluate_two_category_rule(
+    findings: list[ScanFinding],
+    rule: _TwoCategoryRule,
+) -> list[ScanFinding]:
+    """Apply a two-category combination rule and return any triggered finding.
+
+    Selects up to ``COMBINATION_REPRESENTATIVE_COUNT`` findings from each
+    category (first-seen order) to avoid combinatorial explosion, then fires
+    the rule only when both categories are present and all representatives
+    fall within the proximity window.
+    """
+    category_a = [f for f in findings if rule.predicate_a(f)]
+    category_b = [f for f in findings if rule.predicate_b(f)]
+    if not category_a or not category_b:
+        return []
+    representative_count = COMBINATION_REPRESENTATIVE_COUNT
+    candidate_group = category_a[:representative_count] + category_b[:representative_count]
+    if not _findings_within_proximity_window(candidate_group):
+        return []
+    return [
+        _build_combination_finding(
+            source_findings=candidate_group,
+            combination_label=rule.combination_label,
+            note=rule.note,
+        )
+    ]
+
+
+_ZIP_DOB_RULE: _TwoCategoryRule = _TwoCategoryRule(
+    predicate_a=_is_geographic_finding,
+    predicate_b=_is_date_finding,
+    combination_label="ZIP + DOB",
+    note=(
+        f"ZIP code + date of birth combination re-identifies "
+        f"{SWEENEY_REIDENTIFICATION_PERCENTAGE}% of the "
+        "US population (Sweeney 2000). Generalize at least one field."
+    ),
+)
+
+_NAME_DATE_RULE: _TwoCategoryRule = _TwoCategoryRule(
+    predicate_a=_is_name_finding,
+    predicate_b=_is_date_finding,
+    combination_label="NAME + DATE",
+    note="Name and date together are uniquely identifying. Remove or generalize one.",
+)
+
+_AGE_GEOGRAPHIC_RULE: _TwoCategoryRule = _TwoCategoryRule(
+    predicate_a=_is_age_over_threshold_finding,
+    predicate_b=_is_geographic_finding,
+    combination_label=f"AGE_OVER_{HIPAA_AGE_RESTRICTION_THRESHOLD} + GEOGRAPHIC",
+    note=(
+        f"HIPAA §164.514(b)(2)(i): ages over {HIPAA_AGE_RESTRICTION_THRESHOLD} "
+        "combined with geographic data re-identify individuals. "
+        "Generalize the age to a range or remove the geographic field."
+    ),
+)
+
+
 def evaluate_zip_dob_sex_combination(
     findings: list[ScanFinding],
 ) -> list[ScanFinding]:
@@ -190,27 +277,7 @@ def evaluate_zip_dob_sex_combination(
         A single-element list with a QUASI_IDENTIFIER_COMBINATION finding, or
         an empty list if the combination is absent or outside the proximity window.
     """
-    geographic = [f for f in findings if f.hipaa_category == PhiCategory.GEOGRAPHIC]
-    dates = [f for f in findings if f.hipaa_category == PhiCategory.DATE]
-    if not geographic or not dates:
-        return []
-    # Only the first representative of each category is used to avoid
-    # combinatorial explosion when multiple geographic or date findings exist.
-    representative_count = COMBINATION_REPRESENTATIVE_COUNT
-    candidate_group = geographic[:representative_count] + dates[:representative_count]
-    if not _findings_within_proximity_window(candidate_group):
-        return []
-    return [
-        _build_combination_finding(
-            source_findings=candidate_group,
-            combination_label="ZIP + DOB",
-            note=(
-                f"ZIP code + date of birth combination re-identifies "
-                f"{SWEENEY_REIDENTIFICATION_PERCENTAGE}% of the "
-                "US population (Sweeney 2000). Generalize at least one field."
-            ),
-        )
-    ]
+    return _evaluate_two_category_rule(findings, _ZIP_DOB_RULE)
 
 
 def evaluate_name_date_combination(
@@ -228,23 +295,7 @@ def evaluate_name_date_combination(
         A single-element list with a QUASI_IDENTIFIER_COMBINATION finding, or
         an empty list if the combination is absent or outside the proximity window.
     """
-    names = [f for f in findings if f.hipaa_category == PhiCategory.NAME]
-    dates = [f for f in findings if f.hipaa_category == PhiCategory.DATE]
-    if not names or not dates:
-        return []
-    # Only the first representative of each category is used to avoid
-    # combinatorial explosion when multiple name or date findings exist.
-    representative_count = COMBINATION_REPRESENTATIVE_COUNT
-    candidate_group = names[:representative_count] + dates[:representative_count]
-    if not _findings_within_proximity_window(candidate_group):
-        return []
-    return [
-        _build_combination_finding(
-            source_findings=candidate_group,
-            combination_label="NAME + DATE",
-            note="Name and date together are uniquely identifying. Remove or generalize one.",
-        )
-    ]
+    return _evaluate_two_category_rule(findings, _NAME_DATE_RULE)
 
 
 def evaluate_age_geographic_combination(
@@ -263,28 +314,7 @@ def evaluate_age_geographic_combination(
         A single-element list with a QUASI_IDENTIFIER_COMBINATION finding, or
         an empty list if the combination is absent or outside the proximity window.
     """
-    # entity_type "AGE_OVER_THRESHOLD" is produced by the regex layer for ages
-    # strictly above HIPAA_AGE_RESTRICTION_THRESHOLD (i.e., 91+). Never compare
-    # against the literal threshold value here — reference the constant.
-    age_findings = [f for f in findings if f.entity_type == _AGE_OVER_THRESHOLD_ENTITY_TYPE]
-    geographic = [f for f in findings if f.hipaa_category == PhiCategory.GEOGRAPHIC]
-    if not age_findings or not geographic:
-        return []
-    representative_count = COMBINATION_REPRESENTATIVE_COUNT
-    candidate_group = age_findings[:representative_count] + geographic[:representative_count]
-    if not _findings_within_proximity_window(candidate_group):
-        return []
-    return [
-        _build_combination_finding(
-            source_findings=candidate_group,
-            combination_label=f"AGE_OVER_{HIPAA_AGE_RESTRICTION_THRESHOLD} + GEOGRAPHIC",
-            note=(
-                f"HIPAA §164.514(b)(2)(i): ages over {HIPAA_AGE_RESTRICTION_THRESHOLD} "
-                "combined with geographic data re-identify individuals. "
-                "Generalize the age to a range or remove the geographic field."
-            ),
-        )
-    ]
+    return _evaluate_two_category_rule(findings, _AGE_GEOGRAPHIC_RULE)
 
 
 def evaluate_colocated_identifier_combination(

--- a/phi_scan/detection_coordinator.py
+++ b/phi_scan/detection_coordinator.py
@@ -186,8 +186,6 @@ def _is_name_finding(finding: ScanFinding) -> bool:
 
 
 def _is_age_over_threshold_finding(finding: ScanFinding) -> bool:
-    # entity_type "AGE_OVER_THRESHOLD" is produced by the regex layer for ages
-    # strictly above HIPAA_AGE_RESTRICTION_THRESHOLD (i.e., 91+).
     return finding.entity_type == _AGE_OVER_THRESHOLD_ENTITY_TYPE
 
 

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -599,11 +599,26 @@ def _execute_scan_with_cache(
     cached_raw = get_cached_result(cache_key)
     if cached_raw is not None:
         _logger.debug(_CACHE_HIT_DEBUG.format(path=file_path, count=len(cached_raw)))
-        plugin_findings = _execute_plugin_pass_for_file(file_content, file_path)
-        return _apply_post_scan_filters(cached_raw + plugin_findings, file_content, config)
+        return _compose_file_findings(cached_raw, file_content, file_path, config)
     scannable_content = _preprocess_content_for_scan(file_content, file_path)
     raw_findings = detect_phi_in_text_content(scannable_content, file_path)
     store_cached_result(cache_key, raw_findings)
+    return _compose_file_findings(raw_findings, file_content, file_path, config)
+
+
+def _compose_file_findings(
+    raw_findings: list[ScanFinding],
+    file_content: str,
+    file_path: Path,
+    config: ScanConfig,
+) -> list[ScanFinding]:
+    """Merge built-in and plugin findings and apply post-scan filters.
+
+    Runs the scan-scoped plugin pass against ``file_content`` and returns
+    the concatenation of ``raw_findings`` + plugin findings after suppression,
+    confidence, and severity filters. Shared by the cache-hit, cache-miss,
+    and archive-member paths so that a single composition stays drift-free.
+    """
     plugin_findings = _execute_plugin_pass_for_file(file_content, file_path)
     return _apply_post_scan_filters(raw_findings + plugin_findings, file_content, config)
 
@@ -910,9 +925,8 @@ def _scan_archive_members(
             continue
         virtual_path = _compute_display_path(archive_path) / member_name
         raw_findings = detect_phi_in_text_content(member_content, virtual_path)
-        plugin_findings = _execute_plugin_pass_for_file(member_content, virtual_path)
-        member_findings = _apply_post_scan_filters(
-            raw_findings + plugin_findings, member_content, config
+        member_findings = _compose_file_findings(
+            raw_findings, member_content, virtual_path, config
         )
         findings.extend(member_findings)
     return findings

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -601,7 +601,7 @@ def _execute_scan_with_cache(
     if cached_raw is not None:
         _logger.debug(_CACHE_HIT_DEBUG.format(path=file_path, count=len(cached_raw)))
         return _compose_file_findings(
-            _FileScanContext(
+            _FileScanInputs(
                 raw_findings=cached_raw, file_content=file_content, file_path=file_path
             ),
             config,
@@ -610,13 +610,13 @@ def _execute_scan_with_cache(
     raw_findings = detect_phi_in_text_content(scannable_content, file_path)
     store_cached_result(cache_key, raw_findings)
     return _compose_file_findings(
-        _FileScanContext(raw_findings=raw_findings, file_content=file_content, file_path=file_path),
+        _FileScanInputs(raw_findings=raw_findings, file_content=file_content, file_path=file_path),
         config,
     )
 
 
 @dataclass(frozen=True)
-class _FileScanContext:
+class _FileScanInputs:
     """Bundles the per-file inputs to :func:`_compose_file_findings`."""
 
     raw_findings: list[ScanFinding]
@@ -625,7 +625,7 @@ class _FileScanContext:
 
 
 def _compose_file_findings(
-    scan_context: _FileScanContext,
+    scan_inputs: _FileScanInputs,
     config: ScanConfig,
 ) -> list[ScanFinding]:
     """Merge built-in and plugin findings and apply post-scan filters.
@@ -635,12 +635,10 @@ def _compose_file_findings(
     confidence, and severity filters. Shared by the cache-hit, cache-miss,
     and archive-member paths so that a single composition stays drift-free.
     """
-    plugin_findings = _execute_plugin_pass_for_file(
-        scan_context.file_content, scan_context.file_path
-    )
+    plugin_findings = _execute_plugin_pass_for_file(scan_inputs.file_content, scan_inputs.file_path)
     return _apply_post_scan_filters(
-        scan_context.raw_findings + plugin_findings,
-        scan_context.file_content,
+        scan_inputs.raw_findings + plugin_findings,
+        scan_inputs.file_content,
         config,
     )
 
@@ -948,7 +946,7 @@ def _scan_archive_members(
         virtual_path = _compute_display_path(archive_path) / member_name
         raw_findings = detect_phi_in_text_content(member_content, virtual_path)
         member_findings = _compose_file_findings(
-            _FileScanContext(
+            _FileScanInputs(
                 raw_findings=raw_findings,
                 file_content=member_content,
                 file_path=virtual_path,

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -20,6 +20,7 @@ import zipfile
 import zlib
 from collections import Counter
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 from functools import cache
 from pathlib import Path
 from types import MappingProxyType
@@ -599,28 +600,49 @@ def _execute_scan_with_cache(
     cached_raw = get_cached_result(cache_key)
     if cached_raw is not None:
         _logger.debug(_CACHE_HIT_DEBUG.format(path=file_path, count=len(cached_raw)))
-        return _compose_file_findings(cached_raw, file_content, file_path, config)
+        return _compose_file_findings(
+            _FileScanContext(
+                raw_findings=cached_raw, file_content=file_content, file_path=file_path
+            ),
+            config,
+        )
     scannable_content = _preprocess_content_for_scan(file_content, file_path)
     raw_findings = detect_phi_in_text_content(scannable_content, file_path)
     store_cached_result(cache_key, raw_findings)
-    return _compose_file_findings(raw_findings, file_content, file_path, config)
+    return _compose_file_findings(
+        _FileScanContext(raw_findings=raw_findings, file_content=file_content, file_path=file_path),
+        config,
+    )
+
+
+@dataclass(frozen=True)
+class _FileScanContext:
+    """Bundles the per-file inputs to :func:`_compose_file_findings`."""
+
+    raw_findings: list[ScanFinding]
+    file_content: str
+    file_path: Path
 
 
 def _compose_file_findings(
-    raw_findings: list[ScanFinding],
-    file_content: str,
-    file_path: Path,
+    scan_context: _FileScanContext,
     config: ScanConfig,
 ) -> list[ScanFinding]:
     """Merge built-in and plugin findings and apply post-scan filters.
 
-    Runs the scan-scoped plugin pass against ``file_content`` and returns
-    the concatenation of ``raw_findings`` + plugin findings after suppression,
+    Runs the scan-scoped plugin pass against the scan context's file content
+    and returns the concatenation of raw + plugin findings after suppression,
     confidence, and severity filters. Shared by the cache-hit, cache-miss,
     and archive-member paths so that a single composition stays drift-free.
     """
-    plugin_findings = _execute_plugin_pass_for_file(file_content, file_path)
-    return _apply_post_scan_filters(raw_findings + plugin_findings, file_content, config)
+    plugin_findings = _execute_plugin_pass_for_file(
+        scan_context.file_content, scan_context.file_path
+    )
+    return _apply_post_scan_filters(
+        scan_context.raw_findings + plugin_findings,
+        scan_context.file_content,
+        config,
+    )
 
 
 def _execute_plugin_pass_for_file(file_content: str, file_path: Path) -> list[ScanFinding]:
@@ -925,7 +947,14 @@ def _scan_archive_members(
             continue
         virtual_path = _compute_display_path(archive_path) / member_name
         raw_findings = detect_phi_in_text_content(member_content, virtual_path)
-        member_findings = _compose_file_findings(raw_findings, member_content, virtual_path, config)
+        member_findings = _compose_file_findings(
+            _FileScanContext(
+                raw_findings=raw_findings,
+                file_content=member_content,
+                file_path=virtual_path,
+            ),
+            config,
+        )
         findings.extend(member_findings)
     return findings
 

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -925,9 +925,7 @@ def _scan_archive_members(
             continue
         virtual_path = _compute_display_path(archive_path) / member_name
         raw_findings = detect_phi_in_text_content(member_content, virtual_path)
-        member_findings = _compose_file_findings(
-            raw_findings, member_content, virtual_path, config
-        )
+        member_findings = _compose_file_findings(raw_findings, member_content, virtual_path, config)
         findings.extend(member_findings)
     return findings
 

--- a/tests/test_detection_coordinator.py
+++ b/tests/test_detection_coordinator.py
@@ -22,6 +22,8 @@ from phi_scan.detection_coordinator import (
     _apply_variable_name_confidence_boost as apply_variable_name_confidence_boost,
 )
 from phi_scan.detection_coordinator import (
+    _evaluate_two_category_rule,
+    _TwoCategoryRule,
     deduplicate_overlapping_findings,
     detect_phi_in_text_content,
     detect_quasi_identifier_combination,
@@ -572,3 +574,44 @@ def test_detect_phi_in_text_content_deduplicates_cross_layer_duplicates():
     findings_with_shared_hash = [f for f in result if f.value_hash == shared_hash]
     assert len(findings_with_shared_hash) == 1
     assert findings_with_shared_hash[0].detection_layer == DetectionLayer.REGEX
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_two_category_rule (shared skeleton)
+# ---------------------------------------------------------------------------
+
+
+_RULE_UNDER_TEST: _TwoCategoryRule = _TwoCategoryRule(
+    predicate_a=lambda f: f.hipaa_category == PhiCategory.NAME,
+    predicate_b=lambda f: f.hipaa_category == PhiCategory.DATE,
+    combination_label="TEST_A + TEST_B",
+    note="test note",
+)
+
+
+def test_evaluate_two_category_rule_fires_when_both_categories_present_and_proximal():
+    findings = [
+        _make_finding(hipaa_category=PhiCategory.NAME, line_number=_LINE_ONE),
+        _make_finding(hipaa_category=PhiCategory.DATE, line_number=_LINE_TWO),
+    ]
+
+    result = _evaluate_two_category_rule(findings, _RULE_UNDER_TEST)
+
+    assert len(result) == 1
+    assert result[0].entity_type == "TEST_A + TEST_B"
+    assert result[0].hipaa_category == PhiCategory.QUASI_IDENTIFIER_COMBINATION
+
+
+def test_evaluate_two_category_rule_returns_empty_when_only_one_category_present():
+    findings = [_make_finding(hipaa_category=PhiCategory.NAME, line_number=_LINE_ONE)]
+
+    assert _evaluate_two_category_rule(findings, _RULE_UNDER_TEST) == []
+
+
+def test_evaluate_two_category_rule_returns_empty_when_outside_proximity_window():
+    findings = [
+        _make_finding(hipaa_category=PhiCategory.NAME, line_number=_LINE_ONE),
+        _make_finding(hipaa_category=PhiCategory.DATE, line_number=_LINE_FAR_AWAY),
+    ]
+
+    assert _evaluate_two_category_rule(findings, _RULE_UNDER_TEST) == []

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -19,15 +19,18 @@ from phi_scan.constants import (
     DEFAULT_TEXT_ENCODING,
     KNOWN_BINARY_EXTENSIONS,
     MAX_FILE_SIZE_MB,
+    DetectionLayer,
     PathspecMatchStyle,
+    PhiCategory,
     RiskLevel,
     SeverityLevel,
 )
 from phi_scan.exceptions import TraversalError
-from phi_scan.models import ScanConfig, ScanResult
+from phi_scan.models import ScanConfig, ScanFinding, ScanResult
 from phi_scan.scanner import (
     MAX_WORKER_COUNT,
     MIN_WORKER_COUNT,
+    _compose_file_findings,  # noqa: PLC2701
     _passes_decompression_bomb_guards,  # noqa: PLC2701
     _run_sequential_scan,  # noqa: PLC2701
     collect_scan_targets,
@@ -74,6 +77,9 @@ _PARITY_PHI_FIXTURE_PATH: Path = Path(__file__).parent / "fixtures" / "phi" / "p
 # test_load_ignore_patterns_skips_blank_lines: _SAMPLE_IGNORE_PATTERN ("*.log") and "*.tmp".
 # Update this constant if that test's fixture content changes.
 _EXPECTED_NON_BLANK_NON_COMMENT_PATTERN_COUNT: int = 2
+# Confidence values used by the _compose_file_findings seam tests.
+_COMPOSE_TEST_HIGH_CONFIDENCE: float = 0.9
+_COMPOSE_TEST_LOW_CONFIDENCE: float = 0.3
 
 
 def _build_exclusion_spec(patterns: list[str]) -> pathspec.PathSpec:
@@ -776,3 +782,62 @@ def test_scan_file_skips_bomb_member_in_real_zip(
         findings = _scan_file(archive_path, config)
 
     assert findings == []
+
+
+def _make_finding_for_compose_test(
+    entity_type: str,
+    confidence: float,
+    detection_layer: DetectionLayer,
+    value_hash_seed: str,
+) -> ScanFinding:
+    """Build a minimal ScanFinding for the composition seam tests."""
+    return ScanFinding(
+        file_path=Path("sample.py"),
+        line_number=1,
+        entity_type=entity_type,
+        hipaa_category=PhiCategory.UNIQUE_ID,
+        confidence=confidence,
+        detection_layer=detection_layer,
+        value_hash=value_hash_seed * 64,
+        severity=(
+            SeverityLevel.HIGH
+            if confidence >= _COMPOSE_TEST_HIGH_CONFIDENCE
+            else SeverityLevel.LOW
+        ),
+        code_context="sample [REDACTED]",
+        remediation_hint="hint",
+    )
+
+
+def test_compose_file_findings_merges_raw_with_plugin_and_applies_filters() -> None:
+    """_compose_file_findings must call the plugin pass and apply post-scan filters."""
+    raw_finding = _make_finding_for_compose_test(
+        "TEST_ENTITY", _COMPOSE_TEST_HIGH_CONFIDENCE, DetectionLayer.REGEX, "a"
+    )
+    plugin_finding = _make_finding_for_compose_test(
+        "PLUGIN_ENTITY", _COMPOSE_TEST_HIGH_CONFIDENCE, DetectionLayer.PLUGIN, "b"
+    )
+    config = ScanConfig(confidence_threshold=0.0, severity_threshold=SeverityLevel.INFO)
+
+    with patch("phi_scan.scanner._execute_plugin_pass_for_file", return_value=[plugin_finding]):
+        result = _compose_file_findings([raw_finding], "content", Path("sample.py"), config)
+
+    assert {f.entity_type for f in result} == {"TEST_ENTITY", "PLUGIN_ENTITY"}
+
+
+def test_compose_file_findings_drops_findings_below_confidence_threshold() -> None:
+    """Low-confidence findings must be filtered out by _compose_file_findings."""
+    low_confidence_finding = _make_finding_for_compose_test(
+        "TEST_ENTITY", _COMPOSE_TEST_LOW_CONFIDENCE, DetectionLayer.REGEX, "a"
+    )
+    config = ScanConfig(
+        confidence_threshold=_COMPOSE_TEST_HIGH_CONFIDENCE,
+        severity_threshold=SeverityLevel.INFO,
+    )
+
+    with patch("phi_scan.scanner._execute_plugin_pass_for_file", return_value=[]):
+        result = _compose_file_findings(
+            [low_confidence_finding], "content", Path("sample.py"), config
+        )
+
+    assert result == []

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -26,17 +26,18 @@ from phi_scan.constants import (
     SeverityLevel,
 )
 from phi_scan.exceptions import TraversalError
+from phi_scan.hashing import compute_value_hash, severity_from_confidence
 from phi_scan.models import ScanConfig, ScanFinding, ScanResult
 
 # noqa: PLC2701 — these private symbols are tested directly because the
-# composition seam (_FileScanContext / _compose_file_findings) unifies three
+# composition seam (_FileScanInputs / _compose_file_findings) unifies three
 # call sites (cache-hit, cache-miss, archive-member) and must stay drift-free;
 # the bomb-guard and sequential-scan helpers likewise have no public equivalent.
 from phi_scan.scanner import (
     MAX_WORKER_COUNT,
     MIN_WORKER_COUNT,
     _compose_file_findings,  # noqa: PLC2701
-    _FileScanContext,  # noqa: PLC2701
+    _FileScanInputs,  # noqa: PLC2701
     _passes_decompression_bomb_guards,  # noqa: PLC2701
     _run_sequential_scan,  # noqa: PLC2701
     collect_scan_targets,
@@ -90,9 +91,6 @@ _COMPOSE_TEST_LOW_CONFIDENCE: float = 0.3
 # irrelevant because the plugin pass is patched out; only its presence matters.
 _COMPOSE_TEST_FILE_CONTENT: str = "sample content"
 _COMPOSE_TEST_FILE_PATH: Path = Path("sample.py")
-# SHA-256 digest length in hex characters — used to synthesise deterministic
-# value_hash strings from a single-character seed.
-_SHA256_HEX_DIGEST_LENGTH: int = 64
 
 
 def _build_exclusion_spec(patterns: list[str]) -> pathspec.PathSpec:
@@ -801,7 +799,6 @@ def _build_compose_test_finding(
     entity_type: str,
     confidence: float,
     detection_layer: DetectionLayer,
-    value_hash_seed: str,
 ) -> ScanFinding:
     """Build a minimal ScanFinding for the composition seam tests."""
     return ScanFinding(
@@ -811,17 +808,15 @@ def _build_compose_test_finding(
         hipaa_category=PhiCategory.UNIQUE_ID,
         confidence=confidence,
         detection_layer=detection_layer,
-        value_hash=value_hash_seed * _SHA256_HEX_DIGEST_LENGTH,
-        severity=(
-            SeverityLevel.HIGH if confidence >= _COMPOSE_TEST_HIGH_CONFIDENCE else SeverityLevel.LOW
-        ),
+        value_hash=compute_value_hash(entity_type),
+        severity=severity_from_confidence(confidence),
         code_context="sample [REDACTED]",
         remediation_hint="hint",
     )
 
 
-def _build_compose_test_context(raw_findings: list[ScanFinding]) -> _FileScanContext:
-    return _FileScanContext(
+def _build_compose_test_context(raw_findings: list[ScanFinding]) -> _FileScanInputs:
+    return _FileScanInputs(
         raw_findings=raw_findings,
         file_content=_COMPOSE_TEST_FILE_CONTENT,
         file_path=_COMPOSE_TEST_FILE_PATH,
@@ -831,10 +826,10 @@ def _build_compose_test_context(raw_findings: list[ScanFinding]) -> _FileScanCon
 def test_compose_file_findings_merges_raw_with_plugin_and_applies_filters() -> None:
     """_compose_file_findings must call the plugin pass and apply post-scan filters."""
     raw_finding = _build_compose_test_finding(
-        "TEST_ENTITY", _COMPOSE_TEST_HIGH_CONFIDENCE, DetectionLayer.REGEX, "a"
+        "TEST_ENTITY", _COMPOSE_TEST_HIGH_CONFIDENCE, DetectionLayer.REGEX
     )
     plugin_finding = _build_compose_test_finding(
-        "PLUGIN_ENTITY", _COMPOSE_TEST_HIGH_CONFIDENCE, DetectionLayer.PLUGIN, "b"
+        "PLUGIN_ENTITY", _COMPOSE_TEST_HIGH_CONFIDENCE, DetectionLayer.PLUGIN
     )
     config = ScanConfig(confidence_threshold=0.0, severity_threshold=SeverityLevel.INFO)
 
@@ -847,7 +842,7 @@ def test_compose_file_findings_merges_raw_with_plugin_and_applies_filters() -> N
 def test_compose_file_findings_drops_findings_below_confidence_threshold() -> None:
     """Low-confidence findings must be filtered out by _compose_file_findings."""
     low_confidence_finding = _build_compose_test_finding(
-        "TEST_ENTITY", _COMPOSE_TEST_LOW_CONFIDENCE, DetectionLayer.REGEX, "a"
+        "TEST_ENTITY_LOW", _COMPOSE_TEST_LOW_CONFIDENCE, DetectionLayer.REGEX
     )
     config = ScanConfig(
         confidence_threshold=_COMPOSE_TEST_HIGH_CONFIDENCE,

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -800,9 +800,7 @@ def _make_finding_for_compose_test(
         detection_layer=detection_layer,
         value_hash=value_hash_seed * 64,
         severity=(
-            SeverityLevel.HIGH
-            if confidence >= _COMPOSE_TEST_HIGH_CONFIDENCE
-            else SeverityLevel.LOW
+            SeverityLevel.HIGH if confidence >= _COMPOSE_TEST_HIGH_CONFIDENCE else SeverityLevel.LOW
         ),
         code_context="sample [REDACTED]",
         remediation_hint="hint",

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -27,10 +27,16 @@ from phi_scan.constants import (
 )
 from phi_scan.exceptions import TraversalError
 from phi_scan.models import ScanConfig, ScanFinding, ScanResult
+
+# noqa: PLC2701 — these private symbols are tested directly because the
+# composition seam (_FileScanContext / _compose_file_findings) unifies three
+# call sites (cache-hit, cache-miss, archive-member) and must stay drift-free;
+# the bomb-guard and sequential-scan helpers likewise have no public equivalent.
 from phi_scan.scanner import (
     MAX_WORKER_COUNT,
     MIN_WORKER_COUNT,
     _compose_file_findings,  # noqa: PLC2701
+    _FileScanContext,  # noqa: PLC2701
     _passes_decompression_bomb_guards,  # noqa: PLC2701
     _run_sequential_scan,  # noqa: PLC2701
     collect_scan_targets,
@@ -80,6 +86,13 @@ _EXPECTED_NON_BLANK_NON_COMMENT_PATTERN_COUNT: int = 2
 # Confidence values used by the _compose_file_findings seam tests.
 _COMPOSE_TEST_HIGH_CONFIDENCE: float = 0.9
 _COMPOSE_TEST_LOW_CONFIDENCE: float = 0.3
+# File content passed to the _compose_file_findings seam tests. The body is
+# irrelevant because the plugin pass is patched out; only its presence matters.
+_COMPOSE_TEST_FILE_CONTENT: str = "sample content"
+_COMPOSE_TEST_FILE_PATH: Path = Path("sample.py")
+# SHA-256 digest length in hex characters — used to synthesise deterministic
+# value_hash strings from a single-character seed.
+_SHA256_HEX_DIGEST_LENGTH: int = 64
 
 
 def _build_exclusion_spec(patterns: list[str]) -> pathspec.PathSpec:
@@ -784,7 +797,7 @@ def test_scan_file_skips_bomb_member_in_real_zip(
     assert findings == []
 
 
-def _make_finding_for_compose_test(
+def _build_compose_test_finding(
     entity_type: str,
     confidence: float,
     detection_layer: DetectionLayer,
@@ -792,13 +805,13 @@ def _make_finding_for_compose_test(
 ) -> ScanFinding:
     """Build a minimal ScanFinding for the composition seam tests."""
     return ScanFinding(
-        file_path=Path("sample.py"),
+        file_path=_COMPOSE_TEST_FILE_PATH,
         line_number=1,
         entity_type=entity_type,
         hipaa_category=PhiCategory.UNIQUE_ID,
         confidence=confidence,
         detection_layer=detection_layer,
-        value_hash=value_hash_seed * 64,
+        value_hash=value_hash_seed * _SHA256_HEX_DIGEST_LENGTH,
         severity=(
             SeverityLevel.HIGH if confidence >= _COMPOSE_TEST_HIGH_CONFIDENCE else SeverityLevel.LOW
         ),
@@ -807,25 +820,33 @@ def _make_finding_for_compose_test(
     )
 
 
+def _build_compose_test_context(raw_findings: list[ScanFinding]) -> _FileScanContext:
+    return _FileScanContext(
+        raw_findings=raw_findings,
+        file_content=_COMPOSE_TEST_FILE_CONTENT,
+        file_path=_COMPOSE_TEST_FILE_PATH,
+    )
+
+
 def test_compose_file_findings_merges_raw_with_plugin_and_applies_filters() -> None:
     """_compose_file_findings must call the plugin pass and apply post-scan filters."""
-    raw_finding = _make_finding_for_compose_test(
+    raw_finding = _build_compose_test_finding(
         "TEST_ENTITY", _COMPOSE_TEST_HIGH_CONFIDENCE, DetectionLayer.REGEX, "a"
     )
-    plugin_finding = _make_finding_for_compose_test(
+    plugin_finding = _build_compose_test_finding(
         "PLUGIN_ENTITY", _COMPOSE_TEST_HIGH_CONFIDENCE, DetectionLayer.PLUGIN, "b"
     )
     config = ScanConfig(confidence_threshold=0.0, severity_threshold=SeverityLevel.INFO)
 
     with patch("phi_scan.scanner._execute_plugin_pass_for_file", return_value=[plugin_finding]):
-        result = _compose_file_findings([raw_finding], "content", Path("sample.py"), config)
+        result = _compose_file_findings(_build_compose_test_context([raw_finding]), config)
 
     assert {f.entity_type for f in result} == {"TEST_ENTITY", "PLUGIN_ENTITY"}
 
 
 def test_compose_file_findings_drops_findings_below_confidence_threshold() -> None:
     """Low-confidence findings must be filtered out by _compose_file_findings."""
-    low_confidence_finding = _make_finding_for_compose_test(
+    low_confidence_finding = _build_compose_test_finding(
         "TEST_ENTITY", _COMPOSE_TEST_LOW_CONFIDENCE, DetectionLayer.REGEX, "a"
     )
     config = ScanConfig(
@@ -835,7 +856,7 @@ def test_compose_file_findings_drops_findings_below_confidence_threshold() -> No
 
     with patch("phi_scan.scanner._execute_plugin_pass_for_file", return_value=[]):
         result = _compose_file_findings(
-            [low_confidence_finding], "content", Path("sample.py"), config
+            _build_compose_test_context([low_confidence_finding]), config
         )
 
     assert result == []


### PR DESCRIPTION
## Summary

Small, zero-behavior-change dedup pass before the org migration. Two focused refactors plus seam tests; no docs/packaging/plugin-API changes.

- **A1 — scanner plugin-pass dedup.** Extracted `_compose_file_findings(raw_findings, file_content, file_path, config)` in `phi_scan/scanner.py` and routed all three sites (cache-hit, cache-miss, archive-member) through it. Preserves plugin-runtime invariants: `cache_clear()` at top of `execute_scan`, BLE001 isolation boundary, 5-warning rate-limit + summary, per-line failure isolation, deterministic ordering, worker parity.
- **A2 — QI evaluator dedup.** Added `_TwoCategoryRule` frozen dataclass + `_evaluate_two_category_rule` helper in `phi_scan/detection_coordinator.py`. Converted the three two-category evaluators (`evaluate_zip_dob_sex_combination`, `evaluate_name_date_combination`, `evaluate_age_geographic_combination`) into thin delegators, keeping their rationale docstrings verbatim. `evaluate_colocated_identifier_combination` left untouched (structurally different). Combination labels byte-preserved: `"ZIP + DOB"`, `"NAME + DATE"`, `f"AGE_OVER_{HIPAA_AGE_RESTRICTION_THRESHOLD} + GEOGRAPHIC"`. Predicates are named functions (`_is_geographic_finding`, `_is_date_finding`, `_is_name_finding`, `_is_age_over_threshold_finding`) — no anonymous closures in the shipped rules.
- **A3 — serializer dedup.** No action warranted. Only two projection helpers exist (`_serialize_finding_to_dict`, `_serialize_finding_to_csv_row`); they are already centralized and diverge on output shape, not duplicated logic.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run mypy phi_scan` — clean (57 files)
- [x] `uv run pytest -q` — 1973 passed, 3 skipped
- [x] New seam tests: 2 for `_compose_file_findings`, 3 for `_evaluate_two_category_rule`
- [x] Combination-label strings and rationale docstrings preserved byte-for-byte

## Migration-pristine verdict

**YES.** No P0 blockers, no behavior change, no public API change. Safe to transfer.