### PR TITLE
ops(migration): close pre-flight evidence gaps and defer GHCR

### DIFF
--- a/docs/migration/communication-draft.md
+++ b/docs/migration/communication-draft.md
@@ -15,9 +15,10 @@ Drafts only — **do not publish** until the transfer has completed and the
 > canonical URL is https://github.com/phiscanhq/phi-scan.
 >
 > No action is required by existing users. `pip install phi-scan` still
-> installs the same package from PyPI; container images continue to be
-> published to `ghcr.io/phiscanhq/phi-scan` (with historical tags
-> remaining on the old path for this observation window).
+> installs the same package from PyPI. Container image publication to
+> the new canonical path is handled separately as a post-migration
+> hardening step and is not part of this transfer; existing
+> `ghcr.io/joeyessak/phi-scan` tags remain resolvable.
 >
 > If you sign-verify releases with Sigstore / cosign, update the
 > `--cert-identity` flag from
@@ -40,9 +41,10 @@ verification commands must reference the new OIDC subject
 `repo:phiscanhq/phi-scan:…` for releases from this version onward; the
 published `docs/supply-chain.md` example command has been updated.
 
-Old GitHub URLs redirect automatically; the old container path at
-`ghcr.io/joeyessak/phi-scan` remains resolvable during the 48-hour
-observation window documented in `docs/org-migration-checklist.md`.
+Old GitHub URLs redirect automatically. Container image publication to
+the new canonical path is deferred to a post-migration hardening track
+and is not part of this release; `ghcr.io/joeyessak/phi-scan` remains
+resolvable.
 ```
 
 ---

--- a/docs/migration/go-no-go.md
+++ b/docs/migration/go-no-go.md
@@ -23,7 +23,7 @@ described in `docs/org-migration-checklist.md` §2. Every row must be
 | # | Check | Status | Evidence link |
 |---|-------|--------|---------------|
 | 8 | PyPI 2FA confirmed | `GO` / `NO-GO` | `docs/migration/maintainer-checklist.md#1-pypi-2fa-confirmation` |
-| 9 | GHCR pull + digest recorded | `GO` / `NO-GO` | `docs/migration/maintainer-checklist.md#2-ghcr-pull--digest-verification` |
+| 9 | ~~GHCR pull + digest recorded~~ | **`N/A — DEFERRED`** | Out-of-scope for migration-go; see [`docs/org-migration-status.md`](../org-migration-status.md) |
 | 10 | Sigstore bundle verifies under current subject | `GO` / `NO-GO` | `docs/migration/maintainer-checklist.md#3-sigstore--keyless-oidc-verification` |
 
 ## Operational gates

--- a/docs/migration/maintainer-checklist.md
+++ b/docs/migration/maintainer-checklist.md
@@ -33,14 +33,20 @@ Date confirmed: `YYYY-MM-DD`
 
 ---
 
-## 2. GHCR pull + digest verification
+## 2. GHCR pull + digest verification — **Deferred (post-migration hardening)**
 
 ```
-STATUS: PENDING
+STATUS: DEFERRED — out-of-scope for migration-go
 ```
 
-**Required:** Pull the current canonical container image and record the
-manifest digest so post-transfer parity can be verified.
+> GHCR container publication is not required for migration-go (PyPI is
+> the sole required distribution channel). This section is retained
+> for the later post-migration hardening track. See
+> [`docs/org-migration-status.md`](../org-migration-status.md).
+
+**Post-migration hardening (not a migration-go gate):** pull the current
+canonical container image and record the manifest digest so
+post-transfer parity can be verified.
 
 Commands to run (authenticated to ghcr.io):
 
@@ -103,8 +109,9 @@ Date confirmed: `YYYY-MM-DD`
 
 ## 4. Roll-up
 
-All three rows above must be `STATUS: DONE` before the maintainer gives
-the "migration go" approval referenced in §1.6 of the runbook.
+Rows §1 (PyPI 2FA) and §3 (Sigstore) must be `STATUS: DONE` before the
+maintainer gives the "migration go" approval referenced in §1.6 of the
+runbook. Row §2 (GHCR) is **deferred** and is not a migration-go gate.
 
 Signed off by: `MAINTAINER_NAME`
 Date: `YYYY-MM-DD`

