### PR TITLE
refactor(ci): extract Azure DevOps slice

### DIFF
--- a/phi_scan/ci/azure_devops.py
+++ b/phi_scan/ci/azure_devops.py
@@ -1,0 +1,259 @@
+"""Azure DevOps build tags, PR statuses, and Boards work items.
+
+Extracted from phi_scan.ci_integration. Call sites continue to import from
+phi_scan.ci_integration via re-export; this module owns the implementation.
+
+PHI safety: all outbound payloads transmit counts, severity labels, file
+paths, and line numbers only. No raw entity values, value_hash, or
+code_context ever enters any Azure DevOps request body.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from phi_scan.ci import PullRequestContext
+from phi_scan.ci._env import fetch_environment_variable
+from phi_scan.ci._transport import (
+    HttpMethod,
+    HttpRequestConfig,
+    OperationLabel,
+    execute_http_request,
+)
+from phi_scan.models import ScanFinding, ScanResult
+
+_LOG: logging.Logger = logging.getLogger(__name__)
+
+_ENV_SYSTEM_ACCESSTOKEN: str = "SYSTEM_ACCESSTOKEN"
+_ENV_AZURE_BOARDS_INTEGRATION: str = "AZURE_BOARDS_INTEGRATION"
+_ENV_AZURE_BOARDS_INTEGRATION_ENABLED_VALUE: str = "true"
+
+_AZURE_PATCH_CONTENT_TYPE: str = "application/json-patch+json"
+_AZURE_BUILD_TAG_EMPTY_BODY: bytes = b""
+
+_AZURE_API_VERSION: str = "7.1"
+_AZURE_BUILD_TAGS_PATH: str = (
+    "{collection_uri}{team_project}/_apis/build/builds/{build_id}"
+    "/tags/{tag}?api-version={api_version}"
+)
+_AZURE_PR_STATUSES_PATH: str = (
+    "{collection_uri}{team_project}/_apis/git/repositories/{repo_id}"
+    "/pullRequests/{pr_id}/statuses?api-version={api_version}"
+)
+_AZURE_WORK_ITEMS_PATH: str = (
+    "{collection_uri}{team_project}/_apis/wit/workitems/${work_item_type}?api-version={api_version}"
+)
+
+_AZURE_TAG_CLEAN: str = "phi-scan:clean"
+_AZURE_TAG_VIOLATIONS: str = "phi-scan:violations-found"
+
+_AZURE_PR_STATE_SUCCEEDED: str = "succeeded"
+_AZURE_PR_STATE_FAILED: str = "failed"
+_AZURE_STATUS_CONTEXT_NAME: str = "phi-scan"
+_AZURE_STATUS_CONTEXT_GENRE: str = "phi-scan"
+_AZURE_STATUS_DESCRIPTION_CLEAN: str = "No PHI/PII violations found"
+_AZURE_STATUS_DESCRIPTION_VIOLATIONS: str = "{count} PHI/PII violation(s) found"
+
+_AZURE_WORK_ITEM_TYPE: str = "Task"
+_AZURE_WORK_ITEM_TITLE_FORMAT: str = (
+    "phi-scan: {count} HIGH severity PHI/PII violation(s) in PR #{pull_request_number}"
+)
+_AZURE_WORK_ITEM_DESCRIPTION_FORMAT: str = (
+    "phi-scan detected {count} HIGH severity PHI/PII violation(s) in PR #{pull_request_number}. "
+    "Remediate before merging."
+)
+_AZURE_WORK_ITEM_TAGS_VALUE: str = "phi-scan;security;phi-pii"
+_AZURE_JSON_PATCH_OP_ADD: str = "add"
+_AZURE_FIELD_PATH_TITLE: str = "/fields/System.Title"
+_AZURE_FIELD_PATH_DESCRIPTION: str = "/fields/System.Description"
+_AZURE_FIELD_PATH_TAGS: str = "/fields/System.Tags"
+
+_SEVERITY_HIGH_LABEL: str = "high"
+_UNKNOWN_PR_ID: str = "unknown"
+
+_EXTRAS_KEY_COLLECTION_URI: str = "collection_uri"
+_EXTRAS_KEY_TEAM_PROJECT: str = "team_project"
+_EXTRAS_KEY_BUILD_ID: str = "build_id"
+
+
+def _fetch_azure_access_token(skip_log_message: str) -> str | None:
+    token = fetch_environment_variable(_ENV_SYSTEM_ACCESSTOKEN)
+    if not token:
+        _LOG.warning(skip_log_message)
+        return None
+    return token
+
+
+def set_azure_build_tag(scan_result: ScanResult, pr_context: PullRequestContext) -> None:
+    """Tag the Azure DevOps build with phi-scan:clean or phi-scan:violations-found."""
+    collection_uri = pr_context.extras.get(_EXTRAS_KEY_COLLECTION_URI, "")
+    team_project = pr_context.extras.get(_EXTRAS_KEY_TEAM_PROJECT, "")
+    build_id = pr_context.extras.get(_EXTRAS_KEY_BUILD_ID, "")
+
+    if not all((collection_uri, team_project, build_id)):
+        _LOG.debug("Azure DevOps build tag: missing context — skipping")
+        return
+
+    token = _fetch_azure_access_token(
+        "Azure DevOps build tag: SYSTEM_ACCESSTOKEN not set — skipping"
+    )
+    if not token:
+        return
+
+    tag = _AZURE_TAG_CLEAN if scan_result.is_clean else _AZURE_TAG_VIOLATIONS
+    url = _AZURE_BUILD_TAGS_PATH.format(
+        collection_uri=collection_uri,
+        team_project=team_project,
+        build_id=build_id,
+        tag=tag,
+        api_version=_AZURE_API_VERSION,
+    )
+
+    execute_http_request(
+        HttpRequestConfig(
+            method=HttpMethod.PUT,
+            url=url,
+            operation_label=OperationLabel.AZURE_BUILD_TAG,
+            binary_body=_AZURE_BUILD_TAG_EMPTY_BODY,
+            basic_auth_credentials=("", token),
+        )
+    )
+
+    _LOG.debug("Azure DevOps: build tagged with %s", tag)
+
+
+def set_azure_pr_status(scan_result: ScanResult, pr_context: PullRequestContext) -> None:
+    """Set an Azure DevOps PR status to block or allow completion via branch policy."""
+    pr_id = pr_context.pull_request_number
+    repo_id = pr_context.repository
+    collection_uri = pr_context.extras.get(_EXTRAS_KEY_COLLECTION_URI, "")
+    team_project = pr_context.extras.get(_EXTRAS_KEY_TEAM_PROJECT, "")
+
+    if not all((pr_id, repo_id, collection_uri, team_project)):
+        _LOG.debug("Azure DevOps PR status: missing context — skipping")
+        return
+
+    token = _fetch_azure_access_token(
+        "Azure DevOps PR status: SYSTEM_ACCESSTOKEN not set — skipping"
+    )
+    if not token:
+        return
+
+    state = _AZURE_PR_STATE_SUCCEEDED if scan_result.is_clean else _AZURE_PR_STATE_FAILED
+    description = (
+        _AZURE_STATUS_DESCRIPTION_CLEAN
+        if scan_result.is_clean
+        else _AZURE_STATUS_DESCRIPTION_VIOLATIONS.format(count=len(scan_result.findings))
+    )
+    url = _AZURE_PR_STATUSES_PATH.format(
+        collection_uri=collection_uri,
+        team_project=team_project,
+        repo_id=repo_id,
+        pr_id=pr_id,
+        api_version=_AZURE_API_VERSION,
+    )
+    payload = {
+        "state": state,
+        "description": description,
+        "context": {
+            "name": _AZURE_STATUS_CONTEXT_NAME,
+            "genre": _AZURE_STATUS_CONTEXT_GENRE,
+        },
+    }
+
+    execute_http_request(
+        HttpRequestConfig(
+            method=HttpMethod.POST,
+            url=url,
+            operation_label=OperationLabel.AZURE_PR_STATUS,
+            json_body=payload,
+            basic_auth_credentials=("", token),
+        )
+    )
+
+    _LOG.debug("Azure DevOps: PR status set to %s for PR #%s", state, pr_id)
+
+
+def _filter_high_severity_findings(scan_result: ScanResult) -> list[ScanFinding]:
+    return [
+        finding
+        for finding in scan_result.findings
+        if finding.severity.value.lower() == _SEVERITY_HIGH_LABEL
+    ]
+
+
+def _build_work_item_patch(
+    high_finding_count: int, pull_request_number: str
+) -> list[dict[str, Any]]:
+    title = _AZURE_WORK_ITEM_TITLE_FORMAT.format(
+        count=high_finding_count, pull_request_number=pull_request_number
+    )
+    description = _AZURE_WORK_ITEM_DESCRIPTION_FORMAT.format(
+        count=high_finding_count, pull_request_number=pull_request_number
+    )
+    return [
+        {"op": _AZURE_JSON_PATCH_OP_ADD, "path": _AZURE_FIELD_PATH_TITLE, "value": title},
+        {
+            "op": _AZURE_JSON_PATCH_OP_ADD,
+            "path": _AZURE_FIELD_PATH_DESCRIPTION,
+            "value": description,
+        },
+        {
+            "op": _AZURE_JSON_PATCH_OP_ADD,
+            "path": _AZURE_FIELD_PATH_TAGS,
+            "value": _AZURE_WORK_ITEM_TAGS_VALUE,
+        },
+    ]
+
+
+def create_azure_boards_work_item(scan_result: ScanResult, pr_context: PullRequestContext) -> None:
+    """Create an Azure Boards Task work item for HIGH severity PHI/PII findings."""
+    if (
+        fetch_environment_variable(_ENV_AZURE_BOARDS_INTEGRATION)
+        != _ENV_AZURE_BOARDS_INTEGRATION_ENABLED_VALUE
+    ):
+        _LOG.debug("Azure Boards: AZURE_BOARDS_INTEGRATION not enabled — skipping")
+        return
+
+    high_findings = _filter_high_severity_findings(scan_result)
+    if not high_findings:
+        _LOG.debug("Azure Boards: no HIGH severity findings — skipping work item")
+        return
+
+    collection_uri = pr_context.extras.get(_EXTRAS_KEY_COLLECTION_URI, "")
+    team_project = pr_context.extras.get(_EXTRAS_KEY_TEAM_PROJECT, "")
+    pull_request_number = pr_context.pull_request_number or _UNKNOWN_PR_ID
+
+    if not all((collection_uri, team_project)):
+        _LOG.debug("Azure Boards: missing context — skipping work item")
+        return
+
+    token = _fetch_azure_access_token("Azure Boards: SYSTEM_ACCESSTOKEN not set — skipping")
+    if not token:
+        return
+
+    url = _AZURE_WORK_ITEMS_PATH.format(
+        collection_uri=collection_uri,
+        team_project=team_project,
+        work_item_type=_AZURE_WORK_ITEM_TYPE,
+        api_version=_AZURE_API_VERSION,
+    )
+    patch_payload = _build_work_item_patch(len(high_findings), pull_request_number)
+
+    execute_http_request(
+        HttpRequestConfig(
+            method=HttpMethod.POST,
+            url=url,
+            operation_label=OperationLabel.AZURE_WORK_ITEM,
+            headers={"Content-Type": _AZURE_PATCH_CONTENT_TYPE},
+            json_body=patch_payload,
+            basic_auth_credentials=("", token),
+        )
+    )
+
+    _LOG.debug(
+        "Azure Boards: work item created for PR #%s (%d HIGH findings)",
+        pull_request_number,
+        len(high_findings),
+    )

--- a/phi_scan/ci_integration.py
+++ b/phi_scan/ci_integration.py
@@ -26,7 +26,6 @@ phrase — never the response body.
 from __future__ import annotations
 
 import logging
-import os
 from dataclasses import dataclass
 
 from phi_scan.ci import (  # noqa: F401 — backward-compatible re-exports
@@ -57,6 +56,11 @@ from phi_scan.ci.aws_security_hub import (
 from phi_scan.ci.aws_security_hub import (
     import_findings_to_security_hub as import_findings_to_security_hub,
 )
+from phi_scan.ci.azure_devops import (
+    create_azure_boards_work_item as create_azure_boards_work_item,
+)
+from phi_scan.ci.azure_devops import set_azure_build_tag as set_azure_build_tag
+from phi_scan.ci.azure_devops import set_azure_pr_status as set_azure_pr_status
 from phi_scan.ci.bitbucket_insights import (
     post_bitbucket_code_insights as post_bitbucket_code_insights,
 )
@@ -138,38 +142,6 @@ _MAX_FINDINGS_IN_COMMENT_TABLE: int = 50
 # Constants — platform-specific extras
 # ---------------------------------------------------------------------------
 
-_ENV_GITHUB_TOKEN: str = "GITHUB_TOKEN"
-_ENV_SYSTEM_ACCESSTOKEN: str = "SYSTEM_ACCESSTOKEN"
-_ENV_BITBUCKET_TOKEN: str = "BITBUCKET_TOKEN"
-
-_HTTP_TIMEOUT_SECONDS: float = 15.0
-_JSON_CONTENT_TYPE: str = "application/json"
-_AZURE_PATCH_CONTENT_TYPE: str = "application/json-patch+json"
-_AZURE_BUILD_TAG_EMPTY_BODY: bytes = b""
-
-_GITHUB_API_BASE_URL: str = "https://api.github.com"
-_GITHUB_API_SARIF_UPLOAD_PATH: str = "/repos/{repository}/code-scanning/sarifs"
-_SARIF_MAX_MESSAGE_TEXT_LENGTH: int = 1_500
-
-_AZURE_API_VERSION: str = "7.1"
-_AZURE_BUILD_TAGS_PATH: str = (
-    "{collection_uri}{team_project}/_apis/build/builds/{build_id}"
-    "/tags/{tag}?api-version={api_version}"
-)
-_AZURE_PR_STATUSES_PATH: str = (
-    "{collection_uri}{team_project}/_apis/git/repositories/{repo_id}"
-    "/pullRequests/{pr_id}/statuses?api-version={api_version}"
-)
-_AZURE_TAG_CLEAN: str = "phi-scan:clean"
-_AZURE_TAG_VIOLATIONS: str = "phi-scan:violations-found"
-_AZURE_WORK_ITEM_TYPE: str = "Task"
-_AZURE_WORK_ITEMS_PATH: str = (
-    "{collection_uri}{team_project}/_apis/wit/workitems/${work_item_type}?api-version={api_version}"
-)
-_AZURE_WORK_ITEM_TITLE_FORMAT: str = (
-    "phi-scan: {count} HIGH severity PHI/PII violation(s) in PR #{pull_request_number}"
-)
-
 # ---------------------------------------------------------------------------
 # Backward-compatible type re-exports
 # ---------------------------------------------------------------------------
@@ -182,17 +154,6 @@ class BaselineComparison:
     new_findings_count: int
     baselined_count: int
     resolved_count: int
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _env(name: str) -> str | None:
-    """Return the environment variable value, or None if unset or empty."""
-    env_value = os.environ.get(name, "").strip()
-    return env_value if env_value else None
 
 
 # ---------------------------------------------------------------------------
@@ -387,168 +348,10 @@ def set_commit_status(scan_result: ScanResult, pr_context: PRContext) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Public API — Azure DevOps build tag + PR status
+# Public API — Azure DevOps build tag, PR status, and Boards work item
+# Implementation now lives in phi_scan.ci.azure_devops; re-exported at
+# module top.
 # ---------------------------------------------------------------------------
-
-
-def set_azure_build_tag(scan_result: ScanResult, pr_context: PRContext) -> None:
-    """Tag the Azure DevOps build with phi-scan:clean or phi-scan:violations-found."""
-    collection_uri = pr_context.extras.get("collection_uri", "")
-    team_project = pr_context.extras.get("team_project", "")
-    build_id = pr_context.extras.get("build_id", "")
-
-    if not all((collection_uri, team_project, build_id)):
-        _LOG.debug("Azure DevOps build tag: missing context — skipping")
-        return
-
-    token = _env(_ENV_SYSTEM_ACCESSTOKEN)
-    if not token:
-        _LOG.warning("Azure DevOps build tag: SYSTEM_ACCESSTOKEN not set — skipping")
-        return
-
-    tag = _AZURE_TAG_CLEAN if scan_result.is_clean else _AZURE_TAG_VIOLATIONS
-    url = _AZURE_BUILD_TAGS_PATH.format(
-        collection_uri=collection_uri,
-        team_project=team_project,
-        build_id=build_id,
-        tag=tag,
-        api_version=_AZURE_API_VERSION,
-    )
-
-    execute_http_request(
-        HttpRequestConfig(
-            method=HttpMethod.PUT,
-            url=url,
-            operation_label=OperationLabel.AZURE_BUILD_TAG,
-            binary_body=_AZURE_BUILD_TAG_EMPTY_BODY,
-            basic_auth_credentials=("", token),
-        )
-    )
-
-    _LOG.debug("Azure DevOps: build tagged with %s", tag)
-
-
-def set_azure_pr_status(scan_result: ScanResult, pr_context: PRContext) -> None:
-    """Set an Azure DevOps PR status to block or allow completion via branch policy."""
-    pr_id = pr_context.pull_request_number
-    repo_id = pr_context.repository
-    collection_uri = pr_context.extras.get("collection_uri", "")
-    team_project = pr_context.extras.get("team_project", "")
-
-    if not all((pr_id, repo_id, collection_uri, team_project)):
-        _LOG.debug("Azure DevOps PR status: missing context — skipping")
-        return
-
-    token = _env(_ENV_SYSTEM_ACCESSTOKEN)
-    if not token:
-        _LOG.warning("Azure DevOps PR status: SYSTEM_ACCESSTOKEN not set — skipping")
-        return
-
-    state = "succeeded" if scan_result.is_clean else "failed"
-    findings_count = len(scan_result.findings)
-    description = (
-        _COMMIT_STATUS_DESCRIPTION_CLEAN
-        if scan_result.is_clean
-        else _COMMIT_STATUS_DESCRIPTION_VIOLATIONS.format(count=findings_count)
-    )
-    url = _AZURE_PR_STATUSES_PATH.format(
-        collection_uri=collection_uri,
-        team_project=team_project,
-        repo_id=repo_id,
-        pr_id=pr_id,
-        api_version=_AZURE_API_VERSION,
-    )
-    payload = {
-        "state": state,
-        "description": description,
-        "context": {
-            "name": _COMMIT_STATUS_CONTEXT,
-            "genre": "phi-scan",
-        },
-    }
-
-    execute_http_request(
-        HttpRequestConfig(
-            method=HttpMethod.POST,
-            url=url,
-            operation_label=OperationLabel.AZURE_PR_STATUS,
-            json_body=payload,
-            basic_auth_credentials=("", token),
-        )
-    )
-
-    _LOG.debug("Azure DevOps: PR status set to %s for PR #%s", state, pr_id)
-
-
-# ---------------------------------------------------------------------------
-# Public API — Azure Boards work-item linking
-# ---------------------------------------------------------------------------
-
-
-def create_azure_boards_work_item(scan_result: ScanResult, pr_context: PRContext) -> None:
-    """Create an Azure Boards Task work item for HIGH severity PHI/PII findings."""
-    if _env("AZURE_BOARDS_INTEGRATION") != "true":
-        _LOG.debug("Azure Boards: AZURE_BOARDS_INTEGRATION not enabled — skipping")
-        return
-
-    high_findings = [f for f in scan_result.findings if f.severity.value.lower() == "high"]
-    if not high_findings:
-        _LOG.debug("Azure Boards: no HIGH severity findings — skipping work item")
-        return
-
-    collection_uri = pr_context.extras.get("collection_uri", "")
-    team_project = pr_context.extras.get("team_project", "")
-    pr_id = pr_context.pull_request_number or "unknown"
-
-    if not all((collection_uri, team_project)):
-        _LOG.debug("Azure Boards: missing context — skipping work item")
-        return
-
-    token = _env(_ENV_SYSTEM_ACCESSTOKEN)
-    if not token:
-        _LOG.warning("Azure Boards: SYSTEM_ACCESSTOKEN not set — skipping")
-        return
-
-    title = _AZURE_WORK_ITEM_TITLE_FORMAT.format(
-        count=len(high_findings), pull_request_number=pr_id
-    )
-    url = _AZURE_WORK_ITEMS_PATH.format(
-        collection_uri=collection_uri,
-        team_project=team_project,
-        work_item_type=_AZURE_WORK_ITEM_TYPE,
-        api_version=_AZURE_API_VERSION,
-    )
-
-    patch_payload = [
-        {"op": "add", "path": "/fields/System.Title", "value": title},
-        {
-            "op": "add",
-            "path": "/fields/System.Description",
-            "value": (
-                f"phi-scan detected {len(high_findings)} HIGH severity PHI/PII "
-                f"violation(s) in PR #{pr_id}. "
-                "Remediate before merging."
-            ),
-        },
-        {"op": "add", "path": "/fields/System.Tags", "value": "phi-scan;security;phi-pii"},
-    ]
-
-    execute_http_request(
-        HttpRequestConfig(
-            method=HttpMethod.POST,
-            url=url,
-            operation_label=OperationLabel.AZURE_WORK_ITEM,
-            headers={"Content-Type": _AZURE_PATCH_CONTENT_TYPE},
-            json_body=patch_payload,
-            basic_auth_credentials=("", token),
-        )
-    )
-
-    _LOG.debug(
-        "Azure Boards: work item created for PR #%s (%d HIGH findings)",
-        pr_id,
-        len(high_findings),
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ci_integration_remaining.py
+++ b/tests/test_ci_integration_remaining.py
@@ -1492,3 +1492,23 @@ def test_bitbucket_code_insights_reexported_from_ci_integration() -> None:
         ci_integration_module.post_bitbucket_code_insights
         is bitbucket_module.post_bitbucket_code_insights
     ), "post_bitbucket_code_insights no longer re-exported from phi_scan.ci_integration"
+
+
+def test_azure_devops_reexported_from_ci_integration() -> None:
+    """set_azure_build_tag, set_azure_pr_status, and create_azure_boards_work_item
+    moved to phi_scan.ci.azure_devops; the legacy import path on
+    phi_scan.ci_integration must still resolve to the same callables so
+    existing callers and CI flows keep working."""
+    import phi_scan.ci.azure_devops as azure_module
+    import phi_scan.ci_integration as ci_integration_module
+
+    assert ci_integration_module.set_azure_build_tag is azure_module.set_azure_build_tag, (
+        "set_azure_build_tag no longer re-exported from phi_scan.ci_integration"
+    )
+    assert ci_integration_module.set_azure_pr_status is azure_module.set_azure_pr_status, (
+        "set_azure_pr_status no longer re-exported from phi_scan.ci_integration"
+    )
+    assert (
+        ci_integration_module.create_azure_boards_work_item
+        is azure_module.create_azure_boards_work_item
+    ), "create_azure_boards_work_item no longer re-exported from phi_scan.ci_integration"


### PR DESCRIPTION
## Summary
- Extract `set_azure_build_tag`, `set_azure_pr_status`, and `create_azure_boards_work_item` from `phi_scan/ci_integration.py` into `phi_scan/ci/azure_devops.py`.
- Re-export all three from `phi_scan.ci_integration` for backward compatibility.
- Promote every magic string/value to named constants: env var names, tag values (`phi-scan:clean`, `phi-scan:violations-found`), PR state strings (`succeeded`/`failed`), status context name/genre, work-item field paths (`/fields/System.Title`, etc.), JSON-patch `add` op, tags value, HIGH severity label, extras keys (`collection_uri`, `team_project`, `build_id`), and the unknown-PR fallback.
- Extract `_build_work_item_patch` and `_filter_high_severity_findings` helpers; extract `_fetch_azure_access_token` helper to remove duplicated token-read + warning blocks across the three functions.
- Use shared `phi_scan.ci._env.fetch_environment_variable` for env reads.
- Document PHI safety inline: outbound Azure payloads transmit counts, severity labels, file paths, and line numbers only.

## Test plan
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy phi_scan` clean (82 files)
- [x] `uv run pytest -q` — 1982 passed / 3 skipped / 90.93% coverage
- [x] New parity test `test_azure_devops_reexported_from_ci_integration` locks the re-export contract for all three callables