### PR TITLE
refactor(cli): extract CI dispatch from scan.py

### DIFF
--- a/phi_scan/cli/ci_dispatch.py
+++ b/phi_scan/cli/ci_dispatch.py
@@ -69,7 +69,7 @@ class CIIntegrationOptions:
         )
 
 
-def _call_ci_integration(operation: Callable[[], None], label: str, is_rich_mode: bool) -> None:
+def _execute_ci_integration(operation: Callable[[], None], label: str, is_rich_mode: bool) -> None:
     """Execute a CI integration operation, logging warnings on failure."""
     try:
         operation()
@@ -85,17 +85,17 @@ def _dispatch_azure_devops_extras(
     scan_result: ScanResult, pr_context: PullRequestContext, is_rich_mode: bool
 ) -> None:
     """Run Azure-specific PR status, build tag, and Boards work-item calls."""
-    _call_ci_integration(
+    _execute_ci_integration(
         lambda: set_azure_pr_status(scan_result, pr_context),
         _CI_LABEL_AZURE_PR_STATUS,
         is_rich_mode,
     )
-    _call_ci_integration(
+    _execute_ci_integration(
         lambda: set_azure_build_tag(scan_result, pr_context),
         _CI_LABEL_AZURE_BUILD_TAG,
         is_rich_mode,
     )
-    _call_ci_integration(
+    _execute_ci_integration(
         lambda: create_azure_boards_work_item(scan_result, pr_context),
         _CI_LABEL_AZURE_BOARDS,
         is_rich_mode,
@@ -106,7 +106,7 @@ def _dispatch_commit_status_integrations(
     scan_result: ScanResult, pr_context: PullRequestContext, is_rich_mode: bool
 ) -> None:
     """Post the generic commit status plus platform-specific status extras."""
-    _call_ci_integration(
+    _execute_ci_integration(
         lambda: set_commit_status(scan_result, pr_context),
         _CI_LABEL_COMMIT_STATUS,
         is_rich_mode,
@@ -114,7 +114,7 @@ def _dispatch_commit_status_integrations(
     if pr_context.platform is CIPlatform.AZURE_DEVOPS:
         _dispatch_azure_devops_extras(scan_result, pr_context, is_rich_mode)
     if pr_context.platform is CIPlatform.BITBUCKET:
-        _call_ci_integration(
+        _execute_ci_integration(
             lambda: post_bitbucket_code_insights(scan_result, pr_context),
             _CI_LABEL_BITBUCKET_INSIGHTS,
             is_rich_mode,
@@ -133,7 +133,7 @@ def dispatch_ci_integrations(
     pr_context = get_pr_context()
 
     if integration_options.should_post_comment:
-        _call_ci_integration(
+        _execute_ci_integration(
             lambda: post_pr_comment(scan_result, pr_context),
             _CI_LABEL_PR_COMMENT,
             is_rich_mode,
@@ -141,13 +141,13 @@ def dispatch_ci_integrations(
     if integration_options.should_set_status:
         _dispatch_commit_status_integrations(scan_result, pr_context, is_rich_mode)
     if integration_options.should_upload_sarif:
-        _call_ci_integration(
+        _execute_ci_integration(
             lambda: upload_sarif_to_github(scan_result, pr_context),
             _CI_LABEL_SARIF_UPLOAD,
             is_rich_mode,
         )
     if integration_options.should_import_to_security_hub:
-        _call_ci_integration(
+        _execute_ci_integration(
             lambda: import_findings_to_security_hub(scan_result, pr_context),
             _CI_LABEL_SECURITY_HUB,
             is_rich_mode,

--- a/phi_scan/cli/ci_dispatch.py
+++ b/phi_scan/cli/ci_dispatch.py
@@ -9,6 +9,7 @@ a single integration error never aborts the scan.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -51,8 +52,13 @@ class CIIntegrationOptions:
     should_set_status: bool
     should_upload_sarif: bool
 
+    @property
+    def has_any_enabled(self) -> bool:
+        """Return True when at least one integration flag is enabled."""
+        return self.should_post_comment or self.should_set_status or self.should_upload_sarif
 
-def _call_ci_integration(operation: Any, label: str, is_rich_mode: bool) -> None:
+
+def _call_ci_integration(operation: Callable[[], None], label: str, is_rich_mode: bool) -> None:
     """Execute a CI integration operation, logging warnings on failure."""
     try:
         operation()
@@ -67,6 +73,7 @@ def _call_ci_integration(operation: Any, label: str, is_rich_mode: bool) -> None
 def _dispatch_azure_devops_extras(
     scan_result: ScanResult, pr_context: Any, is_rich_mode: bool
 ) -> None:
+    """Run Azure-specific PR status, build tag, and Boards work-item calls."""
     _call_ci_integration(
         lambda: set_azure_pr_status(scan_result, pr_context),
         _CI_LABEL_AZURE_PR_STATUS,
@@ -84,19 +91,32 @@ def _dispatch_azure_devops_extras(
     )
 
 
-def run_ci_integration(
+def _dispatch_commit_status_integrations(
+    scan_result: ScanResult, pr_context: Any, is_rich_mode: bool
+) -> None:
+    """Post the generic commit status plus platform-specific status extras."""
+    _call_ci_integration(
+        lambda: set_commit_status(scan_result, pr_context),
+        _CI_LABEL_COMMIT_STATUS,
+        is_rich_mode,
+    )
+    if pr_context.platform is CIPlatform.AZURE_DEVOPS:
+        _dispatch_azure_devops_extras(scan_result, pr_context, is_rich_mode)
+    if pr_context.platform is CIPlatform.BITBUCKET:
+        _call_ci_integration(
+            lambda: post_bitbucket_code_insights(scan_result, pr_context),
+            _CI_LABEL_BITBUCKET_INSIGHTS,
+            is_rich_mode,
+        )
+
+
+def dispatch_ci_integrations(
     scan_result: ScanResult,
     integration_options: CIIntegrationOptions,
     is_rich_mode: bool,
 ) -> None:
-    """Run all enabled CI/CD platform integrations after a scan completes."""
-    if not any(
-        [
-            integration_options.should_post_comment,
-            integration_options.should_set_status,
-            integration_options.should_upload_sarif,
-        ]
-    ):
+    """Dispatch all enabled CI/CD platform integrations after a scan completes."""
+    if not integration_options.has_any_enabled:
         return
 
     pr_context = get_pr_context()
@@ -107,22 +127,8 @@ def run_ci_integration(
             _CI_LABEL_PR_COMMENT,
             is_rich_mode,
         )
-
     if integration_options.should_set_status:
-        _call_ci_integration(
-            lambda: set_commit_status(scan_result, pr_context),
-            _CI_LABEL_COMMIT_STATUS,
-            is_rich_mode,
-        )
-        if pr_context.platform is CIPlatform.AZURE_DEVOPS:
-            _dispatch_azure_devops_extras(scan_result, pr_context, is_rich_mode)
-        if pr_context.platform is CIPlatform.BITBUCKET:
-            _call_ci_integration(
-                lambda: post_bitbucket_code_insights(scan_result, pr_context),
-                _CI_LABEL_BITBUCKET_INSIGHTS,
-                is_rich_mode,
-            )
-
+        _dispatch_commit_status_integrations(scan_result, pr_context, is_rich_mode)
     if integration_options.should_upload_sarif:
         _call_ci_integration(
             lambda: upload_sarif_to_github(scan_result, pr_context),

--- a/phi_scan/cli/ci_dispatch.py
+++ b/phi_scan/cli/ci_dispatch.py
@@ -5,17 +5,22 @@ Bitbucket Code Insights, and AWS Security Hub imports after a scan
 completes. Each integration failure is logged as a warning and also
 surfaced to the Rich console when the command is running in rich mode;
 a single integration error never aborts the scan.
+
+Security Hub is gated by its own opt-in flag (``should_import_to_security_hub``)
+so that enabling, say, only ``--post-comment`` never causes a surprise
+upload of classification metadata to AWS. Each integration's data-flow
+surface is explicit at the call site.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
 
 from phi_scan.ci_integration import (
     CIIntegrationError,
     CIPlatform,
+    PullRequestContext,
     create_azure_boards_work_item,
     get_pr_context,
     import_findings_to_security_hub,
@@ -51,11 +56,17 @@ class CIIntegrationOptions:
     should_post_comment: bool
     should_set_status: bool
     should_upload_sarif: bool
+    should_import_to_security_hub: bool
 
     @property
     def has_any_enabled(self) -> bool:
         """Return True when at least one integration flag is enabled."""
-        return self.should_post_comment or self.should_set_status or self.should_upload_sarif
+        return (
+            self.should_post_comment
+            or self.should_set_status
+            or self.should_upload_sarif
+            or self.should_import_to_security_hub
+        )
 
 
 def _call_ci_integration(operation: Callable[[], None], label: str, is_rich_mode: bool) -> None:
@@ -71,7 +82,7 @@ def _call_ci_integration(operation: Callable[[], None], label: str, is_rich_mode
 
 
 def _dispatch_azure_devops_extras(
-    scan_result: ScanResult, pr_context: Any, is_rich_mode: bool
+    scan_result: ScanResult, pr_context: PullRequestContext, is_rich_mode: bool
 ) -> None:
     """Run Azure-specific PR status, build tag, and Boards work-item calls."""
     _call_ci_integration(
@@ -92,7 +103,7 @@ def _dispatch_azure_devops_extras(
 
 
 def _dispatch_commit_status_integrations(
-    scan_result: ScanResult, pr_context: Any, is_rich_mode: bool
+    scan_result: ScanResult, pr_context: PullRequestContext, is_rich_mode: bool
 ) -> None:
     """Post the generic commit status plus platform-specific status extras."""
     _call_ci_integration(
@@ -135,9 +146,9 @@ def dispatch_ci_integrations(
             _CI_LABEL_SARIF_UPLOAD,
             is_rich_mode,
         )
-
-    _call_ci_integration(
-        lambda: import_findings_to_security_hub(scan_result, pr_context),
-        _CI_LABEL_SECURITY_HUB,
-        is_rich_mode,
-    )
+    if integration_options.should_import_to_security_hub:
+        _call_ci_integration(
+            lambda: import_findings_to_security_hub(scan_result, pr_context),
+            _CI_LABEL_SECURITY_HUB,
+            is_rich_mode,
+        )

--- a/phi_scan/cli/ci_dispatch.py
+++ b/phi_scan/cli/ci_dispatch.py
@@ -1,0 +1,137 @@
+"""CI/CD integration dispatch for the `phi-scan scan` command.
+
+Runs PR comments, commit statuses, SARIF uploads, Azure DevOps extras,
+Bitbucket Code Insights, and AWS Security Hub imports after a scan
+completes. Each integration failure is logged as a warning and also
+surfaced to the Rich console when the command is running in rich mode;
+a single integration error never aborts the scan.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from phi_scan.ci_integration import (
+    CIIntegrationError,
+    CIPlatform,
+    create_azure_boards_work_item,
+    get_pr_context,
+    import_findings_to_security_hub,
+    post_bitbucket_code_insights,
+    post_pr_comment,
+    set_azure_build_tag,
+    set_azure_pr_status,
+    set_commit_status,
+    upload_sarif_to_github,
+)
+from phi_scan.logging_config import get_logger
+from phi_scan.models import ScanResult
+from phi_scan.output import get_console
+
+_logger = get_logger("cli")
+
+_CI_LABEL_PR_COMMENT: str = "PR comment"
+_CI_LABEL_COMMIT_STATUS: str = "commit status"
+_CI_LABEL_AZURE_PR_STATUS: str = "Azure PR status"
+_CI_LABEL_AZURE_BUILD_TAG: str = "Azure build tag"
+_CI_LABEL_AZURE_BOARDS: str = "Azure Boards work item"
+_CI_LABEL_BITBUCKET_INSIGHTS: str = "Bitbucket Code Insights"
+_CI_LABEL_SARIF_UPLOAD: str = "SARIF upload"
+_CI_LABEL_SECURITY_HUB: str = "Security Hub import"
+_CI_INTEGRATION_FAILURE_LOG: str = "CI integration (%s) failed: %s"
+_CI_INTEGRATION_RICH_WARNING: str = "[yellow]Warning:[/yellow] {label} failed — {error}"
+
+
+@dataclass(frozen=True)
+class CIIntegrationOptions:
+    """Flags controlling which CI/CD integrations run after a scan."""
+
+    should_post_comment: bool
+    should_set_status: bool
+    should_upload_sarif: bool
+
+
+def _call_ci_integration(operation: Any, label: str, is_rich_mode: bool) -> None:
+    """Execute a CI integration operation, logging warnings on failure."""
+    try:
+        operation()
+    except CIIntegrationError as integration_error:
+        _logger.warning(_CI_INTEGRATION_FAILURE_LOG, label, integration_error)
+        if is_rich_mode:
+            get_console().print(
+                _CI_INTEGRATION_RICH_WARNING.format(label=label, error=integration_error)
+            )
+
+
+def _dispatch_azure_devops_extras(
+    scan_result: ScanResult, pr_context: Any, is_rich_mode: bool
+) -> None:
+    _call_ci_integration(
+        lambda: set_azure_pr_status(scan_result, pr_context),
+        _CI_LABEL_AZURE_PR_STATUS,
+        is_rich_mode,
+    )
+    _call_ci_integration(
+        lambda: set_azure_build_tag(scan_result, pr_context),
+        _CI_LABEL_AZURE_BUILD_TAG,
+        is_rich_mode,
+    )
+    _call_ci_integration(
+        lambda: create_azure_boards_work_item(scan_result, pr_context),
+        _CI_LABEL_AZURE_BOARDS,
+        is_rich_mode,
+    )
+
+
+def run_ci_integration(
+    scan_result: ScanResult,
+    integration_options: CIIntegrationOptions,
+    is_rich_mode: bool,
+) -> None:
+    """Run all enabled CI/CD platform integrations after a scan completes."""
+    if not any(
+        [
+            integration_options.should_post_comment,
+            integration_options.should_set_status,
+            integration_options.should_upload_sarif,
+        ]
+    ):
+        return
+
+    pr_context = get_pr_context()
+
+    if integration_options.should_post_comment:
+        _call_ci_integration(
+            lambda: post_pr_comment(scan_result, pr_context),
+            _CI_LABEL_PR_COMMENT,
+            is_rich_mode,
+        )
+
+    if integration_options.should_set_status:
+        _call_ci_integration(
+            lambda: set_commit_status(scan_result, pr_context),
+            _CI_LABEL_COMMIT_STATUS,
+            is_rich_mode,
+        )
+        if pr_context.platform is CIPlatform.AZURE_DEVOPS:
+            _dispatch_azure_devops_extras(scan_result, pr_context, is_rich_mode)
+        if pr_context.platform is CIPlatform.BITBUCKET:
+            _call_ci_integration(
+                lambda: post_bitbucket_code_insights(scan_result, pr_context),
+                _CI_LABEL_BITBUCKET_INSIGHTS,
+                is_rich_mode,
+            )
+
+    if integration_options.should_upload_sarif:
+        _call_ci_integration(
+            lambda: upload_sarif_to_github(scan_result, pr_context),
+            _CI_LABEL_SARIF_UPLOAD,
+            is_rich_mode,
+        )
+
+    _call_ci_integration(
+        lambda: import_findings_to_security_hub(scan_result, pr_context),
+        _CI_LABEL_SECURITY_HUB,
+        is_rich_mode,
+    )

--- a/phi_scan/cli/scan.py
+++ b/phi_scan/cli/scan.py
@@ -31,7 +31,7 @@ from phi_scan.cli._shared import (
     _truncate_filename_for_progress,
     _validate_worker_count,
 )
-from phi_scan.cli.ci_dispatch import CIIntegrationOptions, run_ci_integration
+from phi_scan.cli.ci_dispatch import CIIntegrationOptions, dispatch_ci_integrations
 from phi_scan.cli.report import (
     ScanOutputOptions,
     display_report_phase_header,
@@ -426,7 +426,7 @@ def scan(
         should_set_status=should_set_status,
         should_upload_sarif=should_upload_sarif,
     )
-    run_ci_integration(scan_result, integration_options, is_rich_mode)
+    dispatch_ci_integrations(scan_result, integration_options, is_rich_mode)
     display_report_phase_header(output_options, phase_options.is_verbose)
     emit_report_output(scan_result, output_options, phase_options.should_use_baseline)
 

--- a/phi_scan/cli/scan.py
+++ b/phi_scan/cli/scan.py
@@ -138,6 +138,11 @@ _SCAN_UPLOAD_SARIF_HELP: str = (
     "Requires --output sarif and GITHUB_TOKEN. "
     "Each finding appears as an inline annotation on the exact line in the PR diff."
 )
+_SCAN_IMPORT_SECURITY_HUB_HELP: str = (
+    "Import findings to AWS Security Hub as ASFF. "
+    "Requires AWS_SECURITY_HUB=true, AWS_ACCOUNT_ID, and the AWS CLI. "
+    "Transmits classification metadata only — never raw PHI values or value hashes."
+)
 _SCAN_WORKERS_HELP: str = (
     f"Number of worker threads for parallel file scanning. Default 1 (sequential). "
     f"Values above 1 enable concurrent scanning up to {MAX_WORKER_COUNT}. "
@@ -375,6 +380,9 @@ def scan(
     should_upload_sarif: Annotated[
         bool, typer.Option("--upload-sarif", help=_SCAN_UPLOAD_SARIF_HELP)
     ] = False,
+    should_import_to_security_hub: Annotated[
+        bool, typer.Option("--import-security-hub", help=_SCAN_IMPORT_SECURITY_HUB_HELP)
+    ] = False,
     worker_count: Annotated[
         int, typer.Option("--workers", help=_SCAN_WORKERS_HELP)
     ] = _DEFAULT_WORKER_COUNT,
@@ -425,6 +433,7 @@ def scan(
         should_post_comment=should_post_comment,
         should_set_status=should_set_status,
         should_upload_sarif=should_upload_sarif,
+        should_import_to_security_hub=should_import_to_security_hub,
     )
     dispatch_ci_integrations(scan_result, integration_options, is_rich_mode)
     display_report_phase_header(output_options, phase_options.is_verbose)

--- a/phi_scan/cli/scan.py
+++ b/phi_scan/cli/scan.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import time
 from collections import deque
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated
 
 import typer
 from watchdog.observers import Observer
@@ -17,19 +16,6 @@ from phi_scan.audit import (
     _get_current_repository_path,
     ensure_current_schema,
     insert_scan_event,
-)
-from phi_scan.ci_integration import (
-    CIIntegrationError,
-    CIPlatform,
-    create_azure_boards_work_item,
-    get_pr_context,
-    import_findings_to_security_hub,
-    post_bitbucket_code_insights,
-    post_pr_comment,
-    set_azure_build_tag,
-    set_azure_pr_status,
-    set_commit_status,
-    upload_sarif_to_github,
 )
 from phi_scan.cli._shared import (
     _DEFAULT_WORKER_COUNT,
@@ -45,6 +31,7 @@ from phi_scan.cli._shared import (
     _truncate_filename_for_progress,
     _validate_worker_count,
 )
+from phi_scan.cli.ci_dispatch import CIIntegrationOptions, run_ci_integration
 from phi_scan.cli.report import (
     ScanOutputOptions,
     display_report_phase_header,
@@ -84,7 +71,6 @@ from phi_scan.output import (
     display_phase_scanning,
     display_scan_header,
     display_status_spinner,
-    get_console,
 )
 from phi_scan.scanner import (
     MAX_WORKER_COUNT,
@@ -172,17 +158,6 @@ _VERBOSE_PHASE_AUDIT: str = "writing audit record"
 _WATCH_PATH_DOES_NOT_EXIST: str = "Path does not exist: {path}"
 _WATCH_PATH_NOT_DIRECTORY: str = "Path is not a directory: {path}"
 _WATCH_PATH_PARAM_HINT: str = "'PATH'"
-
-_CI_LABEL_PR_COMMENT: str = "PR comment"
-_CI_LABEL_COMMIT_STATUS: str = "commit status"
-_CI_LABEL_AZURE_PR_STATUS: str = "Azure PR status"
-_CI_LABEL_AZURE_BUILD_TAG: str = "Azure build tag"
-_CI_LABEL_AZURE_BOARDS: str = "Azure Boards work item"
-_CI_LABEL_BITBUCKET_INSIGHTS: str = "Bitbucket Code Insights"
-_CI_LABEL_SARIF_UPLOAD: str = "SARIF upload"
-_CI_LABEL_SECURITY_HUB: str = "Security Hub import"
-_CI_INTEGRATION_FAILURE_LOG: str = "CI integration (%s) failed: %s"
-_CI_INTEGRATION_RICH_WARNING: str = "[yellow]Warning:[/yellow] {label} failed — {error}"
 
 
 def _run_sequential_scan_with_progress(
@@ -360,99 +335,6 @@ def _persist_audit_record(
         _write_audit_record(scan_result, scan_config.database_path, sent_channels)
 
 
-def _call_ci_integration(
-    operation: Any,
-    label: str,
-    is_rich_mode: bool,
-) -> None:
-    """Execute a CI integration operation, logging warnings on failure."""
-    try:
-        operation()
-    except CIIntegrationError as integration_error:
-        _logger.warning(_CI_INTEGRATION_FAILURE_LOG, label, integration_error)
-        if is_rich_mode:
-            get_console().print(
-                _CI_INTEGRATION_RICH_WARNING.format(label=label, error=integration_error)
-            )
-
-
-@dataclass(frozen=True)
-class _CIIntegrationOptions:
-    """Flags controlling which CI/CD integrations run after a scan."""
-
-    should_post_comment: bool
-    should_set_status: bool
-    should_upload_sarif: bool
-
-
-def _run_ci_integration(
-    scan_result: ScanResult,
-    integration_options: _CIIntegrationOptions,
-    is_rich_mode: bool,
-) -> None:
-    """Run all enabled CI/CD platform integrations after a scan completes."""
-    if not any(
-        [
-            integration_options.should_post_comment,
-            integration_options.should_set_status,
-            integration_options.should_upload_sarif,
-        ]
-    ):
-        return
-
-    pr_context = get_pr_context()
-
-    if integration_options.should_post_comment:
-        _call_ci_integration(
-            lambda: post_pr_comment(scan_result, pr_context),
-            _CI_LABEL_PR_COMMENT,
-            is_rich_mode,
-        )
-
-    if integration_options.should_set_status:
-        _call_ci_integration(
-            lambda: set_commit_status(scan_result, pr_context),
-            _CI_LABEL_COMMIT_STATUS,
-            is_rich_mode,
-        )
-        if pr_context.platform is CIPlatform.AZURE_DEVOPS:
-            _call_ci_integration(
-                lambda: set_azure_pr_status(scan_result, pr_context),
-                _CI_LABEL_AZURE_PR_STATUS,
-                is_rich_mode,
-            )
-            _call_ci_integration(
-                lambda: set_azure_build_tag(scan_result, pr_context),
-                _CI_LABEL_AZURE_BUILD_TAG,
-                is_rich_mode,
-            )
-            _call_ci_integration(
-                lambda: create_azure_boards_work_item(scan_result, pr_context),
-                _CI_LABEL_AZURE_BOARDS,
-                is_rich_mode,
-            )
-
-        if pr_context.platform is CIPlatform.BITBUCKET:
-            _call_ci_integration(
-                lambda: post_bitbucket_code_insights(scan_result, pr_context),
-                _CI_LABEL_BITBUCKET_INSIGHTS,
-                is_rich_mode,
-            )
-
-    if integration_options.should_upload_sarif:
-        _call_ci_integration(
-            lambda: upload_sarif_to_github(scan_result, pr_context),
-            _CI_LABEL_SARIF_UPLOAD,
-            is_rich_mode,
-        )
-
-    _call_ci_integration(
-        lambda: import_findings_to_security_hub(scan_result, pr_context),
-        _CI_LABEL_SECURITY_HUB,
-        is_rich_mode,
-    )
-
-
 def scan(
     path: Annotated[Path, typer.Argument(help=_SCAN_PATH_HELP)] = Path("."),
     diff_ref: Annotated[str | None, typer.Option("--diff", help=_SCAN_DIFF_HELP)] = None,
@@ -539,12 +421,12 @@ def scan(
     )
     _display_audit_phase_header(output_options, phase_options)
     _persist_audit_record(scan_result, scan_config, output_options)
-    integration_options = _CIIntegrationOptions(
+    integration_options = CIIntegrationOptions(
         should_post_comment=should_post_comment,
         should_set_status=should_set_status,
         should_upload_sarif=should_upload_sarif,
     )
-    _run_ci_integration(scan_result, integration_options, is_rich_mode)
+    run_ci_integration(scan_result, integration_options, is_rich_mode)
     display_report_phase_header(output_options, phase_options.is_verbose)
     emit_report_output(scan_result, output_options, phase_options.should_use_baseline)
 


### PR DESCRIPTION
## Summary
Phase 3 CLI decomp, slice 1: pull the CI/CD integration dispatch out of `phi_scan/cli/scan.py`.

- New module `phi_scan/cli/ci_dispatch.py` owns `CIIntegrationOptions`, `dispatch_ci_integrations`, and `_execute_ci_integration`. Azure DevOps extras and commit-status branches are lifted into `_dispatch_azure_devops_extras` and `_dispatch_commit_status_integrations` to flatten the dispatcher.
- `scan.py` sheds 10 `phi_scan.ci_integration` imports and the entire CI orchestration block.
- Sole caller is the `scan` command — no external API contract changes.

## Security improvement
**AWS Security Hub import is now explicit and opt-in.** Previously (inherited from pre-refactor `scan.py`), `import_findings_to_security_hub` fired unconditionally whenever any other CI flag was enabled. That meant `--post-comment` with `AWS_SECURITY_HUB=true` in the env would silently upload classification metadata to AWS without explicit consent. This PR adds `should_import_to_security_hub` to `CIIntegrationOptions` and a matching `--import-security-hub` CLI flag (default off). The `AWS_SECURITY_HUB=true` env gate inside `import_findings_to_security_hub` still applies as a second layer. ASFF has always transmitted classification metadata only (never raw values or value hashes), so there was no raw-PHI exposure — but the unexpected data-flow surface is now closed.

**Behaviour change:** callers relying on the implicit always-on import must add `--import-security-hub` explicitly.

## Test plan
- [x] ruff check / format clean
- [x] mypy clean (83 files)
- [x] pytest — 1982 passed / 3 skipped / 90.93% coverage
- [x] Smoke test: `phi-scan scan` on synthetic SSN/date fixture renders rich table and exits 1; clean-file scan exits 0