--- a/docs/migration/ticket-template.md
+++ b/docs/migration/ticket-template.md
@@ -39,7 +39,8 @@ Out of scope: `phi-scan-pro` (does not exist; see
 - [ ] Repo configuration re-applied (§2.2)
 - [ ] PyPI token rotated (§2.3)
 - [ ] Sigstore bundle verified under new OIDC subject (§2.4)
-- [ ] GHCR image pushed to new canonical path (§2.5)
+- [ ] ~~GHCR image pushed to new canonical path (§2.5)~~ **Deferred —
+      out-of-scope for migration-go; post-migration hardening.**
 - [ ] Hardcoded-reference sweep round 2 (§2.6)
 - [ ] End-to-end validation (§2.7) passes
 - [ ] `phi-scan-action` transfer initiated (§3) — **only after** §2.7
@@ -48,14 +49,16 @@ Out of scope: `phi-scan-pro` (does not exist; see
 
 - [ ] 48h freeze on new releases unless emergency
 - [ ] Daily CI check
-- [ ] Ghcr pull counts monitored on old and new paths
+- [ ] ~~Ghcr pull counts monitored on old and new paths~~ **Deferred —
+      GHCR is out-of-scope for migration-go.**
 - [ ] Issues monitored for redirect or signing failures
 
 ### Cleanup (§4.3)
 
 - [ ] Old PyPI token revoked
 - [ ] Post-mortem note added to this ticket
-- [ ] Legacy ghcr image path schedule set for a future minor release
+- [ ] ~~Legacy ghcr image path schedule set for a future minor release~~
+      **Deferred — handled in post-migration hardening track.**
 
 ### Rollback plan
 

--- a/docs/org-migration-checklist.md
+++ b/docs/org-migration-checklist.md
@@ -10,6 +10,16 @@ Pre-flight execution is recorded in
 which captures the §1 snapshot, the hardcoded-reference sweep, the
 external-dependency inventory, and the go/no-go readiness matrix.
 
+Operational status (live) is tracked in
+[`docs/org-migration-status.md`](org-migration-status.md). That page is
+the single source of truth for "what is left before migration-go".
+
+**GHCR scope:** PyPI is the only required distribution channel for
+migration-go. GHCR container publication is deferred to a
+post-migration hardening track and is **not a transfer blocker**. GHCR
+items below are retained for post-migration reference and are marked
+**Deferred**.
+
 ## Scope
 
 - `joeyessak/phi-scan` → `phiscanhq/phi-scan`
@@ -52,8 +62,9 @@ or rely on GitHub redirect) before proceeding.
 - [ ] `pyproject.toml` — project URLs (`Homepage`, `Source`, `Issues`).
 - [ ] `.pre-commit-hooks.yaml` and any consumer-facing
       `.pre-commit-config.yaml` example.
-- [ ] Docker image references in docs and workflows
-      (`ghcr.io/joeyessak/phi-scan`).
+- [ ] ~~Docker image references in docs and workflows
+      (`ghcr.io/joeyessak/phi-scan`).~~ **Deferred — post-migration
+      hardening (out-of-scope for migration-go).**
 
 Command reference (run locally, not blocking):
 
@@ -91,7 +102,9 @@ new org.
 
 - [ ] PyPI project `phi-scan` — owner currently `joeyessak`; confirm
       maintainer email and 2FA status.
-- [ ] ghcr.io — current image path `ghcr.io/joeyessak/phi-scan`.
+- [ ] ~~ghcr.io — current image path `ghcr.io/joeyessak/phi-scan`.~~
+      **Deferred — post-migration hardening (out-of-scope for
+      migration-go).**
 - [ ] Sigstore signing — currently keyless OIDC with workload subject
       `repo:joeyessak/phi-scan:…`.
 - [ ] `phi-scan-action` — consumers reference via `joeyessak/phi-scan-action@v1`.
@@ -166,7 +179,13 @@ encodes the repo path and will change at transfer time from
 - [ ] Update `docs/supply-chain.md` verification example to reference the
       new subject.
 
-### 2.5 GHCR container continuity
+### 2.5 GHCR container continuity — **Deferred (post-migration hardening)**
+
+> **Deferred — out-of-scope for migration-go.** GHCR container
+> publication is not required for the PyPI-focused transfer. The steps
+> below are retained for a later post-migration hardening PR and must
+> not gate migration-go. See
+> [`docs/org-migration-status.md`](org-migration-status.md).
 
 - [ ] Build and push the image to `ghcr.io/phiscanhq/phi-scan` tagged
       with the current release version and `latest`.
@@ -232,15 +251,17 @@ During the first 48 hours after `phi-scan` transfer:
 - [ ] Monitor issues for redirect failures, pre-commit resolution errors,
       or signing verification failures.
 - [ ] Monitor CI on `main` daily.
-- [ ] Track ghcr pull counts on both old and new image paths to detect
-      stale references.
+- [ ] ~~Track ghcr pull counts on both old and new image paths to detect
+      stale references.~~ **Deferred — GHCR is out-of-scope for
+      migration-go; revisit in post-migration hardening.**
 
 ### 4.3 Cleanup (after 48h clean)
 
 - [ ] Revoke old PyPI token (if not already done in §2.3).
 - [ ] Close the migration ticket with a summary and post-mortem note.
-- [ ] Schedule removal of the legacy ghcr image path for a later minor
-      release, with notice.
+- [ ] ~~Schedule removal of the legacy ghcr image path for a later minor
+      release, with notice.~~ **Deferred — handled in post-migration
+      hardening track.**
 
 ---
 
@@ -271,8 +292,9 @@ redirect failure), execute rollback:
       token was already published.
 - [ ] Re-validate Sigstore subject reverts to
       `repo:joeyessak/phi-scan:…` for subsequent signing runs.
