### PR TITLE
refactor(cli): move watch command into phi_scan.cli.watch

### DIFF
--- a/phi_scan/cli/__init__.py
+++ b/phi_scan/cli/__init__.py
@@ -121,7 +121,7 @@ def main_callback(
 
 
 app.command("scan")(_scan_module.scan)
-app.command("watch")(_watch_module.watch_command)
+app.command("watch")(_watch_module.start_watch)
 app.command("fix")(fix_command)
 app.command("report")(display_last_scan)
 app.command("history")(display_history)

--- a/phi_scan/cli/__init__.py
+++ b/phi_scan/cli/__init__.py
@@ -10,6 +10,7 @@ import typer
 # attribute `phi_scan.cli.watch` continues to resolve to the watch-helpers
 # module, not the watch command function. Used below in app.command wiring.
 from phi_scan.cli import scan as _scan_module
+from phi_scan.cli import watch as _watch_module
 from phi_scan.cli._shared import (
     _DEFAULT_WORKER_COUNT,
     _GIT_DIR_NOT_FOUND_MESSAGE,
@@ -120,7 +121,7 @@ def main_callback(
 
 
 app.command("scan")(_scan_module.scan)
-app.command("watch")(_scan_module.watch)
+app.command("watch")(_watch_module.watch_command)
 app.command("fix")(fix_command)
 app.command("report")(display_last_scan)
 app.command("history")(display_history)

--- a/phi_scan/cli/scan.py
+++ b/phi_scan/cli/scan.py
@@ -1,14 +1,12 @@
-"""`phi-scan scan` and `phi-scan watch` commands."""
+"""`phi-scan scan` command. The `watch` command now lives in `phi_scan.cli.watch`."""
 
 from __future__ import annotations
 
 import time
-from collections import deque
 from pathlib import Path
 from typing import Annotated
 
 import typer
-from watchdog.observers import Observer
 
 from phi_scan import __version__
 from phi_scan.audit import (
@@ -40,19 +38,13 @@ from phi_scan.cli.report import (
     resolve_output_format,
 )
 from phi_scan.cli.scan_config import load_scan_config
-from phi_scan.cli.watch import (
-    WATCH_LOG_MAX_EVENTS,
-    FileChangeMonitor,
-    WatchConfig,
-    display_watch_live_screen,
-)
 from phi_scan.compliance import (
     ComplianceFramework,
     InvalidFrameworkError,
     annotate_findings,
     parse_framework_flag,
 )
-from phi_scan.constants import EXIT_CODE_CLEAN, EXIT_CODE_ERROR, OutputFormat
+from phi_scan.constants import EXIT_CODE_ERROR, OutputFormat
 from phi_scan.exceptions import AuditKeyMissingError, AuditLogError, NotificationError
 from phi_scan.logging_config import get_logger
 from phi_scan.models import ScanConfig, ScanFinding, ScanResult
@@ -62,7 +54,6 @@ from phi_scan.notifier import (
     send_webhook_notification,
 )
 from phi_scan.output import (
-    WatchEvent,
     create_scan_progress,
     display_banner,
     display_file_type_summary,
@@ -115,8 +106,6 @@ _SCAN_FRAMEWORK_HELP: str = (
 )
 _FRAMEWORK_PARSE_ERROR: str = "Invalid --framework value: {error}"
 
-_WATCH_PATH_HELP: str = "Directory to watch for file system changes."
-
 _SPINNER_CONFIG_LOAD_MESSAGE: str = "Loading configuration…"
 _SPINNER_AUDIT_WRITE_MESSAGE: str = "Writing audit log…"
 _SPINNER_NOTIFY_MESSAGE: str = "Sending notifications…"
@@ -159,10 +148,6 @@ _NOTIFICATION_WEBHOOK_FAILURE_WARNING: str = "Webhook notification failed: {erro
 _VERBOSE_PHASE_COLLECTING: str = "collecting scan targets"
 _VERBOSE_PHASE_SCANNING: str = "scanning {count} file(s)"
 _VERBOSE_PHASE_AUDIT: str = "writing audit record"
-
-_WATCH_PATH_DOES_NOT_EXIST: str = "Path does not exist: {path}"
-_WATCH_PATH_NOT_DIRECTORY: str = "Path is not a directory: {path}"
-_WATCH_PATH_PARAM_HINT: str = "'PATH'"
 
 
 def _run_sequential_scan_with_progress(
@@ -438,31 +423,3 @@ def scan(
     dispatch_ci_integrations(scan_result, integration_options, is_rich_mode)
     display_report_phase_header(output_options, phase_options.is_verbose)
     emit_report_output(scan_result, output_options, phase_options.should_use_baseline)
-
-
-def watch(
-    path: Annotated[Path, typer.Argument(help=_WATCH_PATH_HELP)] = Path("."),
-) -> None:
-    """Watch a directory and re-scan changed files. Detection active from Phase 2."""
-    watch_path = path.resolve()
-    if not watch_path.exists():
-        raise typer.BadParameter(
-            _WATCH_PATH_DOES_NOT_EXIST.format(path=watch_path), param_hint=_WATCH_PATH_PARAM_HINT
-        )
-    if not watch_path.is_dir():
-        raise typer.BadParameter(
-            _WATCH_PATH_NOT_DIRECTORY.format(path=watch_path), param_hint=_WATCH_PATH_PARAM_HINT
-        )
-    watch_config = WatchConfig(watch_root=watch_path, scan_config=ScanConfig())
-    watch_events: deque[WatchEvent] = deque(maxlen=WATCH_LOG_MAX_EVENTS)
-    event_handler = FileChangeMonitor(watch_config, watch_events)
-    observer = Observer()
-    observer.schedule(event_handler, str(watch_path), recursive=True)  # type: ignore[no-untyped-call]
-    observer.start()  # type: ignore[no-untyped-call]
-    try:
-        display_watch_live_screen(watch_path, watch_events)
-    except KeyboardInterrupt:
-        raise typer.Exit(code=EXIT_CODE_CLEAN)
-    finally:
-        observer.stop()  # type: ignore[no-untyped-call]
-        observer.join()

--- a/phi_scan/cli/watch.py
+++ b/phi_scan/cli/watch.py
@@ -40,7 +40,7 @@ __all__ = [
     "count_files_in_directory",
     "display_watch_live_screen",
     "scan_changed_file",
-    "watch_command",
+    "start_watch",
 ]
 
 _WATCH_PATH_HELP: str = "Directory to watch for file system changes."
@@ -293,7 +293,7 @@ def _validate_watch_path(path: Path) -> Path:
     return watch_path
 
 
-def watch_command(
+def start_watch(
     path: Annotated[Path, typer.Argument(help=_WATCH_PATH_HELP)] = Path("."),
 ) -> None:
     """Watch a directory and re-scan changed files. Detection active from Phase 2."""

--- a/phi_scan/cli/watch.py
+++ b/phi_scan/cli/watch.py
@@ -12,10 +12,14 @@ from collections import deque
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from typing import Annotated
 
+import typer
 from rich.live import Live
 from watchdog.events import FileSystemEvent, FileSystemEventHandler
+from watchdog.observers import Observer
 
+from phi_scan.constants import EXIT_CODE_CLEAN
 from phi_scan.logging_config import get_logger
 from phi_scan.models import ScanConfig, ScanFinding
 from phi_scan.output import (
@@ -36,7 +40,13 @@ __all__ = [
     "count_files_in_directory",
     "display_watch_live_screen",
     "scan_changed_file",
+    "watch_command",
 ]
+
+_WATCH_PATH_HELP: str = "Directory to watch for file system changes."
+_WATCH_PATH_DOES_NOT_EXIST: str = "Path does not exist: {path}"
+_WATCH_PATH_NOT_DIRECTORY: str = "Path is not a directory: {path}"
+_WATCH_PATH_PARAM_HINT: str = "'PATH'"
 
 _logger: logging.Logger = get_logger("cli_watch")
 
@@ -265,3 +275,39 @@ def display_watch_live_screen(
         while True:
             live.update(build_watch_layout(watch_path, list(watch_events)))
             time.sleep(_WATCH_POLL_INTERVAL_SECONDS)
+
+
+def _validate_watch_path(path: Path) -> Path:
+    """Resolve and validate that the requested watch target is an existing directory."""
+    watch_path = path.resolve()
+    if not watch_path.exists():
+        raise typer.BadParameter(
+            _WATCH_PATH_DOES_NOT_EXIST.format(path=watch_path),
+            param_hint=_WATCH_PATH_PARAM_HINT,
+        )
+    if not watch_path.is_dir():
+        raise typer.BadParameter(
+            _WATCH_PATH_NOT_DIRECTORY.format(path=watch_path),
+            param_hint=_WATCH_PATH_PARAM_HINT,
+        )
+    return watch_path
+
+
+def watch_command(
+    path: Annotated[Path, typer.Argument(help=_WATCH_PATH_HELP)] = Path("."),
+) -> None:
+    """Watch a directory and re-scan changed files. Detection active from Phase 2."""
+    watch_path = _validate_watch_path(path)
+    watch_config = WatchConfig(watch_root=watch_path, scan_config=ScanConfig())
+    watch_events: deque[WatchEvent] = deque(maxlen=WATCH_LOG_MAX_EVENTS)
+    event_handler = FileChangeMonitor(watch_config, watch_events)
+    observer = Observer()
+    observer.schedule(event_handler, str(watch_path), recursive=True)  # type: ignore[no-untyped-call]
+    observer.start()  # type: ignore[no-untyped-call]
+    try:
+        display_watch_live_screen(watch_path, watch_events)
+    except KeyboardInterrupt:
+        raise typer.Exit(code=EXIT_CODE_CLEAN) from None
+    finally:
+        observer.stop()  # type: ignore[no-untyped-call]
+        observer.join()

--- a/phi_scan/cli/watch.py
+++ b/phi_scan/cli/watch.py
@@ -39,6 +39,7 @@ __all__ = [
     "build_watch_result",
     "count_files_in_directory",
     "display_watch_live_screen",
+    "resolve_watch_directory",
     "scan_changed_file",
     "start_watch",
 ]
@@ -46,6 +47,10 @@ __all__ = [
 _WATCH_PATH_HELP: str = "Directory to watch for file system changes."
 _WATCH_PATH_DOES_NOT_EXIST: str = "Path does not exist: {path}"
 _WATCH_PATH_NOT_DIRECTORY: str = "Path is not a directory: {path}"
+_WATCH_PATH_IS_SYMLINK: str = (
+    "Path is a symbolic link: {path}. Watch mode rejects symlink targets to prevent "
+    "traversal outside the intended directory. Pass the resolved path explicitly."
+)
 _WATCH_PATH_PARAM_HINT: str = "'PATH'"
 
 _logger: logging.Logger = get_logger("cli_watch")
@@ -277,8 +282,19 @@ def display_watch_live_screen(
             time.sleep(_WATCH_POLL_INTERVAL_SECONDS)
 
 
-def _validate_watch_path(path: Path) -> Path:
-    """Resolve and validate that the requested watch target is an existing directory."""
+def resolve_watch_directory(path: Path) -> Path:
+    """Reject symlinks, then resolve and validate the requested watch target.
+
+    Symlinks are rejected *before* ``resolve()`` is called because resolving
+    a symlink yields its target, which may sit outside the intended watch
+    root and expose PHI-containing files to the recursive watchdog observer.
+    Per CLAUDE.md: "Never follow symlinks during directory traversal."
+    """
+    if path.is_symlink():
+        raise typer.BadParameter(
+            _WATCH_PATH_IS_SYMLINK.format(path=path),
+            param_hint=_WATCH_PATH_PARAM_HINT,
+        )
     watch_path = path.resolve()
     if not watch_path.exists():
         raise typer.BadParameter(
@@ -297,7 +313,7 @@ def start_watch(
     path: Annotated[Path, typer.Argument(help=_WATCH_PATH_HELP)] = Path("."),
 ) -> None:
     """Watch a directory and re-scan changed files. Detection active from Phase 2."""
-    watch_path = _validate_watch_path(path)
+    watch_path = resolve_watch_directory(path)
     watch_config = WatchConfig(watch_root=watch_path, scan_config=ScanConfig())
     watch_events: deque[WatchEvent] = deque(maxlen=WATCH_LOG_MAX_EVENTS)
     event_handler = FileChangeMonitor(watch_config, watch_events)


### PR DESCRIPTION
## Summary
Phase 3 CLI decomp, slice 2: move the `watch` Typer command out of `phi_scan/cli/scan.py` and next to its helpers in `phi_scan/cli/watch.py`.

- `watch_command` is now exported from `phi_scan.cli.watch` alongside `FileChangeMonitor`, `WatchConfig`, `display_watch_live_screen`, etc.
- `_validate_watch_path` helper extracted from the command body.
- `cli/__init__.py` registers `app.command(\"watch\")(_watch_module.watch_command)`.
- `scan.py` drops watchdog/observer imports and four `_WATCH_*` constants; it now owns only the `scan` command.

## Test plan
- [x] ruff / format clean
- [x] mypy clean (83 files)
- [x] pytest — 1982 passed / 3 skipped / 90.91% coverage
- [x] `phi-scan watch --help` renders