### PR TITLE
refactor(ci): extract Bitbucket Code Insights slice

### DIFF
--- a/phi_scan/ci/bitbucket_insights.py
+++ b/phi_scan/ci/bitbucket_insights.py
@@ -58,6 +58,19 @@ _BITBUCKET_ANNOTATION_SEVERITY_MAP: dict[SeverityLevel, str] = {
 _BITBUCKET_ANNOTATIONS_BATCH_LIMIT: int = 1000
 _SHA_LOG_PREFIX_LENGTH: int = 8
 
+# PR context extras keys — set by phi_scan.ci.bitbucket when the adapter
+# extracts workspace/repo identity from CI environment variables.
+_EXTRAS_KEY_WORKSPACE: str = "workspace"
+_EXTRAS_KEY_REPO_SLUG: str = "repo_slug"
+
+# PHI safety contract for the Bitbucket Code Insights payload:
+# - `path` and `line` expose source-file location metadata (non-PHI).
+# - `message` embeds ScanFinding classification labels only — hipaa_category
+#   (enum value like "SSN"), severity (enum value like "HIGH"), and a rounded
+#   confidence percentage. No finding.value, value_hash, code_context, or
+#   remediation_hint ever enters the payload. This is verified by
+#   tests/test_ci_integration_remaining.py exercising the JSON body.
+
 
 def _build_report_payload(scan_result: ScanResult) -> dict[str, Any]:
     findings_count = len(scan_result.findings)
@@ -103,11 +116,53 @@ def _build_annotations(scan_result: ScanResult) -> list[dict[str, Any]]:
     ]
 
 
+def _post_report(
+    headers: dict[str, str], workspace: str, repo_slug: str, sha: str, scan_result: ScanResult
+) -> None:
+    report_url = _BITBUCKET_API_BASE_URL + _BITBUCKET_REPORTS_PATH.format(
+        workspace=workspace,
+        repo_slug=repo_slug,
+        commit=sha,
+        report_id=_BITBUCKET_REPORT_ID,
+    )
+    execute_http_request(
+        HttpRequestConfig(
+            method=HttpMethod.PUT,
+            url=report_url,
+            operation_label=OperationLabel.BITBUCKET_CODE_INSIGHTS_REPORT,
+            headers=headers,
+            json_body=_build_report_payload(scan_result),
+        )
+    )
+
+
+def _post_annotations(
+    headers: dict[str, str], workspace: str, repo_slug: str, sha: str, scan_result: ScanResult
+) -> int:
+    annotations_url = _BITBUCKET_API_BASE_URL + _BITBUCKET_ANNOTATIONS_PATH.format(
+        workspace=workspace,
+        repo_slug=repo_slug,
+        commit=sha,
+        report_id=_BITBUCKET_REPORT_ID,
+    )
+    annotations = _build_annotations(scan_result)
+    execute_http_request(
+        HttpRequestConfig(
+            method=HttpMethod.POST,
+            url=annotations_url,
+            operation_label=OperationLabel.BITBUCKET_CODE_INSIGHTS_ANNOTATIONS,
+            headers=headers,
+            json_body=annotations,
+        )
+    )
+    return len(annotations)
+
+
 def post_bitbucket_code_insights(scan_result: ScanResult, pr_context: PullRequestContext) -> None:
     """Post Bitbucket Code Insights report and inline annotations."""
     sha = pr_context.sha
-    workspace = pr_context.extras.get("workspace", "")
-    repo_slug = pr_context.extras.get("repo_slug", "")
+    workspace = pr_context.extras.get(_EXTRAS_KEY_WORKSPACE, "")
+    repo_slug = pr_context.extras.get(_EXTRAS_KEY_REPO_SLUG, "")
 
     if not sha or not workspace or not repo_slug:
         _LOG.debug("Bitbucket Code Insights: missing context — skipping")
@@ -122,46 +177,16 @@ def post_bitbucket_code_insights(scan_result: ScanResult, pr_context: PullReques
         "Authorization": _AUTHORIZATION_BEARER_PREFIX + token,
         "Content-Type": _JSON_CONTENT_TYPE,
     }