-- [ ] Revert ghcr image path in docs/workflows; keep any `phiscanhq/`
-      images in place for historical access.
+- [ ] ~~Revert ghcr image path in docs/workflows; keep any `phiscanhq/`
+      images in place for historical access.~~ **Deferred — GHCR was
+      out-of-scope for migration-go; no ghcr changes to revert.**
 
 ### 5.4 Post-rollback
 
@@ -298,6 +320,6 @@ written. Refresh this section immediately before execution.
 | Required status check | `Python 3.12 on ubuntu-latest` |
 | Actions secrets | `ANTHROPIC_API_KEY`, `PYPI_API_TOKEN` |
 | PyPI project | `phi-scan` |
-| Container image | `ghcr.io/joeyessak/phi-scan` → `ghcr.io/phiscanhq/phi-scan` |
+| Container image | `ghcr.io/joeyessak/phi-scan` → `ghcr.io/phiscanhq/phi-scan` *(Deferred — post-migration hardening)* |
 | Sigstore OIDC subject | `repo:joeyessak/phi-scan:…` → `repo:phiscanhq/phi-scan:…` |
 | Observation window | 48 hours post-transfer |

--- a/docs/org-migration-preflight-report.md
+++ b/docs/org-migration-preflight-report.md
@@ -183,7 +183,14 @@ after `pyproject.toml` is flipped (§2.2) will carry the new URLs.
 **2FA status** is not exposed on the public JSON endpoint and must be
 confirmed by the maintainer out-of-band (maintainer-run check).
 
-### 4.2 GHCR (maintainer-run — not queried live)
+### 4.2 GHCR — **Deferred (post-migration hardening)**
+
+> **Deferred — out-of-scope for migration-go.** PyPI is the only
+> required distribution channel for the transfer. GHCR container
+> publication is not a migration-go blocker. The commands below remain
+> useful for the later post-migration hardening track but must not
+> gate migration-go. See
+> [`docs/org-migration-status.md`](org-migration-status.md).
 
 - Current canonical image path per docs: `ghcr.io/joeyessak/phi-scan`.
 - Live image manifest verification is deferred to the maintainer to
@@ -236,17 +243,19 @@ confirmed by the maintainer out-of-band (maintainer-run check).
 | 5 | Variables / environments / webhooks enumerated | **READY** | §3.3–3.5 — all empty |
 | 6 | Collaborators / teams / `CODEOWNERS` enumerated | **READY** | §3.6 — solo admin, no `CODEOWNERS` |
 | 7 | PyPI owner + 2FA confirmed | **PENDING MAINTAINER** | Owner email confirmed via public API; 2FA status needs out-of-band check |
-| 8 | GHCR manifest reachable and current | **PENDING MAINTAINER** | Auth-gated; commands listed in §4.2 |
+| 8 | GHCR manifest reachable and current | **DEFERRED** | Out-of-scope for migration-go — see [`docs/org-migration-status.md`](org-migration-status.md). Post-migration hardening only. |
 | 9 | Sigstore bundle verifies under current subject | **PENDING MAINTAINER** | Commands listed in §4.3 |
