### PR TITLE
refactor(cli): lock shim policy with parity matrix and deprecation docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `completion_tokens`, and `estimated_cost_usd` in the SQLite audit trail for cost tracking
   and compliance reporting.
 
+### Deprecated
+
+- **Top-level `phi_scan.cli_*` compatibility shims** (`cli_baseline`, `cli_config`,
+  `cli_explain`, `cli_plugins`, `cli_report`, `cli_scan_config`, `cli_watch`) are
+  deprecated. The canonical import paths are `phi_scan.cli.<name>`. The shims
+  continue to work unchanged for the v1.x series and will be **removed in v2.0**.
+  A runtime `DeprecationWarning` will be added in a later pre-v2.0 minor release.
+  See `docs/lts-eol-policy.md` for the full deprecation timeline.
+
 ### Changed
 
 - `ai.enable_claude_review` is deprecated — emits `DeprecationWarning`; still accepted for

--- a/docs/lts-eol-policy.md
+++ b/docs/lts-eol-policy.md
@@ -146,8 +146,24 @@ Python version support follows this policy:
 
 ---
 
+## Deprecation Timelines
+
+Public API deprecations that have a scheduled removal target are recorded
+here so consumers can plan upgrades against a known horizon.
+
+| Deprecated surface | Deprecated in | Removal target | Canonical replacement |
+|--------------------|--------------|----------------|----------------------|
+| Top-level `phi_scan.cli_*` compatibility shims (`cli_baseline`, `cli_config`, `cli_explain`, `cli_plugins`, `cli_report`, `cli_scan_config`, `cli_watch`) | v1.x (see `CHANGELOG.md` Unreleased) | **v2.0** | `phi_scan.cli.<name>` |
+
+A runtime `DeprecationWarning` for the above shims is deferred to a
+pre-v2.0 minor release so that v1.x consumers do not experience a
+silent behavior change mid-series.
+
+---
+
 ## Version History
 
 | Date | Change |
 |------|--------|
 | 2026-04-16 | Initial LTS and EOL policy for C6 scorecard check |
+| 2026-04-14 | Added deprecation timeline for `phi_scan.cli_*` shims (removal v2.0) |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,7 @@ _SARIF_VERSION_KEY: str = "version"
 _SARIF_EXPECTED_VERSION: str = "2.1.0"
 _HOOK_PATH_RELATIVE: str = ".git/hooks/pre-commit"
 _FOREIGN_HOOK_CONTENT: str = "#!/bin/sh\necho hello\n"
+_MISSING_DIRECTORY_NAME: str = "does-not-exist"
 # Observable hook marker — the string phi-scan writes into every hook it installs.
 _EXPECTED_HOOK_MARKER: str = "phi-scan scan"
 # Full hook script content — must match what install_hook writes verbatim so
@@ -227,7 +228,7 @@ def test_scan_unsupported_output_format_prints_error_message(tmp_path: Path) -> 
 
 
 def test_scan_nonexistent_path_exits_nonzero(tmp_path: Path) -> None:
-    missing_path = tmp_path / "does-not-exist"
+    missing_path = tmp_path / _MISSING_DIRECTORY_NAME
 
     result = _runner.invoke(app, ["scan", str(missing_path)])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -226,6 +226,14 @@ def test_scan_unsupported_output_format_prints_error_message(tmp_path: Path) -> 
     assert _UNSUPPORTED_FORMAT_NAME in result.output
 
 
+def test_scan_nonexistent_path_exits_nonzero(tmp_path: Path) -> None:
+    missing_path = tmp_path / "does-not-exist"
+
+    result = _runner.invoke(app, ["scan", str(missing_path)])
+
+    assert result.exit_code != _EXIT_CODE_SUCCESS
+
+
 # ---------------------------------------------------------------------------
 # scan — severity threshold override
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_shim_parity.py
+++ b/tests/test_cli_shim_parity.py
@@ -30,44 +30,37 @@ _SHIM_DOCSTRING_MARKER: str = "Compatibility shim"
 _MINIMUM_EXPORTED_NAMES: int = 1
 
 
