### PR TITLE
refactor(cli): extract report writers

### DIFF
--- a/phi_scan/cli/report.py
+++ b/phi_scan/cli/report.py
@@ -13,17 +13,19 @@ from typing import TYPE_CHECKING, NoReturn
 
 import typer
 
-from phi_scan.audit import query_recent_scans
 from phi_scan.baseline import (
     BaselineSnapshot,
     filter_baselined_findings,
     load_baseline,
 )
+from phi_scan.cli.report_writers import (
+    generate_report_bytes,
+    write_binary_report,
+    write_report_text_to_file,
+)
 from phi_scan.constants import (
     BASELINE_LOAD_ERROR_MESSAGE,
     DEFAULT_BASELINE_FILENAME,
-    DEFAULT_DATABASE_PATH,
-    DEFAULT_TEXT_ENCODING,
     EXIT_CODE_CLEAN,
     EXIT_CODE_ERROR,
     EXIT_CODE_VIOLATION,
@@ -52,7 +54,6 @@ from phi_scan.output import (
     format_junit,
     format_sarif,
 )
-from phi_scan.report import generate_html_report, generate_pdf_report
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -85,20 +86,9 @@ _REPORT_PATH_TABLE_FORMAT_ERROR: str = (
     "--report-path requires a serialized output format. "
     "Use --output json, sarif, csv, junit, codequality, gitlab-sast, pdf, or html."
 )
-_REPORT_PATH_BINARY_FORMAT_REQUIRED_ERROR: str = (
-    "--output {format} requires --report-path <file.{format}> "
-    "-- binary formats cannot be written to stdout."
-)
-_UNEXPECTED_BINARY_FORMAT_ERROR: str = (
-    "_generate_report_bytes received unexpected output format {format!r} — "
-    "only OutputFormat.PDF and OutputFormat.HTML are supported"
-)
-_REPORT_PATH_WRITE_ERROR: str = "Failed to write report to {path!r}: {error}"
-_REPORT_PATH_WRITTEN_MESSAGE: str = "Report written to {path}"
 _VERBOSE_TIMESTAMP_FORMAT: str = "%Y-%m-%d %H:%M:%S"
 _VERBOSE_PHASE_PREFIX: str = "[{timestamp}] Phase: {message}"
 _VERBOSE_PHASE_REPORT: str = "rendering report"
-_TREND_CHART_LOOKBACK_DAYS: int = 30
 
 # ---------------------------------------------------------------------------
 # Output format serializer dispatch table
@@ -211,108 +201,6 @@ def display_rich_scan_results(scan_result: ScanResult) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Report file writing
-# ---------------------------------------------------------------------------
-
-
-def _invoke_report_writer(write_callable: Callable[[Path], object], report_path: Path) -> None:
-    try:
-        write_callable(report_path)
-    except OSError as write_error:
-        typer.echo(_REPORT_PATH_WRITE_ERROR.format(path=report_path, error=write_error), err=True)
-        raise typer.Exit(code=EXIT_CODE_ERROR) from write_error
-    typer.echo(_REPORT_PATH_WRITTEN_MESSAGE.format(path=report_path), err=True)
-
-
-def _write_report_to_file(content: str, report_path: Path) -> None:
-    """Write serialized report content to a file and confirm on stderr.
-
-    Args:
-        content: The serialized report string (JSON, XML, CSV, etc.).
-        report_path: Destination file path.
-
-    Raises:
-        typer.Exit: If the file cannot be written (e.g. permission error).
-    """
-    _invoke_report_writer(
-        lambda p: p.write_text(content, encoding=DEFAULT_TEXT_ENCODING), report_path
-    )
-
-
-def _write_report_bytes_to_file(content: bytes, report_path: Path) -> None:
-    """Write binary report content (PDF or HTML) to a file and confirm on stderr.
-
-    Args:
-        content: Raw bytes to write (PDF or UTF-8 HTML).
-        report_path: Destination file path.
-
-    Raises:
-        typer.Exit: If the file cannot be written (e.g. permission error).
-    """
-    _invoke_report_writer(lambda p: p.write_bytes(content), report_path)
-
-
-def generate_report_bytes(
-    scan_result: ScanResult,
-    options: ScanOutputOptions,
-    audit_rows: list[dict[str, object]],
-) -> bytes:
-    """Generate PDF or HTML report bytes from a scan result.
-
-    Args:
-        scan_result: The completed scan result.
-        options: Must have output_format in (OutputFormat.PDF, OutputFormat.HTML).
-            scan_target defaults to Path(".") when not supplied by the caller.
-        audit_rows: Recent audit rows for the trend chart.
-
-    Returns:
-        Raw bytes of the generated report (PDF or UTF-8 HTML).
-    """
-    if options.output_format not in {OutputFormat.PDF, OutputFormat.HTML}:
-        raise ValueError(_UNEXPECTED_BINARY_FORMAT_ERROR.format(format=options.output_format))
-    if options.output_format == OutputFormat.PDF:
-        return generate_pdf_report(
-            scan_result,
-            options.scan_target,
-            audit_rows,
-            options.framework_annotations,
-        )
-    return generate_html_report(
-        scan_result,
-        options.scan_target,
-        audit_rows,
-        options.framework_annotations,
-    )
-
-
-def _fetch_report_audit_rows() -> list[dict[str, object]]:
-    """Return recent audit rows for the binary report trend chart."""
-    database_path = Path(DEFAULT_DATABASE_PATH).expanduser()
-    return query_recent_scans(database_path, _TREND_CHART_LOOKBACK_DAYS)
-
-
-def _write_binary_report(scan_result: ScanResult, options: ScanOutputOptions) -> None:
-    """Write the rendered binary report to the path specified in options.
-
-    Args:
-        scan_result: The completed scan result.
-        options: Must have output_format in (pdf, html) and a non-None report_path.
-
-    Raises:
-        typer.Exit: If report_path is missing or the file cannot be written.
-    """
-    if options.report_path is None:
-        typer.echo(
-            _REPORT_PATH_BINARY_FORMAT_REQUIRED_ERROR.format(format=options.output_format.value),
-            err=True,
-        )
-        raise typer.Exit(code=EXIT_CODE_ERROR)
-    audit_rows = _fetch_report_audit_rows()
-    report_bytes = generate_report_bytes(scan_result, options, audit_rows)
-    _write_report_bytes_to_file(report_bytes, options.report_path)
-
-
-# ---------------------------------------------------------------------------
 # Scan output dispatch
 # ---------------------------------------------------------------------------
 
@@ -338,7 +226,7 @@ def emit_scan_output(scan_result: ScanResult, options: ScanOutputOptions) -> Non
             display_rich_scan_results(scan_result)
         return
     if options.output_format in (OutputFormat.PDF, OutputFormat.HTML):
-        _write_binary_report(scan_result, options)
+        write_binary_report(scan_result, options)
         return
     serializer = _FORMAT_SERIALIZERS.get(options.output_format)
     if serializer is None:
@@ -347,7 +235,7 @@ def emit_scan_output(scan_result: ScanResult, options: ScanOutputOptions) -> Non
         raise typer.Exit(code=EXIT_CODE_ERROR)
     serialized = serializer(scan_result)
     if options.report_path is not None:
-        _write_report_to_file(serialized, options.report_path)
+        write_report_text_to_file(serialized, options.report_path)
     else:
         typer.echo(serialized)
 

--- a/phi_scan/cli/report_writers.py
+++ b/phi_scan/cli/report_writers.py
@@ -1,0 +1,118 @@
+"""Report file-writing helpers for the `phi-scan scan` command.
+
+Isolates OS-facing file writes (text and binary) and binary-report
+generation (PDF / HTML) from the format dispatch logic in
+``cli/report.py``. Split out so that the text-format serializer path
+and the binary-report trend-chart path do not share a module with the
+higher-level dispatch function.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import typer
+
+from phi_scan.audit import query_recent_scans
+from phi_scan.constants import (
+    DEFAULT_DATABASE_PATH,
+    DEFAULT_TEXT_ENCODING,
+    EXIT_CODE_ERROR,
+    OutputFormat,
+)
+from phi_scan.report import generate_html_report, generate_pdf_report
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from phi_scan.cli.report import ScanOutputOptions
+    from phi_scan.models import ScanResult
+
+__all__ = [
+    "generate_report_bytes",
+    "write_binary_report",
+    "write_report_text_to_file",
+]
+
+_UNEXPECTED_BINARY_FORMAT_ERROR: str = (
+    "generate_report_bytes received unexpected output format {format!r} — "
+    "only OutputFormat.PDF and OutputFormat.HTML are supported"
+)
+_REPORT_PATH_BINARY_FORMAT_REQUIRED_ERROR: str = (
+    "--output {format} requires --report-path <file.{format}> "
+    "-- binary formats cannot be written to stdout."
+)
+_REPORT_PATH_WRITE_ERROR: str = "Failed to write report to {path!r}: {error}"
+_REPORT_PATH_WRITTEN_MESSAGE: str = "Report written to {path}"
+_TREND_CHART_LOOKBACK_DAYS: int = 30
+
+
+def _invoke_report_writer(write_callable: Callable[[Path], object], report_path: Path) -> None:
+    """Invoke a write callable on report_path, translating OS errors into typer.Exit."""
+    try:
+        write_callable(report_path)
+    except OSError as write_error:
+        typer.echo(_REPORT_PATH_WRITE_ERROR.format(path=report_path, error=write_error), err=True)
+        raise typer.Exit(code=EXIT_CODE_ERROR) from write_error
+    typer.echo(_REPORT_PATH_WRITTEN_MESSAGE.format(path=report_path), err=True)
+
+
+def write_report_text_to_file(content: str, report_path: Path) -> None:
+    """Write serialized report content to a file and confirm on stderr."""
+    _invoke_report_writer(
+        lambda destination_path: destination_path.write_text(
+            content, encoding=DEFAULT_TEXT_ENCODING
+        ),
+        report_path,
+    )
+
+
+def _write_report_bytes_to_file(content: bytes, report_path: Path) -> None:
+    """Write binary report content (PDF or HTML) to a file and confirm on stderr."""
+    _invoke_report_writer(
+        lambda destination_path: destination_path.write_bytes(content),
+        report_path,
+    )
+
+
+def generate_report_bytes(
+    scan_result: ScanResult,
+    options: ScanOutputOptions,
+    audit_rows: list[dict[str, object]],
+) -> bytes:
+    """Generate PDF or HTML report bytes from a scan result."""
+    if options.output_format not in {OutputFormat.PDF, OutputFormat.HTML}:
+        raise ValueError(_UNEXPECTED_BINARY_FORMAT_ERROR.format(format=options.output_format))
+    if options.output_format == OutputFormat.PDF:
+        return generate_pdf_report(
+            scan_result,
+            options.scan_target,
+            audit_rows,
+            options.framework_annotations,
+        )
+    return generate_html_report(
+        scan_result,
+        options.scan_target,
+        audit_rows,
+        options.framework_annotations,
+    )
+
+
+def _fetch_report_audit_rows() -> list[dict[str, object]]:
+    """Return recent audit rows for the binary report trend chart."""
+    database_path = Path(DEFAULT_DATABASE_PATH).expanduser()
+    return query_recent_scans(database_path, _TREND_CHART_LOOKBACK_DAYS)
+
+
+def write_binary_report(scan_result: ScanResult, options: ScanOutputOptions) -> None:
+    """Write the rendered binary report to the path specified in options."""
+    if options.report_path is None:
+        typer.echo(
+            _REPORT_PATH_BINARY_FORMAT_REQUIRED_ERROR.format(format=options.output_format.value),
+            err=True,
+        )
+        raise typer.Exit(code=EXIT_CODE_ERROR)
+    audit_rows = _fetch_report_audit_rows()
+    report_bytes = generate_report_bytes(scan_result, options, audit_rows)
+    _write_report_bytes_to_file(report_bytes, options.report_path)


### PR DESCRIPTION
## Summary
- Extract file-writing and binary-report (PDF/HTML) helpers out of cli/report.py into a new cli/report_writers.py (~118 lines).
- cli/report.py down from 461 → 349 lines, focused on format dispatch, rich rendering, and baseline output.
- Public helpers (generate_report_bytes, write_binary_report, write_report_text_to_file) live in the new module; dispatch calls them via direct import.
- Behavior unchanged.

## Test plan
- [x] uv run ruff check / format
- [x] uv run mypy
- [x] uv run pytest — 1982 passed