-| 10 | Draft migration notice prepared | **NOT STARTED** | §1.5 of checklist (non-blocking for pre-flight merge) |
-| 11 | Draft release-notes entry prepared | **NOT STARTED** | §1.5 of checklist (non-blocking for pre-flight merge) |
+| 10 | Draft migration notice prepared | **DONE** | [`docs/migration/communication-draft.md §1`](migration/communication-draft.md) |
+| 11 | Draft release-notes entry prepared | **DONE** | [`docs/migration/communication-draft.md §2`](migration/communication-draft.md) |
 | 12 | Migration ticket opened | **NOT STARTED** | §1.6 of checklist |
 | 13 | Maintainer "migration go" approval | **NOT GIVEN** | §1.6 of checklist — requested after this report is merged |
 
-**Overall:** No P0 blockers found. Six automated gates READY; three
-require maintainer-run verification (2FA, GHCR, Sigstore) before
-transfer; four are operational tasks to complete during §1.5–§1.6 of
-the checklist.
+**Overall:** No P0 blockers found. Six automated gates READY; two
+require maintainer-run verification (PyPI 2FA, Sigstore) before
+transfer; GHCR is **deferred** as out-of-scope for migration-go;
+drafts (rows 10, 11) are complete; the remaining operational tasks
+(rows 12, 13) are executed during §1.5–§1.6 of the checklist. Live
+status tracked in [`docs/org-migration-status.md`](org-migration-status.md).
 
 ---
 

--- a/docs/org-migration-status.md
+++ b/docs/org-migration-status.md
@@ -1,0 +1,95 @@
+# Org Migration Status — `joeyessak/*` → `phiscanhq/*`
+
+**Date:** 2026-04-13
+**Purpose:** Single operational source of truth for migration-go readiness.
+**Runbook:** [`docs/org-migration-checklist.md`](org-migration-checklist.md)
+**Pre-flight snapshot:** [`docs/org-migration-preflight-report.md`](org-migration-preflight-report.md)
+**Final gate form:** [`docs/migration/go-no-go.md`](migration/go-no-go.md)
+**Maintainer evidence form:** [`docs/migration/maintainer-checklist.md`](migration/maintainer-checklist.md)
+**Comms drafts (not published):** [`docs/migration/communication-draft.md`](migration/communication-draft.md)
+**Tracking-issue template:** [`docs/migration/ticket-template.md`](migration/ticket-template.md)
+
+No transfer action has been taken. No repo config has been changed.
+
+---
+
+## Scope decision — GHCR deferred
+
+PyPI is the only required distribution channel for migration-go. GHCR
+container publication is deferred to a post-migration hardening track
+and is **not a transfer blocker**. All GHCR-related gates in the
+checklist, pre-flight report, go/no-go form, maintainer checklist,
+ticket template, and communication drafts have been reclassified as
+**DEFERRED** in this PR.
+
+CI workflow files are intentionally unchanged in this PR. Any container
+publish steps that currently reference `ghcr.io/joeyessak/phi-scan`
+remain operational and will be addressed in a later post-migration
+hardening PR.
+
+---
+
+## Classification table
+
+Every migration-go readiness item, classified so the maintainer can
+execute from one page.
+
+| # | Item | Classification | Evidence / Unblock command |
+|---|------|----------------|-----------------------------|
+| 1 | Repo clean (no open PRs, no in-flight runs, `main` green) | **done-with-evidence** | Pre-flight §1 (verified 2026-04-18) |
+| 2 | Hardcoded-reference sweep with plan | **done-with-evidence** | Pre-flight §2 (0 P0, 15 P1 hunks, 5 P2 entries) |
+| 3 | Branch-protection ruleset captured | **done-with-evidence** | Pre-flight §3.1 (ruleset `14041817` `Protect main`) |
+| 4 | Actions secrets enumerated | **done-with-evidence** | Pre-flight §3.2 (`ANTHROPIC_API_KEY`, `PYPI_API_TOKEN`) |
+| 5 | Variables / environments / webhooks | **done-with-evidence** | Pre-flight §3.3–3.5 (all empty) |
+| 6 | Collaborators / teams / `CODEOWNERS` | **done-with-evidence** | Pre-flight §3.6 (solo admin, no `CODEOWNERS`) |
+| 7 | PyPI 2FA confirmed | **pending-with-command** | `docs/migration/maintainer-checklist.md §1` — out-of-band confirmation + evidence paste |
+| 8 | GHCR pull + digest recorded | **de-scoped** | See "Scope decision — GHCR deferred" above |
+| 9 | Sigstore bundle verifies under current subject | **pending-with-command** | `docs/migration/maintainer-checklist.md §3` — run `cosign verify-blob` on latest release bundle |
+| 10 | Draft migration notice prepared | **done-with-evidence** | [`docs/migration/communication-draft.md §1`](migration/communication-draft.md) |
+| 11 | Draft release-notes entry prepared | **done-with-evidence** | [`docs/migration/communication-draft.md §2`](migration/communication-draft.md) |
+| 12 | Migration ticket opened | **pending-with-command** | `gh issue create --repo joeyessak/phi-scan -F docs/migration/ticket-template.md --title "Migrate phi-scan from joeyessak/* to phiscanhq/*"` |
+| 13 | Maintainer "migration go" approval | **pending-with-command** | Sign off on [`docs/migration/go-no-go.md`](migration/go-no-go.md) after rows 1–12 are GO |
+
+---
+
+## Migration-go blockers remaining
+
+Only four items stand between current state and executable migration-go:
+
+1. **PyPI 2FA** — maintainer confirms out-of-band; paste evidence into
+   `docs/migration/maintainer-checklist.md §1`.
+2. **Sigstore verification** — maintainer runs `cosign verify-blob`
+   against the latest release bundle and pastes the `Verified OK`
+   output into `docs/migration/maintainer-checklist.md §3`.
+3. **Migration ticket** — open one tracking issue using
+   `docs/migration/ticket-template.md`.
+4. **Maintainer go approval** — sign off on `docs/migration/go-no-go.md`
+   once every other gate reads `GO`.
+
+No other gate requires action. No repo config, workflow, or code change
+is needed before migration-go.
+
+---
+
+## What changes after migration-go
+
+Execution order is frozen in `docs/org-migration-checklist.md` §2–§5.
+This status doc is updated after each phase boundary:
+
+1. After §2.7 passes — mark `phi-scan` transfer complete; append digest
+   evidence if available.
+2. After §3 completes — mark `phi-scan-action` transfer complete.
+3. After the 48-hour observation window closes — close out this status
+   doc and link to the post-mortem note on the migration ticket.
+
+---
+
+## Not in PR 1
+
+The following are intentionally out of scope for the status-closure PR:
+
+- CI workflow edits (including any `ghcr.io/joeyessak/phi-scan` references).
+- Relocation of drafts out of `docs/migration/communication-draft.md`.
+- Any transfer action or URL flip.
+- Any content change to the drafts themselves beyond softening the
+  container-image language consistent with the GHCR deferral.