-@pytest.fixture(
-    params=list(_SHIM_TO_CANONICAL.items()),
-    ids=list(_SHIM_TO_CANONICAL),
-)
-def load_shim_and_canonical_modules(
+@pytest.fixture(params=list(_SHIM_TO_CANONICAL), ids=list(_SHIM_TO_CANONICAL))
+def load_shim_module(request: pytest.FixtureRequest) -> ModuleType:
+    return importlib.import_module(request.param)
+
+
+@pytest.fixture(params=list(_SHIM_TO_CANONICAL.items()), ids=list(_SHIM_TO_CANONICAL))
+def load_shim_with_canonical(
     request: pytest.FixtureRequest,
 ) -> tuple[ModuleType, ModuleType]:
     shim_path, canonical_path = request.param
     return importlib.import_module(shim_path), importlib.import_module(canonical_path)
 
 
-def test_shim_module_loads_without_error(
-    load_shim_and_canonical_modules: tuple[ModuleType, ModuleType],
-) -> None:
-    shim, _canonical = load_shim_and_canonical_modules
-    assert shim is not None
+def test_shim_module_loads_without_error(load_shim_module: ModuleType) -> None:
+    assert isinstance(load_shim_module, ModuleType)
 
 
-def test_shim_exports_non_empty_public_names(
-    load_shim_and_canonical_modules: tuple[ModuleType, ModuleType],
-) -> None:
-    shim, _canonical = load_shim_and_canonical_modules
-    assert hasattr(shim, "__all__")
-    assert len(shim.__all__) >= _MINIMUM_EXPORTED_NAMES
+def test_shim_exports_non_empty_public_names(load_shim_module: ModuleType) -> None:
+    assert hasattr(load_shim_module, "__all__")
+    assert len(load_shim_module.__all__) >= _MINIMUM_EXPORTED_NAMES
 
 
-def test_shim_docstring_marks_compatibility(
-    load_shim_and_canonical_modules: tuple[ModuleType, ModuleType],
-) -> None:
-    shim, _canonical = load_shim_and_canonical_modules
-    assert shim.__doc__ is not None
-    assert _SHIM_DOCSTRING_MARKER in shim.__doc__
+def test_shim_docstring_marks_compatibility(load_shim_module: ModuleType) -> None:
+    assert load_shim_module.__doc__ is not None
+    assert _SHIM_DOCSTRING_MARKER in load_shim_module.__doc__
 
 
 def test_shim_resolves_names_identical_to_canonical(
-    load_shim_and_canonical_modules: tuple[ModuleType, ModuleType],
+    load_shim_with_canonical: tuple[ModuleType, ModuleType],
 ) -> None:
-    shim, canonical = load_shim_and_canonical_modules
+    shim, canonical = load_shim_with_canonical
     for exported_name in shim.__all__:
         assert hasattr(canonical, exported_name), (
             f"canonical module missing attribute {exported_name!r}"

--- a/tests/test_cli_shim_parity.py
+++ b/tests/test_cli_shim_parity.py
@@ -1,0 +1,70 @@
+"""Parity tests for top-level ``phi_scan.cli_*`` compatibility shims.
+
+These shims preserve the historical import paths that predate the
+``phi_scan.cli`` package. Each shim is a star-import re-export of its
+canonical counterpart under ``phi_scan.cli.<name>``. This matrix pins
+that contract in one place so per-file drift cannot accumulate.
+
+Shim removal target: **v2.0** (see ``CHANGELOG.md`` and
+``docs/lts-eol-policy.md``).
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+import pytest
+
+_SHIM_TO_CANONICAL: dict[str, str] = {
+    "phi_scan.cli_baseline": "phi_scan.cli.baseline",
+    "phi_scan.cli_config": "phi_scan.cli.config",
+    "phi_scan.cli_explain": "phi_scan.cli.explain",
+    "phi_scan.cli_plugins": "phi_scan.cli.plugins",
+    "phi_scan.cli_report": "phi_scan.cli.report",
+    "phi_scan.cli_scan_config": "phi_scan.cli.scan_config",
+    "phi_scan.cli_watch": "phi_scan.cli.watch",
+}
+
+_SHIM_DOCSTRING_MARKER: str = "Compatibility shim"
+
+
+@pytest.fixture(
+    params=list(_SHIM_TO_CANONICAL.items()),
+    ids=list(_SHIM_TO_CANONICAL),
+)
+def shim_and_canonical(request: pytest.FixtureRequest) -> tuple[ModuleType, ModuleType]:
+    shim_path, canonical_path = request.param
+    return importlib.import_module(shim_path), importlib.import_module(canonical_path)
+
+
+def test_shim_imports_cleanly(shim_and_canonical: tuple[ModuleType, ModuleType]) -> None:
+    shim, _canonical = shim_and_canonical
+    assert shim is not None
+
+
+def test_shim_has_non_empty_all(shim_and_canonical: tuple[ModuleType, ModuleType]) -> None:
+    shim, _canonical = shim_and_canonical
+    assert hasattr(shim, "__all__")
+    assert len(shim.__all__) > 0
+
+
+def test_shim_docstring_marks_compatibility(
+    shim_and_canonical: tuple[ModuleType, ModuleType],
+) -> None:
+    shim, _canonical = shim_and_canonical
+    assert shim.__doc__ is not None
+    assert _SHIM_DOCSTRING_MARKER in shim.__doc__
+
+
+def test_shim_all_names_are_identity_equal_to_canonical(
+    shim_and_canonical: tuple[ModuleType, ModuleType],
+) -> None:
+    shim, canonical = shim_and_canonical
+    for exported_name in shim.__all__:
+        assert hasattr(canonical, exported_name), (
+            f"canonical module missing attribute {exported_name!r}"
+        )
+        assert getattr(shim, exported_name) is getattr(canonical, exported_name), (
+            f"{exported_name!r} on shim is not the same object as on canonical module"
+        )

--- a/tests/test_cli_shim_parity.py
+++ b/tests/test_cli_shim_parity.py
@@ -27,40 +27,47 @@ _SHIM_TO_CANONICAL: dict[str, str] = {
 }
 
 _SHIM_DOCSTRING_MARKER: str = "Compatibility shim"
+_MINIMUM_EXPORTED_NAMES: int = 1
 
 
 @pytest.fixture(
     params=list(_SHIM_TO_CANONICAL.items()),
     ids=list(_SHIM_TO_CANONICAL),
 )
-def shim_and_canonical(request: pytest.FixtureRequest) -> tuple[ModuleType, ModuleType]:
+def load_shim_and_canonical_modules(
+    request: pytest.FixtureRequest,
+) -> tuple[ModuleType, ModuleType]:
     shim_path, canonical_path = request.param
     return importlib.import_module(shim_path), importlib.import_module(canonical_path)
 
 
-def test_shim_imports_cleanly(shim_and_canonical: tuple[ModuleType, ModuleType]) -> None:
-    shim, _canonical = shim_and_canonical
+def test_shim_module_loads_without_error(
+    load_shim_and_canonical_modules: tuple[ModuleType, ModuleType],
+) -> None:
+    shim, _canonical = load_shim_and_canonical_modules
     assert shim is not None
 
 
-def test_shim_has_non_empty_all(shim_and_canonical: tuple[ModuleType, ModuleType]) -> None:
-    shim, _canonical = shim_and_canonical
+def test_shim_exports_non_empty_public_names(
+    load_shim_and_canonical_modules: tuple[ModuleType, ModuleType],
+) -> None:
+    shim, _canonical = load_shim_and_canonical_modules
     assert hasattr(shim, "__all__")
-    assert len(shim.__all__) > 0
+    assert len(shim.__all__) >= _MINIMUM_EXPORTED_NAMES
 
 
 def test_shim_docstring_marks_compatibility(
-    shim_and_canonical: tuple[ModuleType, ModuleType],
+    load_shim_and_canonical_modules: tuple[ModuleType, ModuleType],
 ) -> None:
-    shim, _canonical = shim_and_canonical
+    shim, _canonical = load_shim_and_canonical_modules
     assert shim.__doc__ is not None
     assert _SHIM_DOCSTRING_MARKER in shim.__doc__
 
 
-def test_shim_all_names_are_identity_equal_to_canonical(
-    shim_and_canonical: tuple[ModuleType, ModuleType],
+def test_shim_resolves_names_identical_to_canonical(
+    load_shim_and_canonical_modules: tuple[ModuleType, ModuleType],
 ) -> None:
-    shim, canonical = shim_and_canonical
+    shim, canonical = load_shim_and_canonical_modules
     for exported_name in shim.__all__:
         assert hasattr(canonical, exported_name), (
             f"canonical module missing attribute {exported_name!r}"


### PR DESCRIPTION
## Summary

- Keep the seven top-level \`phi_scan.cli_*\` compatibility shims unchanged for v1.x; remove in **v2.0**.
- Add \`tests/test_cli_shim_parity.py\` — a single parametrized matrix over all seven shims × four assertions each (imports cleanly, \`__all__\` non-empty, docstring carries the "Compatibility shim" marker, every exported name is identity-equal to the canonical \`phi_scan.cli.<name>\` attribute). 28 parametrized cases.
- CLI contract hardening: added one targeted test — \`test_scan_nonexistent_path_exits_nonzero\` — pinning the previously-untested TraversalError → nonzero exit behavior. Audit confirmed no other contract gaps.
- Deprecation documented in both \`CHANGELOG.md\` (release-facing) and \`docs/lts-eol-policy.md\` (durable policy reference), with a v2.0 removal target.
- Runtime \`DeprecationWarning\` is **deferred** to a pre-v2.0 minor release to avoid a silent behavior change mid-series.

## Test plan

- [x] \`uv run ruff format --check .\` — 170 files already formatted
- [x] \`uv run ruff check .\` — All checks passed
- [x] \`uv run mypy phi_scan\` — Success: no issues found in 88 source files
- [x] \`uv run pytest -q\` — 2022 passed, 3 skipped; coverage 91.17%
- [x] Shim modules unchanged (no behavior change)
- [x] No unrelated refactors