### PR TITLE
refactor(ci): finish ci_integration shim reduction (phase-3 closure)

### DIFF
--- a/phi_scan/ci/comment_body.py
+++ b/phi_scan/ci/comment_body.py
@@ -27,7 +27,7 @@ _COMMENT_BADGE_VIOLATIONS: str = (
 )
 
 _MAX_COMMENT_LENGTH: int = 60_000
-_COMMENT_BODY_SPLIT_MAXSPLIT: int = 2
+_COMMENT_BODY_NEWLINE_SPLIT_LIMIT: int = 2
 _COMMENT_MIN_SECTION_COUNT: int = 2
 _BASELINE_CONTEXT_FORMAT: str = (
     "**{new_findings_count} new** | "
@@ -144,7 +144,7 @@ def _insert_baseline_context_into_comment(
     baseline_line: str,
 ) -> str:
     """Insert a baseline context line after the first header line of a comment body."""
-    lines = comment_body.split("\n", _COMMENT_BODY_SPLIT_MAXSPLIT)
+    lines = comment_body.split("\n", _COMMENT_BODY_NEWLINE_SPLIT_LIMIT)
     if len(lines) < _COMMENT_MIN_SECTION_COUNT:
         return baseline_line + "\n\n" + comment_body
     return "\n".join([lines[0], "", baseline_line, "", *lines[1:]])

--- a/phi_scan/ci/comment_body.py
+++ b/phi_scan/ci/comment_body.py
@@ -27,7 +27,9 @@ _COMMENT_BADGE_VIOLATIONS: str = (
 )
 
 _MAX_COMMENT_LENGTH: int = 60_000
-_COMMENT_BODY_SPLIT_MAX_PARTS: int = 2
+# ``str.split(sep, maxsplit)`` returns at most ``maxsplit + 1`` items. This
+# constant is the ``maxsplit`` argument, not a count of resulting parts.
+_COMMENT_BODY_SPLIT_MAXSPLIT: int = 2
 _COMMENT_MIN_SECTION_COUNT: int = 2
 _BASELINE_CONTEXT_FORMAT: str = (
     "**{new_findings_count} new** | "
@@ -46,32 +48,9 @@ class BaselineComparison:
     resolved_count: int
 
 
-def build_comment_body(scan_result: ScanResult) -> SanitisedCommentBody:
-    """Build a markdown PR/MR comment body from a ``ScanResult``.
-
-    The body contains only counts, file names, and line numbers — never raw
-    entity values. Truncated to ``_MAX_COMMENT_LENGTH`` characters to stay
-    within platform comment size limits.
-    """
-    if scan_result.is_clean:
-        header = _COMMENT_HEADER_CLEAN
-        badge = _COMMENT_BADGE_CLEAN
-        body_lines = [
-            f"{badge}",
-            "",
-            f"**{header}**",
-            "",
-            f"Scanned **{scan_result.files_scanned}** file(s) — no PHI/PII detected.",
-            "",
-            f"*Scan duration: {scan_result.scan_duration:.2f}s*",
-        ]
-        return SanitisedCommentBody("\n".join(body_lines))
-
-    findings_count = len(scan_result.findings)
-    header = _COMMENT_HEADER_VIOLATIONS
-    badge = _COMMENT_BADGE_VIOLATIONS
-
-    severity_summary = ", ".join(
+def _format_severity_summary(scan_result: ScanResult) -> str:
+    """Join non-zero severity counts into a comma-separated summary string."""
+    return ", ".join(
         f"{count} {level.value}"
         for level, count in sorted(
             scan_result.severity_counts.items(),
@@ -80,10 +59,49 @@ def build_comment_body(scan_result: ScanResult) -> SanitisedCommentBody:
         if count > 0
     )
 
-    body_lines = [
-        badge,
+
+def _build_clean_comment_lines(scan_result: ScanResult) -> list[str]:
+    """Lines for the 'no violations' comment body."""
+    return [
+        _COMMENT_BADGE_CLEAN,
         "",
-        f"**{header}**",
+        f"**{_COMMENT_HEADER_CLEAN}**",
+        "",
+        f"Scanned **{scan_result.files_scanned}** file(s) — no PHI/PII detected.",
+        "",
+        f"*Scan duration: {scan_result.scan_duration:.2f}s*",
+    ]
+
+
+def _build_findings_table_lines(scan_result: ScanResult) -> list[str]:
+    """Markdown table rows for the findings section (capped + truncation row)."""
+    findings_count = len(scan_result.findings)
+    rows = [
+        "| File | Line | Type | Severity | Confidence |",
+        "|------|------|------|----------|------------|",
+    ]
+    for finding in scan_result.findings[:_MAX_FINDINGS_IN_COMMENT_TABLE]:
+        rows.append(
+            f"| `{finding.file_path}` | {finding.line_number} "
+            f"| {finding.hipaa_category.value} "
+            f"| {finding.severity.value} "
+            f"| {finding.confidence:.0%} |"
+        )
+    if findings_count > _MAX_FINDINGS_IN_COMMENT_TABLE:
+        rows.append(
+            f"| … and {findings_count - _MAX_FINDINGS_IN_COMMENT_TABLE} more | | | | |"
+        )
+    return rows
+
+
+def _build_violations_comment_lines(scan_result: ScanResult) -> list[str]:
+    """Lines for the 'violations detected' comment body."""
+    findings_count = len(scan_result.findings)
+    severity_summary = _format_severity_summary(scan_result)
+    header_lines = [
+        _COMMENT_BADGE_VIOLATIONS,
+        "",
+        f"**{_COMMENT_HEADER_VIOLATIONS}**",
         "",
         f"phi-scan detected **{findings_count}** PHI/PII finding(s) across "
         f"**{scan_result.files_with_findings}** file(s).",
@@ -93,24 +111,8 @@ def build_comment_body(scan_result: ScanResult) -> SanitisedCommentBody:
         "",
         "### Findings",
         "",
-        "| File | Line | Type | Severity | Confidence |",
-        "|------|------|------|----------|------------|",
     ]
-
-    for finding in scan_result.findings[:_MAX_FINDINGS_IN_COMMENT_TABLE]:
-        body_lines.append(
-            f"| `{finding.file_path}` | {finding.line_number} "
-            f"| {finding.hipaa_category.value} "
-            f"| {finding.severity.value} "
-            f"| {finding.confidence:.0%} |"
-        )
-
-    if findings_count > _MAX_FINDINGS_IN_COMMENT_TABLE:
-        body_lines.append(
-            f"| … and {findings_count - _MAX_FINDINGS_IN_COMMENT_TABLE} more | | | | |"
-        )
-
-    body_lines += [
+    footer_lines = [
         "",
         "> **Action required:** Remove or de-identify all flagged values before merging.",
         "> Run `phi-scan scan . --output table` locally for full details.",
@@ -118,13 +120,27 @@ def build_comment_body(scan_result: ScanResult) -> SanitisedCommentBody:
         f"*Scan duration: {scan_result.scan_duration:.2f}s | "
         f"Files scanned: {scan_result.files_scanned}*",
     ]
+    return header_lines + _build_findings_table_lines(scan_result) + footer_lines
 
-    comment_body = "\n".join(body_lines)
-    if len(comment_body) > _MAX_COMMENT_LENGTH:
-        comment_body = (
-            comment_body[:_MAX_COMMENT_LENGTH] + "\n\n*(comment truncated — too many findings)*"
-        )
-    return SanitisedCommentBody(comment_body)
+
+def _truncate_comment_body(comment_body: str) -> str:
+    """Cap the body at ``_MAX_COMMENT_LENGTH`` and append a truncation note."""
+    if len(comment_body) <= _MAX_COMMENT_LENGTH:
+        return comment_body
+    return comment_body[:_MAX_COMMENT_LENGTH] + "\n\n*(comment truncated — too many findings)*"
+
+
+def build_comment_body(scan_result: ScanResult) -> SanitisedCommentBody:
+    """Build a markdown PR/MR comment body from a ``ScanResult``.
+
+    The body contains only counts, file names, and line numbers — never raw
+    entity values. Truncated to ``_MAX_COMMENT_LENGTH`` characters to stay
+    within platform comment size limits.
+    """
+    if scan_result.is_clean:
+        return SanitisedCommentBody("\n".join(_build_clean_comment_lines(scan_result)))
+    body_lines = _build_violations_comment_lines(scan_result)
+    return SanitisedCommentBody(_truncate_comment_body("\n".join(body_lines)))
 
 
 def _insert_baseline_context_into_comment(
@@ -132,7 +148,7 @@ def _insert_baseline_context_into_comment(
     baseline_line: str,
 ) -> str:
     """Insert a baseline context line after the first header line of a comment body."""
-    lines = comment_body.split("\n", _COMMENT_BODY_SPLIT_MAX_PARTS)
+    lines = comment_body.split("\n", _COMMENT_BODY_SPLIT_MAXSPLIT)
     if len(lines) < _COMMENT_MIN_SECTION_COUNT:
         return baseline_line + "\n\n" + comment_body
     return "\n".join([lines[0], "", baseline_line, "", *lines[1:]])

--- a/phi_scan/ci/comment_body.py
+++ b/phi_scan/ci/comment_body.py
@@ -27,8 +27,6 @@ _COMMENT_BADGE_VIOLATIONS: str = (
 )
 
 _MAX_COMMENT_LENGTH: int = 60_000
-# ``str.split(sep, maxsplit)`` returns at most ``maxsplit + 1`` items. This
-# constant is the ``maxsplit`` argument, not a count of resulting parts.
 _COMMENT_BODY_SPLIT_MAXSPLIT: int = 2
 _COMMENT_MIN_SECTION_COUNT: int = 2
 _BASELINE_CONTEXT_FORMAT: str = (
@@ -88,9 +86,7 @@ def _build_findings_table_lines(scan_result: ScanResult) -> list[str]:
             f"| {finding.confidence:.0%} |"
         )
     if findings_count > _MAX_FINDINGS_IN_COMMENT_TABLE:
-        rows.append(
-            f"| … and {findings_count - _MAX_FINDINGS_IN_COMMENT_TABLE} more | | | | |"
-        )
+        rows.append(f"| … and {findings_count - _MAX_FINDINGS_IN_COMMENT_TABLE} more | | | | |")
     return rows
 
 

--- a/phi_scan/ci/comment_body.py
+++ b/phi_scan/ci/comment_body.py
@@ -1,0 +1,153 @@
+# phi-scan:ignore-file
+"""Comment-body formatting for CI/CD PR/MR comments.
+
+Produces the sanitised markdown body posted by platform adapters.
+The body contains only counts, file names, and line numbers — never raw
+entity values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from phi_scan.ci._base import SanitisedCommentBody
+from phi_scan.models import ScanResult
+
+__all__ = [
+    "BaselineComparison",
+    "build_comment_body",
+    "build_comment_body_with_baseline",
+]
+
+_COMMENT_HEADER_CLEAN: str = "## phi-scan: No PHI/PII Violations Found"
+_COMMENT_HEADER_VIOLATIONS: str = "## phi-scan: PHI/PII Violations Detected"
+_COMMENT_BADGE_CLEAN: str = "![clean](https://img.shields.io/badge/phi--scan-clean-green)"
+_COMMENT_BADGE_VIOLATIONS: str = (
+    "![violations](https://img.shields.io/badge/phi--scan-violations-red)"
+)
+
+_MAX_COMMENT_LENGTH: int = 60_000
+_COMMENT_BODY_SPLIT_MAX_PARTS: int = 2
+_COMMENT_MIN_SECTION_COUNT: int = 2
+_BASELINE_CONTEXT_FORMAT: str = (
+    "**{new_findings_count} new** | "
+    "{baselined_count} baselined | "
+    "{resolved_count} resolved since last scan"
+)
+_MAX_FINDINGS_IN_COMMENT_TABLE: int = 50
+
+
+@dataclass(frozen=True)
+class BaselineComparison:
+    """Counts from a baseline comparison to include in PR/MR comment context."""
+
+    new_findings_count: int
+    baselined_count: int
+    resolved_count: int
+
+
+def build_comment_body(scan_result: ScanResult) -> SanitisedCommentBody:
+    """Build a markdown PR/MR comment body from a ``ScanResult``.
+
+    The body contains only counts, file names, and line numbers — never raw
+    entity values. Truncated to ``_MAX_COMMENT_LENGTH`` characters to stay
+    within platform comment size limits.
+    """
+    if scan_result.is_clean:
+        header = _COMMENT_HEADER_CLEAN
+        badge = _COMMENT_BADGE_CLEAN
+        body_lines = [
+            f"{badge}",
+            "",
+            f"**{header}**",
+            "",
+            f"Scanned **{scan_result.files_scanned}** file(s) — no PHI/PII detected.",
+            "",
+            f"*Scan duration: {scan_result.scan_duration:.2f}s*",
+        ]
+        return SanitisedCommentBody("\n".join(body_lines))
+
+    findings_count = len(scan_result.findings)
+    header = _COMMENT_HEADER_VIOLATIONS
+    badge = _COMMENT_BADGE_VIOLATIONS
+
+    severity_summary = ", ".join(
+        f"{count} {level.value}"
+        for level, count in sorted(
+            scan_result.severity_counts.items(),
+            key=lambda severity_item: severity_item[0].value,
+        )
+        if count > 0
+    )
+
+    body_lines = [
+        badge,
+        "",
+        f"**{header}**",
+        "",
+        f"phi-scan detected **{findings_count}** PHI/PII finding(s) across "
+        f"**{scan_result.files_with_findings}** file(s).",
+        "",
+        f"**Risk level:** {scan_result.risk_level.value}  ",
+        f"**Severity breakdown:** {severity_summary}",
+        "",
+        "### Findings",
+        "",
+        "| File | Line | Type | Severity | Confidence |",
+        "|------|------|------|----------|------------|",
+    ]
+
+    for finding in scan_result.findings[:_MAX_FINDINGS_IN_COMMENT_TABLE]:
+        body_lines.append(
+            f"| `{finding.file_path}` | {finding.line_number} "
+            f"| {finding.hipaa_category.value} "
+            f"| {finding.severity.value} "
+            f"| {finding.confidence:.0%} |"
+        )
+
+    if findings_count > _MAX_FINDINGS_IN_COMMENT_TABLE:
+        body_lines.append(
+            f"| … and {findings_count - _MAX_FINDINGS_IN_COMMENT_TABLE} more | | | | |"
+        )
+
+    body_lines += [
+        "",
+        "> **Action required:** Remove or de-identify all flagged values before merging.",
+        "> Run `phi-scan scan . --output table` locally for full details.",
+        "",
+        f"*Scan duration: {scan_result.scan_duration:.2f}s | "
+        f"Files scanned: {scan_result.files_scanned}*",
+    ]
+
+    comment_body = "\n".join(body_lines)
+    if len(comment_body) > _MAX_COMMENT_LENGTH:
+        comment_body = (
+            comment_body[:_MAX_COMMENT_LENGTH] + "\n\n*(comment truncated — too many findings)*"
+        )
+    return SanitisedCommentBody(comment_body)
+
+
+def _insert_baseline_context_into_comment(
+    comment_body: str,
+    baseline_line: str,
+) -> str:
+    """Insert a baseline context line after the first header line of a comment body."""
+    lines = comment_body.split("\n", _COMMENT_BODY_SPLIT_MAX_PARTS)
+    if len(lines) < _COMMENT_MIN_SECTION_COUNT:
+        return baseline_line + "\n\n" + comment_body
+    return "\n".join([lines[0], "", baseline_line, "", *lines[1:]])
+
+
+def build_comment_body_with_baseline(
+    scan_result: ScanResult,
+    baseline_comparison: BaselineComparison,
+) -> SanitisedCommentBody:
+    """Build a PR/MR comment body that includes baseline comparison context."""
+    baseline_line = _BASELINE_CONTEXT_FORMAT.format(
+        new_findings_count=baseline_comparison.new_findings_count,
+        baselined_count=baseline_comparison.baselined_count,
+        resolved_count=baseline_comparison.resolved_count,
+    )
+    return SanitisedCommentBody(
+        _insert_baseline_context_into_comment(build_comment_body(scan_result), baseline_line)
+    )

--- a/phi_scan/ci/dispatch.py
+++ b/phi_scan/ci/dispatch.py
@@ -1,0 +1,81 @@
+# phi-scan:ignore-file
+"""Orchestration dispatch for CI/CD PR comments and commit statuses.
+
+Selects the platform-specific adapter via ``resolve_adapter`` and forwards
+the request. Does nothing (with a debug/warning log) when required
+context or support is missing.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from phi_scan.ci import resolve_adapter
+from phi_scan.ci._detect import PullRequestContext
+from phi_scan.ci.comment_body import build_comment_body
+from phi_scan.exceptions import CIIntegrationError
+from phi_scan.models import ScanResult
+
+__all__ = [
+    "post_pr_comment",
+    "post_pull_request_comment",
+    "set_commit_status",
+]
+
+_LOG: logging.Logger = logging.getLogger(__name__)
+
+
+def post_pr_comment(scan_result: ScanResult, pr_context: PullRequestContext) -> None:
+    """Post a PR/MR comment with scan findings to the detected CI/CD platform.
+
+    Selects the platform-specific adapter based on ``pr_context.platform``.
+    Does nothing and logs a warning when the platform is ``UNKNOWN`` or when
+    required context (PR number, token) is missing.
+    """
+    if not pr_context.pull_request_number:
+        _LOG.debug("No PR number in context — skipping comment posting")
+        return
+
+    try:
+        adapter = resolve_adapter(pr_context.platform)
+    except CIIntegrationError:
+        _LOG.warning(
+            "PR comment posting not implemented for platform %s",
+            pr_context.platform.value,
+        )
+        return
+
+    comment_body = build_comment_body(scan_result)
+    adapter.post_pull_request_comment(comment_body, pr_context)
+
+
+post_pull_request_comment = post_pr_comment
+
+
+def set_commit_status(scan_result: ScanResult, pr_context: PullRequestContext) -> None:
+    """Set the commit status (PASS/FAIL) on the CI/CD platform.
+
+    Selects the platform-specific adapter based on ``pr_context.platform``.
+    Does nothing and logs a warning when required context (SHA, token) is missing.
+    """
+    if not pr_context.sha:
+        _LOG.debug("No commit SHA in context — skipping status posting")
+        return
+
+    try:
+        adapter = resolve_adapter(pr_context.platform)
+    except CIIntegrationError:
+        _LOG.warning(
+            "Commit status not implemented for platform %s",
+            pr_context.platform.value,
+        )
+        return
+
+    if not adapter.can_post_commit_status:
+        _LOG.debug(
+            "Adapter %s does not support commit status — skipping",
+            type(adapter).__name__,
+        )
+        return
+
+    adapter.set_commit_status(scan_result, pr_context)

--- a/phi_scan/ci_integration.py
+++ b/phi_scan/ci_integration.py
@@ -1,32 +1,29 @@
 # phi-scan:ignore-file
-"""CI/CD platform integration for phi-scan.
+"""Backward-compatible façade for the CI/CD integration package.
 
-This module is the backward-compatible entry point for CI/CD integration.
-Platform detection, PR context extraction, and per-platform adapters now
-live in the ``phi_scan.ci`` package. This module provides:
+All implementation lives in the ``phi_scan.ci`` package:
 
-  1. **Orchestration**: ``post_pr_comment`` and ``set_commit_status``
-     dispatch to per-platform adapters via ``phi_scan.ci.resolve_adapter``.
-  2. **Comment formatting**: ``build_comment_body`` and
-     ``build_comment_body_with_baseline`` produce the markdown PR body.
-  3. **Platform-specific extras**: SARIF upload, Bitbucket Code Insights,
-     Azure build tags/PR statuses/Boards work items, and AWS Security Hub
-     ASFF import remain here pending a follow-up migration PR.
-  4. **Backward-compatible re-exports**: all names previously importable
-     from ``phi_scan.ci_integration`` continue to work.
+- Platform detection + PR context: ``phi_scan.ci._detect``
+- Per-platform adapters: ``phi_scan.ci.github``, ``azure``, ``gitlab``, etc.
+- Platform-specific extras: ``phi_scan.ci.sarif``,
+  ``phi_scan.ci.bitbucket_insights``, ``phi_scan.ci.azure_devops``,
+  ``phi_scan.ci.aws_security_hub``
+- Comment-body formatting: ``phi_scan.ci.comment_body``
+- Orchestration dispatch: ``phi_scan.ci.dispatch``
+
+This module re-exports every symbol that was previously importable from
+``phi_scan.ci_integration`` so external callers continue to work
+unchanged.
 
 Security audit summary
 ----------------------
 All outbound HTTP calls go through ``phi_scan.ci._transport.execute_http_request``,
 which re-raises both ``httpx.HTTPStatusError`` and ``httpx.RequestError`` as
-``CIIntegrationError``. Error messages include only the status code and reason
-phrase — never the response body.
+``CIIntegrationError``. Error messages include only the status code and
+reason phrase — never the response body.
 """
 
 from __future__ import annotations
-
-import logging
-from dataclasses import dataclass
 
 from phi_scan.ci import (  # noqa: F401 — backward-compatible re-exports
     AzureAdapter,
@@ -64,9 +61,20 @@ from phi_scan.ci.azure_devops import set_azure_pr_status as set_azure_pr_status
 from phi_scan.ci.bitbucket_insights import (
     post_bitbucket_code_insights as post_bitbucket_code_insights,
 )
+from phi_scan.ci.comment_body import (
+    BaselineComparison as BaselineComparison,
+)
+from phi_scan.ci.comment_body import (
+    build_comment_body as build_comment_body,
+)
+from phi_scan.ci.comment_body import (
+    build_comment_body_with_baseline as build_comment_body_with_baseline,
+)
+from phi_scan.ci.dispatch import post_pr_comment as post_pr_comment
+from phi_scan.ci.dispatch import post_pull_request_comment as post_pull_request_comment
+from phi_scan.ci.dispatch import set_commit_status as set_commit_status
 from phi_scan.ci.sarif import upload_sarif_to_github as upload_sarif_to_github
 from phi_scan.exceptions import CIIntegrationError  # noqa: F401 — backward-compatible re-export
-from phi_scan.models import ScanResult
 
 PRContext = PullRequestContext
 get_pr_context = get_pull_request_context
@@ -107,255 +115,3 @@ __all__ = [
     "set_commit_status",
     "upload_sarif_to_github",
 ]
-
-_LOG: logging.Logger = logging.getLogger(__name__)
-
-# ---------------------------------------------------------------------------
-# Constants — comment formatting
-# ---------------------------------------------------------------------------
-
-_COMMENT_HEADER_CLEAN: str = "## phi-scan: No PHI/PII Violations Found"
-_COMMENT_HEADER_VIOLATIONS: str = "## phi-scan: PHI/PII Violations Detected"
-_COMMENT_BADGE_CLEAN: str = "![clean](https://img.shields.io/badge/phi--scan-clean-green)"
-_COMMENT_BADGE_VIOLATIONS: str = (
-    "![violations](https://img.shields.io/badge/phi--scan-violations-red)"
-)
-
-_COMMIT_STATUS_CONTEXT: str = "phi-scan"
-_COMMIT_STATUS_DESCRIPTION_CLEAN: str = "No PHI/PII violations found"
-_COMMIT_STATUS_DESCRIPTION_VIOLATIONS: str = "{count} PHI/PII violation(s) found"
-
-_MAX_COMMENT_LENGTH: int = 60_000
-_MAX_ERROR_RESPONSE_LOG_LENGTH: int = 200
-_DEFAULT_GIT_REF: str = "refs/heads/main"
-_COMMENT_BODY_SPLIT_MAX_PARTS: int = 2
-_COMMENT_MIN_SECTION_COUNT: int = 2
-_BASELINE_CONTEXT_FORMAT: str = (
-    "**{new_findings_count} new** | "
-    "{baselined_count} baselined | "
-    "{resolved_count} resolved since last scan"
-)
-
-_MAX_FINDINGS_IN_COMMENT_TABLE: int = 50
-
-# ---------------------------------------------------------------------------
-# Constants — platform-specific extras
-# ---------------------------------------------------------------------------
-
-# ---------------------------------------------------------------------------
-# Backward-compatible type re-exports
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class BaselineComparison:
-    """Counts from a baseline comparison to include in PR/MR comment context."""
-
-    new_findings_count: int
-    baselined_count: int
-    resolved_count: int
-
-
-# ---------------------------------------------------------------------------
-# Comment body builder
-# ---------------------------------------------------------------------------
-
-
-def build_comment_body(scan_result: ScanResult) -> SanitisedCommentBody:
-    """Build a markdown PR/MR comment body from a ``ScanResult``.
-
-    The body contains only counts, file names, and line numbers — never raw
-    entity values. Truncated to ``_MAX_COMMENT_LENGTH`` characters to stay
-    within platform comment size limits.
-    """
-    if scan_result.is_clean:
-        header = _COMMENT_HEADER_CLEAN
-        badge = _COMMENT_BADGE_CLEAN
-        body_lines = [
-            f"{badge}",
-            "",
-            f"**{header}**",
-            "",
-            f"Scanned **{scan_result.files_scanned}** file(s) — no PHI/PII detected.",
-            "",
-            f"*Scan duration: {scan_result.scan_duration:.2f}s*",
-        ]
-        return SanitisedCommentBody("\n".join(body_lines))
-
-    findings_count = len(scan_result.findings)
-    header = _COMMENT_HEADER_VIOLATIONS
-    badge = _COMMENT_BADGE_VIOLATIONS
-
-    severity_summary = ", ".join(
-        f"{count} {level.value}"
-        for level, count in sorted(
-            scan_result.severity_counts.items(),
-            key=lambda severity_item: severity_item[0].value,
-        )
-        if count > 0
-    )
-
-    body_lines = [
-        badge,
-        "",
-        f"**{header}**",
-        "",
-        f"phi-scan detected **{findings_count}** PHI/PII finding(s) across "
-        f"**{scan_result.files_with_findings}** file(s).",
-        "",
-        f"**Risk level:** {scan_result.risk_level.value}  ",
-        f"**Severity breakdown:** {severity_summary}",
-        "",
-        "### Findings",
-        "",
-        "| File | Line | Type | Severity | Confidence |",
-        "|------|------|------|----------|------------|",
-    ]
-
-    for finding in scan_result.findings[:_MAX_FINDINGS_IN_COMMENT_TABLE]:
-        body_lines.append(
-            f"| `{finding.file_path}` | {finding.line_number} "
-            f"| {finding.hipaa_category.value} "
-            f"| {finding.severity.value} "
-            f"| {finding.confidence:.0%} |"
-        )
-
-    if findings_count > _MAX_FINDINGS_IN_COMMENT_TABLE:
-        body_lines.append(
-            f"| … and {findings_count - _MAX_FINDINGS_IN_COMMENT_TABLE} more | | | | |"
-        )
-
-    body_lines += [
-        "",
-        "> **Action required:** Remove or de-identify all flagged values before merging.",
-        "> Run `phi-scan scan . --output table` locally for full details.",
-        "",
-        f"*Scan duration: {scan_result.scan_duration:.2f}s | "
-        f"Files scanned: {scan_result.files_scanned}*",
-    ]
-
-    comment_body = "\n".join(body_lines)
-    if len(comment_body) > _MAX_COMMENT_LENGTH:
-        comment_body = (
-            comment_body[:_MAX_COMMENT_LENGTH] + "\n\n*(comment truncated — too many findings)*"
-        )
-    return SanitisedCommentBody(comment_body)
-
-
-def _insert_baseline_context_into_comment(
-    comment_body: str,
-    baseline_line: str,
-) -> str:
-    """Insert a baseline context line after the first header line of a comment body."""
-    lines = comment_body.split("\n", _COMMENT_BODY_SPLIT_MAX_PARTS)
-    if len(lines) < _COMMENT_MIN_SECTION_COUNT:
-        return baseline_line + "\n\n" + comment_body
-    return "\n".join([lines[0], "", baseline_line, "", *lines[1:]])
-
-
-def build_comment_body_with_baseline(
-    scan_result: ScanResult,
-    baseline_comparison: BaselineComparison,
-) -> SanitisedCommentBody:
-    """Build a PR/MR comment body that includes baseline comparison context."""
-    baseline_line = _BASELINE_CONTEXT_FORMAT.format(
-        new_findings_count=baseline_comparison.new_findings_count,
-        baselined_count=baseline_comparison.baselined_count,
-        resolved_count=baseline_comparison.resolved_count,
-    )
-    return SanitisedCommentBody(
-        _insert_baseline_context_into_comment(build_comment_body(scan_result), baseline_line)
-    )
-
-
-# ---------------------------------------------------------------------------
-# Public API — post PR/MR comment (dispatches to adapter)
-# ---------------------------------------------------------------------------
-
-
-def post_pr_comment(scan_result: ScanResult, pr_context: PRContext) -> None:
-    """Post a PR/MR comment with scan findings to the detected CI/CD platform.
-
-    Selects the platform-specific adapter based on ``pr_context.platform``.
-    Does nothing and logs a warning when the platform is ``UNKNOWN`` or when
-    required context (PR number, token) is missing.
-    """
-    if not pr_context.pull_request_number:
-        _LOG.debug("No PR number in context — skipping comment posting")
-        return
-
-    try:
-        adapter = resolve_adapter(pr_context.platform)
-    except CIIntegrationError:
-        _LOG.warning(
-            "PR comment posting not implemented for platform %s",
-            pr_context.platform.value,
-        )
-        return
-
-    comment_body = build_comment_body(scan_result)
-    adapter.post_pull_request_comment(comment_body, pr_context)
-
-
-post_pull_request_comment = post_pr_comment
-
-
-# ---------------------------------------------------------------------------
-# Public API — set commit status (dispatches to adapter)
-# ---------------------------------------------------------------------------
-
-
-def set_commit_status(scan_result: ScanResult, pr_context: PRContext) -> None:
-    """Set the commit status (PASS/FAIL) on the CI/CD platform.
-
-    Selects the platform-specific adapter based on ``pr_context.platform``.
-    Does nothing and logs a warning when required context (SHA, token) is missing.
-    """
-    if not pr_context.sha:
-        _LOG.debug("No commit SHA in context — skipping status posting")
-        return
-
-    try:
-        adapter = resolve_adapter(pr_context.platform)
-    except CIIntegrationError:
-        _LOG.warning(
-            "Commit status not implemented for platform %s",
-            pr_context.platform.value,
-        )
-        return
-
-    if not adapter.can_post_commit_status:
-        _LOG.debug(
-            "Adapter %s does not support commit status — skipping",
-            type(adapter).__name__,
-        )
-        return
-
-    adapter.set_commit_status(scan_result, pr_context)
-
-
-# ---------------------------------------------------------------------------
-# Public API — upload SARIF to GitHub Code Scanning
-# Implementation now lives in phi_scan.ci.sarif; re-exported at module top.
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
-# Public API — Bitbucket Code Insights annotations
-# Implementation now lives in phi_scan.ci.bitbucket_insights; re-exported at
-# module top.
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
-# Public API — Azure DevOps build tag, PR status, and Boards work item
-# Implementation now lives in phi_scan.ci.azure_devops; re-exported at
-# module top.
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
-# Public API — AWS Security Hub ASFF import
-# Implementation now lives in phi_scan.ci.aws_security_hub; re-exported at
-# module top.
-# ---------------------------------------------------------------------------

--- a/tests/test_ci_integration_shim_parity.py
+++ b/tests/test_ci_integration_shim_parity.py
@@ -105,3 +105,69 @@ def test_post_pr_comment_forwards_to_resolved_adapter(
     posted_body, posted_context = fake_adapter.post_pull_request_comment.call_args.args
     assert "No PHI/PII Violations Found" in str(posted_body)
     assert posted_context is pr_context
+
+
+def test_set_commit_status_forwards_to_resolved_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_adapter = MagicMock()
+    fake_adapter.can_post_commit_status = True
+    monkeypatch.setattr(canonical_dispatch, "resolve_adapter", lambda _platform: fake_adapter)
+
+    clean_scan = MagicMock(spec=ScanResult)
+    pr_context = PullRequestContext(
+        platform=CIPlatform.GITHUB_ACTIONS,
+        pull_request_number="42",
+        repository="acme/example",
+        sha="deadbeef",
+        branch="feature",
+        base_branch="main",
+    )
+
+    ci_integration.set_commit_status(clean_scan, pr_context)
+
+    assert fake_adapter.set_commit_status.call_count == 1
+    forwarded_scan, forwarded_context = fake_adapter.set_commit_status.call_args.args
+    assert forwarded_scan is clean_scan
+    assert forwarded_context is pr_context
+
+
+def test_set_commit_status_returns_early_when_sha_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_adapter = MagicMock()
+    monkeypatch.setattr(canonical_dispatch, "resolve_adapter", lambda _platform: fake_adapter)
+
+    pr_context = PullRequestContext(
+        platform=CIPlatform.GITHUB_ACTIONS,
+        pull_request_number="42",
+        repository="acme/example",
+        sha=None,
+        branch="feature",
+        base_branch="main",
+    )
+
+    ci_integration.set_commit_status(MagicMock(spec=ScanResult), pr_context)
+
+    assert fake_adapter.set_commit_status.call_count == 0
+
+
+def test_set_commit_status_returns_early_when_adapter_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_adapter = MagicMock()
+    fake_adapter.can_post_commit_status = False
+    monkeypatch.setattr(canonical_dispatch, "resolve_adapter", lambda _platform: fake_adapter)
+
+    pr_context = PullRequestContext(
+        platform=CIPlatform.GITHUB_ACTIONS,
+        pull_request_number="42",
+        repository="acme/example",
+        sha="deadbeef",
+        branch="feature",
+        base_branch="main",
+    )
+
+    ci_integration.set_commit_status(MagicMock(spec=ScanResult), pr_context)
+
+    assert fake_adapter.set_commit_status.call_count == 0

--- a/tests/test_ci_integration_shim_parity.py
+++ b/tests/test_ci_integration_shim_parity.py
@@ -1,0 +1,107 @@
+"""Parity tests for the ``phi_scan.ci_integration`` compatibility shim.
+
+Phase-3 extraction moved comment-body formatting to
+``phi_scan.ci.comment_body`` and orchestration dispatch to
+``phi_scan.ci.dispatch``. These tests pin the contract that every
+symbol still imports cleanly from ``phi_scan.ci_integration`` and that
+each re-export is the same object as its new canonical home.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from phi_scan import ci_integration
+from phi_scan.ci import comment_body as canonical_comment_body
+from phi_scan.ci import dispatch as canonical_dispatch
+from phi_scan.ci._detect import CIPlatform, PullRequestContext
+from phi_scan.models import ScanResult
+
+# ---------------------------------------------------------------------------
+# Slice A — comment_body identity
+# ---------------------------------------------------------------------------
+
+
+def test_build_comment_body_is_canonical_reexport() -> None:
+    assert ci_integration.build_comment_body is canonical_comment_body.build_comment_body
+
+
+def test_build_comment_body_with_baseline_is_canonical_reexport() -> None:
+    assert (
+        ci_integration.build_comment_body_with_baseline
+        is canonical_comment_body.build_comment_body_with_baseline
+    )
+
+
+def test_baseline_comparison_is_canonical_reexport() -> None:
+    assert ci_integration.BaselineComparison is canonical_comment_body.BaselineComparison
+
+
+# ---------------------------------------------------------------------------
+# Slice B — dispatch identity
+# ---------------------------------------------------------------------------
+
+
+def test_post_pr_comment_is_canonical_reexport() -> None:
+    assert ci_integration.post_pr_comment is canonical_dispatch.post_pr_comment
+
+
+def test_post_pull_request_comment_is_alias_for_post_pr_comment() -> None:
+    assert ci_integration.post_pull_request_comment is canonical_dispatch.post_pull_request_comment
+    assert ci_integration.post_pull_request_comment is ci_integration.post_pr_comment
+
+
+def test_set_commit_status_is_canonical_reexport() -> None:
+    assert ci_integration.set_commit_status is canonical_dispatch.set_commit_status
+
+
+# ---------------------------------------------------------------------------
+# Behavioral smoke — comment body
+# ---------------------------------------------------------------------------
+
+
+def test_build_comment_body_clean_scan_produces_no_violations_header() -> None:
+    clean_scan = MagicMock(spec=ScanResult)
+    clean_scan.is_clean = True
+    clean_scan.files_scanned = 7
+    clean_scan.scan_duration = 0.25
+
+    body = ci_integration.build_comment_body(clean_scan)
+
+    assert "No PHI/PII Violations Found" in str(body)
+    assert "Scanned **7** file(s)" in str(body)
+
+
+# ---------------------------------------------------------------------------
+# Behavioral smoke — dispatch with monkeypatched adapter resolution
+# ---------------------------------------------------------------------------
+
+
+def test_post_pr_comment_forwards_to_resolved_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_adapter = MagicMock()
+    monkeypatch.setattr(canonical_dispatch, "resolve_adapter", lambda _platform: fake_adapter)
+
+    clean_scan = MagicMock(spec=ScanResult)
+    clean_scan.is_clean = True
+    clean_scan.files_scanned = 1
+    clean_scan.scan_duration = 0.01
+
+    pr_context = PullRequestContext(
+        platform=CIPlatform.GITHUB_ACTIONS,
+        pull_request_number="42",
+        repository="acme/example",
+        sha="deadbeef",
+        branch="feature",
+        base_branch="main",
+    )
+
+    ci_integration.post_pr_comment(clean_scan, pr_context)
+
+    assert fake_adapter.post_pull_request_comment.call_count == 1
+    posted_body, posted_context = fake_adapter.post_pull_request_comment.call_args[0]
+    assert "No PHI/PII Violations Found" in str(posted_body)
+    assert posted_context is pr_context

--- a/tests/test_ci_integration_shim_parity.py
+++ b/tests/test_ci_integration_shim_parity.py
@@ -102,6 +102,6 @@ def test_post_pr_comment_forwards_to_resolved_adapter(
     ci_integration.post_pr_comment(clean_scan, pr_context)
 
     assert fake_adapter.post_pull_request_comment.call_count == 1
-    posted_body, posted_context = fake_adapter.post_pull_request_comment.call_args[0]
+    posted_body, posted_context = fake_adapter.post_pull_request_comment.call_args.args
     assert "No PHI/PII Violations Found" in str(posted_body)
     assert posted_context is pr_context


### PR DESCRIPTION
## Summary

- Extract the two remaining in-file slices from \`phi_scan/ci_integration.py\` into dedicated modules so the shim becomes a pure compatibility façade.
- Slice A: comment-body formatting → \`phi_scan/ci/comment_body.py\` (\`BaselineComparison\`, \`build_comment_body\`, \`build_comment_body_with_baseline\`, \`_insert_baseline_context_into_comment\`, comment-formatting constants).
- Slice B: orchestration dispatch → \`phi_scan/ci/dispatch.py\` (\`post_pr_comment\`, \`post_pull_request_comment\`, \`set_commit_status\`).
- Shim reduced from **361 → 117 lines** (−67.6%). Removed stale docstring claim that extras "remain here pending a follow-up migration PR" — they were already extracted. Removed four dead section banners.
- Verified \`BaseCIAdapter.import_findings_to_security_hub\` is the abstract interface contract only (raises \`UnsupportedOperation\`); real implementation lives in \`phi_scan/ci/aws_security_hub.py\`. No duplicate runtime implementation.

## Parity tests (new: \`tests/test_ci_integration_shim_parity.py\`, 8 tests)

- Symbol-identity assertions for every moved symbol in both slices.
- Behavioral smoke: \`build_comment_body\` on a clean scan produces the expected header.
- Behavioral smoke: \`post_pr_comment\` with monkeypatched \`resolve_adapter\` forwards a sanitised body to the adapter.

## Test plan

- [x] \`uv run ruff check .\` — All checks passed
- [x] \`uv run mypy phi_scan\` — Success: no issues found in 88 source files
- [x] \`uv run pytest -q\` — 1990 passed, 3 skipped; coverage 90.92%
- [x] No behavior changes
- [x] No unrelated refactors
- [x] External import surface unchanged (\`__all__\` preserved)