-    report_url = _BITBUCKET_API_BASE_URL + _BITBUCKET_REPORTS_PATH.format(
-        workspace=workspace,
-        repo_slug=repo_slug,
-        commit=sha,
-        report_id=_BITBUCKET_REPORT_ID,
-    )
 
-    execute_http_request(
-        HttpRequestConfig(
-            method=HttpMethod.PUT,
-            url=report_url,
-            operation_label=OperationLabel.BITBUCKET_CODE_INSIGHTS_REPORT,
-            headers=headers,
-            json_body=_build_report_payload(scan_result),
-        )
-    )
+    _post_report(headers, workspace, repo_slug, sha, scan_result)
 
     if not scan_result.findings:
         return
 
-    annotations_url = _BITBUCKET_API_BASE_URL + _BITBUCKET_ANNOTATIONS_PATH.format(
-        workspace=workspace,
-        repo_slug=repo_slug,
-        commit=sha,
-        report_id=_BITBUCKET_REPORT_ID,
-    )
-    annotations = _build_annotations(scan_result)
-
-    execute_http_request(
-        HttpRequestConfig(
-            method=HttpMethod.POST,
-            url=annotations_url,
-            operation_label=OperationLabel.BITBUCKET_CODE_INSIGHTS_ANNOTATIONS,
-            headers=headers,
-            json_body=annotations,
-        )
-    )
+    annotations_count = _post_annotations(headers, workspace, repo_slug, sha, scan_result)
 
     _LOG.debug(
         "Bitbucket: Code Insights report + %d annotation(s) posted for %s",
-        len(annotations),
+        annotations_count,
         sha[:_SHA_LOG_PREFIX_LENGTH],
     )