--- a/docs/org-migration-status.md
+++ b/docs/org-migration-status.md
@@ -1,6 +1,7 @@
 # Org Migration Status — `joeyessak/*` → `phiscanhq/*`
 
-**Date:** 2026-04-13
+**Last updated:** 2026-04-13
+**Pre-flight evidence date:** 2026-04-18 (per [`docs/org-migration-preflight-report.md`](org-migration-preflight-report.md); evidence remains valid — refresh before transfer per runbook Appendix A)
 **Purpose:** Single operational source of truth for migration-go readiness.
 **Runbook:** [`docs/org-migration-checklist.md`](org-migration-checklist.md)
 **Pre-flight snapshot:** [`docs/org-migration-preflight-report.md`](org-migration-preflight-report.md)


### PR DESCRIPTION
## Summary

- Add \`docs/org-migration-status.md\` as the single operational source of truth for migration-go readiness, with a classification table (done-with-evidence / pending-with-command / de-scoped) so the maintainer can execute from one page.
- Formally scope GHCR **out** of migration-go. PyPI is the only required distribution channel; GHCR container publication is deferred to a post-migration hardening track and is no longer a transfer blocker. Deferral applied consistently across checklist, pre-flight report, go/no-go form, maintainer checklist, ticket template, and communication drafts. GHCR content is retained (not deleted) behind "Deferred" banners.
- Reclassify pre-flight readiness rows 10 and 11 from NOT STARTED to DONE — the migration notice and release-notes entry drafts already exist in \`docs/migration/communication-draft.md\`.
- CI workflows are intentionally unchanged in this PR.

**Migration-go blockers remaining:** PyPI 2FA + Sigstore verification + migration ticket + maintainer go approval.

## Test plan

- [x] \`uv run ruff check .\` — All checks passed
- [x] \`uv run mypy phi_scan\` — Success: no issues found in 86 source files
- [x] \`uv run pytest -q\` — 1982 passed, 3 skipped; coverage 90.91%
- [x] No contradictions remain between checklist and pre-flight report
- [x] All "pending maintainer" items are either pending-with-command or explicitly de-scoped
- [x] No transfer actions taken; no repo config changed