--- a/phi_scan/ci/bitbucket_insights.py
+++ b/phi_scan/ci/bitbucket_insights.py
@@ -7,6 +7,7 @@ phi_scan.ci_integration via re-export; this module owns the implementation.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 from phi_scan.ci import PullRequestContext
@@ -57,6 +58,9 @@ _BITBUCKET_ANNOTATION_SEVERITY_MAP: dict[SeverityLevel, str] = {
 
 _BITBUCKET_ANNOTATIONS_BATCH_LIMIT: int = 1000
 _SHA_LOG_PREFIX_LENGTH: int = 8
+_BITBUCKET_ANNOTATION_EXTERNAL_ID_PREFIX: str = "phi-scan-"
+_BITBUCKET_DATA_TITLE_TOTAL_FINDINGS: str = "Total findings"
+_BITBUCKET_DATA_TITLE_RISK_LEVEL: str = "Risk level"
 
 # PR context extras keys — set by phi_scan.ci.bitbucket when the adapter
 # extracts workspace/repo identity from CI environment variables.
@@ -82,12 +86,12 @@ def _build_report_payload(scan_result: ScanResult) -> dict[str, Any]:
         "result": report_result,
         "data": [
             {
-                "title": "Total findings",
+                "title": _BITBUCKET_DATA_TITLE_TOTAL_FINDINGS,
                 "type": _BITBUCKET_DATA_TYPE_NUMBER,
                 "value": findings_count,
             },
             {
-                "title": "Risk level",
+                "title": _BITBUCKET_DATA_TITLE_RISK_LEVEL,
                 "type": _BITBUCKET_DATA_TYPE_TEXT,
                 "value": scan_result.risk_level.value,
             },
@@ -98,7 +102,10 @@ def _build_report_payload(scan_result: ScanResult) -> dict[str, Any]:
 def _build_annotations(scan_result: ScanResult) -> list[dict[str, Any]]:
     return [
         {
-            "external_id": f"phi-scan-{finding.file_path}-{finding.line_number}-{annotation_index}",
+            "external_id": (
+                f"{_BITBUCKET_ANNOTATION_EXTERNAL_ID_PREFIX}"
+                f"{finding.file_path}-{finding.line_number}-{annotation_index}"
+            ),
             "annotation_type": _BITBUCKET_ANNOTATION_TYPE_VULNERABILITY,
             "path": str(finding.file_path),
             "line": finding.line_number,
@@ -116,13 +123,21 @@ def _build_annotations(scan_result: ScanResult) -> list[dict[str, Any]]:
     ]
 
 
-def _post_report(
-    headers: dict[str, str], workspace: str, repo_slug: str, sha: str, scan_result: ScanResult
-) -> None:
+@dataclass(frozen=True)
+class _BitbucketReportContext:
+    """Bundle of request values shared by the report + annotations POSTs."""
+
+    headers: dict[str, str]
+    workspace: str
+    repo_slug: str
+    sha: str
+
+
+def _post_report(report_context: _BitbucketReportContext, scan_result: ScanResult) -> None:
     report_url = _BITBUCKET_API_BASE_URL + _BITBUCKET_REPORTS_PATH.format(
-        workspace=workspace,
-        repo_slug=repo_slug,
-        commit=sha,
+        workspace=report_context.workspace,
+        repo_slug=report_context.repo_slug,
+        commit=report_context.sha,
         report_id=_BITBUCKET_REPORT_ID,
     )
     execute_http_request(
@@ -130,19 +145,17 @@ def _post_report(
             method=HttpMethod.PUT,
             url=report_url,
             operation_label=OperationLabel.BITBUCKET_CODE_INSIGHTS_REPORT,
-            headers=headers,
+            headers=report_context.headers,
             json_body=_build_report_payload(scan_result),
         )
     )
 
 
-def _post_annotations(
-    headers: dict[str, str], workspace: str, repo_slug: str, sha: str, scan_result: ScanResult
-) -> int:
+def _post_annotations(report_context: _BitbucketReportContext, scan_result: ScanResult) -> int:
     annotations_url = _BITBUCKET_API_BASE_URL + _BITBUCKET_ANNOTATIONS_PATH.format(
-        workspace=workspace,
-        repo_slug=repo_slug,
-        commit=sha,
+        workspace=report_context.workspace,
+        repo_slug=report_context.repo_slug,
+        commit=report_context.sha,
         report_id=_BITBUCKET_REPORT_ID,
     )
     annotations = _build_annotations(scan_result)
@@ -151,7 +164,7 @@ def _post_annotations(
             method=HttpMethod.POST,
             url=annotations_url,
             operation_label=OperationLabel.BITBUCKET_CODE_INSIGHTS_ANNOTATIONS,
-            headers=headers,
+            headers=report_context.headers,
             json_body=annotations,
         )
     )
@@ -173,17 +186,22 @@ def post_bitbucket_code_insights(scan_result: ScanResult, pr_context: PullReques
         _LOG.warning("Bitbucket: BITBUCKET_TOKEN not set — skipping Code Insights")
         return
 
-    headers = {
-        "Authorization": _AUTHORIZATION_BEARER_PREFIX + token,
-        "Content-Type": _JSON_CONTENT_TYPE,
-    }
+    report_context = _BitbucketReportContext(
+        headers={
+            "Authorization": _AUTHORIZATION_BEARER_PREFIX + token,
+            "Content-Type": _JSON_CONTENT_TYPE,
+        },
+        workspace=workspace,
+        repo_slug=repo_slug,
+        sha=sha,
+    )
 
-    _post_report(headers, workspace, repo_slug, sha, scan_result)
+    _post_report(report_context, scan_result)
 
     if not scan_result.findings:
         return
 
-    annotations_count = _post_annotations(headers, workspace, repo_slug, sha, scan_result)
+    annotations_count = _post_annotations(report_context, scan_result)
 
     _LOG.debug(
         "Bitbucket: Code Insights report + %d annotation(s) posted for %s",

--- a/phi_scan/ci/bitbucket_insights.py
+++ b/phi_scan/ci/bitbucket_insights.py
@@ -1,0 +1,167 @@
+"""Bitbucket Code Insights report + inline annotations.
+
+Extracted from phi_scan.ci_integration. Call sites continue to import from
+phi_scan.ci_integration via re-export; this module owns the implementation.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from phi_scan.ci import PullRequestContext
+from phi_scan.ci._env import fetch_environment_variable
+from phi_scan.ci._transport import (
+    HttpMethod,
+    HttpRequestConfig,
+    OperationLabel,
+    execute_http_request,
+)
+from phi_scan.constants import SeverityLevel
+from phi_scan.models import ScanResult
+
+_LOG: logging.Logger = logging.getLogger(__name__)
+
+_ENV_BITBUCKET_TOKEN: str = "BITBUCKET_TOKEN"
+_JSON_CONTENT_TYPE: str = "application/json"
+_AUTHORIZATION_BEARER_PREFIX: str = "Bearer "
+
+_BITBUCKET_API_BASE_URL: str = "https://api.bitbucket.org/2.0"
+_BITBUCKET_REPORTS_PATH: str = (
+    "/repositories/{workspace}/{repo_slug}/commit/{commit}/reports/{report_id}"
+)
+_BITBUCKET_ANNOTATIONS_PATH: str = (
+    "/repositories/{workspace}/{repo_slug}/commit/{commit}/reports/{report_id}/annotations"
+)
+_BITBUCKET_REPORT_ID: str = "phi-scan"
+_BITBUCKET_REPORT_TITLE: str = "phi-scan PHI/PII Scan"
+_BITBUCKET_REPORT_TYPE: str = "SECURITY"
+_BITBUCKET_REPORTER: str = "phi-scan"
+_BITBUCKET_RESULT_PASSED: str = "PASSED"
+_BITBUCKET_RESULT_FAILED: str = "FAILED"
+_BITBUCKET_ANNOTATION_TYPE_VULNERABILITY: str = "VULNERABILITY"
+_BITBUCKET_DATA_TYPE_NUMBER: str = "NUMBER"
+_BITBUCKET_DATA_TYPE_TEXT: str = "TEXT"
+_BITBUCKET_ANNOTATION_DEFAULT_SEVERITY: str = "MEDIUM"
+
+_BITBUCKET_HIGH_SEVERITY_LABEL: str = "HIGH"
+_BITBUCKET_MEDIUM_SEVERITY_LABEL: str = "MEDIUM"
+_BITBUCKET_LOW_SEVERITY_LABEL: str = "LOW"
+_BITBUCKET_INFO_SEVERITY_LABEL: str = _BITBUCKET_LOW_SEVERITY_LABEL
+_BITBUCKET_ANNOTATION_SEVERITY_MAP: dict[SeverityLevel, str] = {
+    SeverityLevel.HIGH: _BITBUCKET_HIGH_SEVERITY_LABEL,
+    SeverityLevel.MEDIUM: _BITBUCKET_MEDIUM_SEVERITY_LABEL,
+    SeverityLevel.LOW: _BITBUCKET_LOW_SEVERITY_LABEL,
+    SeverityLevel.INFO: _BITBUCKET_INFO_SEVERITY_LABEL,
+}
+
+_BITBUCKET_ANNOTATIONS_BATCH_LIMIT: int = 1000
+_SHA_LOG_PREFIX_LENGTH: int = 8
+
+
+def _build_report_payload(scan_result: ScanResult) -> dict[str, Any]:
+    findings_count = len(scan_result.findings)
+    report_result = _BITBUCKET_RESULT_PASSED if scan_result.is_clean else _BITBUCKET_RESULT_FAILED
+    return {
+        "title": _BITBUCKET_REPORT_TITLE,
+        "report_type": _BITBUCKET_REPORT_TYPE,
+        "reporter": _BITBUCKET_REPORTER,
+        "result": report_result,
+        "data": [
+            {
+                "title": "Total findings",
+                "type": _BITBUCKET_DATA_TYPE_NUMBER,
+                "value": findings_count,
+            },
+            {
+                "title": "Risk level",
+                "type": _BITBUCKET_DATA_TYPE_TEXT,
+                "value": scan_result.risk_level.value,
+            },
+        ],
+    }
+
+
+def _build_annotations(scan_result: ScanResult) -> list[dict[str, Any]]:
+    return [
+        {
+            "external_id": f"phi-scan-{finding.file_path}-{finding.line_number}-{annotation_index}",
+            "annotation_type": _BITBUCKET_ANNOTATION_TYPE_VULNERABILITY,
+            "path": str(finding.file_path),
+            "line": finding.line_number,
+            "message": (
+                f"{finding.hipaa_category.value} detected "
+                f"({finding.severity.value}, {finding.confidence:.0%} confidence)"
+            ),
+            "severity": _BITBUCKET_ANNOTATION_SEVERITY_MAP.get(
+                finding.severity, _BITBUCKET_ANNOTATION_DEFAULT_SEVERITY
+            ),
+        }
+        for annotation_index, finding in enumerate(
+            scan_result.findings[:_BITBUCKET_ANNOTATIONS_BATCH_LIMIT]
+        )
+    ]
+
+
+def post_bitbucket_code_insights(scan_result: ScanResult, pr_context: PullRequestContext) -> None:
+    """Post Bitbucket Code Insights report and inline annotations."""
+    sha = pr_context.sha
+    workspace = pr_context.extras.get("workspace", "")
+    repo_slug = pr_context.extras.get("repo_slug", "")
+
+    if not sha or not workspace or not repo_slug:
+        _LOG.debug("Bitbucket Code Insights: missing context — skipping")
+        return
+
+    token = fetch_environment_variable(_ENV_BITBUCKET_TOKEN)
+    if not token:
+        _LOG.warning("Bitbucket: BITBUCKET_TOKEN not set — skipping Code Insights")
+        return
+
+    headers = {
+        "Authorization": _AUTHORIZATION_BEARER_PREFIX + token,
+        "Content-Type": _JSON_CONTENT_TYPE,
+    }
+    report_url = _BITBUCKET_API_BASE_URL + _BITBUCKET_REPORTS_PATH.format(
+        workspace=workspace,
+        repo_slug=repo_slug,
+        commit=sha,
+        report_id=_BITBUCKET_REPORT_ID,
+    )
+
+    execute_http_request(
+        HttpRequestConfig(
+            method=HttpMethod.PUT,
+            url=report_url,
+            operation_label=OperationLabel.BITBUCKET_CODE_INSIGHTS_REPORT,
+            headers=headers,
+            json_body=_build_report_payload(scan_result),
+        )
+    )
+
+    if not scan_result.findings:
+        return
+
+    annotations_url = _BITBUCKET_API_BASE_URL + _BITBUCKET_ANNOTATIONS_PATH.format(
+        workspace=workspace,
+        repo_slug=repo_slug,
+        commit=sha,
+        report_id=_BITBUCKET_REPORT_ID,
+    )
+    annotations = _build_annotations(scan_result)
+
+    execute_http_request(
+        HttpRequestConfig(
+            method=HttpMethod.POST,
+            url=annotations_url,
+            operation_label=OperationLabel.BITBUCKET_CODE_INSIGHTS_ANNOTATIONS,
+            headers=headers,
+            json_body=annotations,
+        )
+    )
+
+    _LOG.debug(
+        "Bitbucket: Code Insights report + %d annotation(s) posted for %s",
+        len(annotations),
+        sha[:_SHA_LOG_PREFIX_LENGTH],
+    )

--- a/phi_scan/ci_integration.py
+++ b/phi_scan/ci_integration.py
@@ -53,6 +53,9 @@ from phi_scan.ci._transport import (
     OperationLabel,
     execute_http_request,
 )
+from phi_scan.ci.bitbucket_insights import (
+    post_bitbucket_code_insights as post_bitbucket_code_insights,
+)
 from phi_scan.ci.sarif import upload_sarif_to_github as upload_sarif_to_github
 from phi_scan.constants import SeverityLevel
 from phi_scan.exceptions import CIIntegrationError  # noqa: F401 — backward-compatible re-export
@@ -177,26 +180,6 @@ _AWS_SECURITY_HUB_SEVERITY_MAP: dict[SeverityLevel, str] = {
     SeverityLevel.LOW: _AWS_SECURITY_HUB_LOW_SEVERITY_LABEL,
     SeverityLevel.INFO: _AWS_SECURITY_HUB_INFO_SEVERITY_LABEL,
 }
-
-_BITBUCKET_API_BASE_URL: str = "https://api.bitbucket.org/2.0"
-_BITBUCKET_REPORTS_PATH: str = (
-    "/repositories/{workspace}/{repo_slug}/commit/{commit}/reports/{report_id}"
-)
-_BITBUCKET_ANNOTATIONS_PATH: str = (
-    "/repositories/{workspace}/{repo_slug}/commit/{commit}/reports/{report_id}/annotations"
-)
-_BITBUCKET_REPORT_ID: str = "phi-scan"
-_BITBUCKET_HIGH_SEVERITY_LABEL: str = "HIGH"
-_BITBUCKET_MEDIUM_SEVERITY_LABEL: str = "MEDIUM"
-_BITBUCKET_LOW_SEVERITY_LABEL: str = "LOW"
-_BITBUCKET_INFO_SEVERITY_LABEL: str = _BITBUCKET_LOW_SEVERITY_LABEL
-_BITBUCKET_ANNOTATION_SEVERITY_MAP: dict[SeverityLevel, str] = {
-    SeverityLevel.HIGH: _BITBUCKET_HIGH_SEVERITY_LABEL,
-    SeverityLevel.MEDIUM: _BITBUCKET_MEDIUM_SEVERITY_LABEL,
-    SeverityLevel.LOW: _BITBUCKET_LOW_SEVERITY_LABEL,
-    SeverityLevel.INFO: _BITBUCKET_INFO_SEVERITY_LABEL,
-}
-
 
 # ---------------------------------------------------------------------------
 # Backward-compatible type re-exports
@@ -409,100 +392,9 @@ def set_commit_status(scan_result: ScanResult, pr_context: PRContext) -> None:
 
 # ---------------------------------------------------------------------------
 # Public API — Bitbucket Code Insights annotations
+# Implementation now lives in phi_scan.ci.bitbucket_insights; re-exported at
+# module top.
 # ---------------------------------------------------------------------------
-
-
-def post_bitbucket_code_insights(scan_result: ScanResult, pr_context: PRContext) -> None:
-    """Post Bitbucket Code Insights report and inline annotations."""
-    sha = pr_context.sha
-    workspace = pr_context.extras.get("workspace", "")
-    repo_slug = pr_context.extras.get("repo_slug", "")
-
-    if not sha or not workspace or not repo_slug:
-        _LOG.debug("Bitbucket Code Insights: missing context — skipping")
-        return
-
-    token = _env(_ENV_BITBUCKET_TOKEN)
-    if not token:
-        _LOG.warning("Bitbucket: BITBUCKET_TOKEN not set — skipping Code Insights")
-        return
-
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": _JSON_CONTENT_TYPE,
-    }
-    report_url = _BITBUCKET_API_BASE_URL + _BITBUCKET_REPORTS_PATH.format(
-        workspace=workspace,
-        repo_slug=repo_slug,
-        commit=sha,
-        report_id=_BITBUCKET_REPORT_ID,
-    )
-
-    findings_count = len(scan_result.findings)
-    report_payload: dict[str, Any] = {
-        "title": "phi-scan PHI/PII Scan",
-        "report_type": "SECURITY",
-        "reporter": "phi-scan",
-        "result": "PASSED" if scan_result.is_clean else "FAILED",
-        "data": [
-            {"title": "Total findings", "type": "NUMBER", "value": findings_count},
-            {
-                "title": "Risk level",
-                "type": "TEXT",
-                "value": scan_result.risk_level.value,
-            },
-        ],
-    }
-
-    execute_http_request(
-        HttpRequestConfig(
-            method=HttpMethod.PUT,
-            url=report_url,
-            operation_label=OperationLabel.BITBUCKET_CODE_INSIGHTS_REPORT,
-            headers=headers,
-            json_body=report_payload,
-        )
-    )
-
-    if not scan_result.findings:
-        return
-
-    annotations_url = _BITBUCKET_API_BASE_URL + _BITBUCKET_ANNOTATIONS_PATH.format(
-        workspace=workspace,
-        repo_slug=repo_slug,
-        commit=sha,
-        report_id=_BITBUCKET_REPORT_ID,
-    )
-    annotations = [
-        {
-            "external_id": f"phi-scan-{finding.file_path}-{finding.line_number}-{idx}",
-            "annotation_type": "VULNERABILITY",
-            "path": str(finding.file_path),
-            "line": finding.line_number,
-            "message": (
-                f"{finding.hipaa_category.value} detected "
-                f"({finding.severity.value}, {finding.confidence:.0%} confidence)"
-            ),
-            "severity": _BITBUCKET_ANNOTATION_SEVERITY_MAP.get(finding.severity, "MEDIUM"),
-        }
-        for idx, finding in enumerate(scan_result.findings[:1000])
-    ]
-
-    execute_http_request(
-        HttpRequestConfig(
-            method=HttpMethod.POST,
-            url=annotations_url,
-            operation_label=OperationLabel.BITBUCKET_CODE_INSIGHTS_ANNOTATIONS,
-            headers=headers,
-            json_body=annotations,
-        )
-    )
-
-    _LOG.debug(
-        "Bitbucket: Code Insights report + %d annotation(s) posted for %s",
-        len(annotations),
-        sha[:8],
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ci_integration_remaining.py
+++ b/tests/test_ci_integration_remaining.py
@@ -1463,3 +1463,16 @@ def test_sarif_symbols_reexported_from_ci_integration() -> None:
     assert ci_integration_module.upload_sarif_to_github is sarif_module.upload_sarif_to_github, (
         "upload_sarif_to_github no longer re-exported from phi_scan.ci_integration"
     )
+
+
+def test_bitbucket_code_insights_reexported_from_ci_integration() -> None:
+    """post_bitbucket_code_insights moved to phi_scan.ci.bitbucket_insights;
+    the legacy import path on phi_scan.ci_integration must still resolve to
+    the same callable so existing callers and CI flows keep working."""
+    import phi_scan.ci.bitbucket_insights as bitbucket_module
+    import phi_scan.ci_integration as ci_integration_module
+
+    assert (
+        ci_integration_module.post_bitbucket_code_insights
+        is bitbucket_module.post_bitbucket_code_insights
+    ), "post_bitbucket_code_insights no longer re-exported from phi_scan.ci_integration"


### PR DESCRIPTION
## Summary
Second vertical slice out of the `phi_scan/ci_integration.py` monolith, following the same pattern as the merged SARIF slice.

- New `phi_scan/ci/bitbucket_insights.py` owns `post_bitbucket_code_insights` plus two small payload builders (`_build_report_payload`, `_build_annotations`).
- Removes all Bitbucket-specific constants from `ci_integration.py`; re-export preserves the `phi_scan.ci_integration.post_bitbucket_code_insights` import path.
- Replaces inline magic strings (`"PASSED"`, `"FAILED"`, `"VULNERABILITY"`, `"NUMBER"`, `"TEXT"`, `"SECURITY"`, default severity, report title/reporter) and the 1000-item annotation batch cap with named constants.
- Uses shared `phi_scan.ci._env.fetch_environment_variable` instead of the old local `_env` helper.
- Adds parity test `test_bitbucket_code_insights_reexported_from_ci_integration` locking the public re-export.

## Test plan
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy phi_scan` clean (80 files)
- [x] `uv run pytest -q` → 1979 passed, 3 skipped, 90.82% coverage
- [x] Existing Bitbucket behaviour tests pass unchanged
- [x] New parity test passes