### PR TITLE
feat(plugins): ship v1.1 BaseSuppressor hook

### DIFF
--- a/docs/plugin-api-v1.md
+++ b/docs/plugin-api-v1.md
@@ -1,5 +1,10 @@
 # Plugin API v1 — Compatibility and Deprecation Policy
 
+> **Suppressor plugins (v1.1):** the suppressor hook under the
+> `phi_scan.suppressors` entry-point group is documented separately in
+> [`plugin-api-v1_1.md`](plugin-api-v1_1.md). The recognizer contract
+> below is unchanged.
+
 This document defines the compatibility contract, deprecation rules, and
 authoring constraints for third-party recognizer plugins that register
 under the `phi_scan.plugins` entry-point group.

--- a/docs/plugin-api-v1_1.md
+++ b/docs/plugin-api-v1_1.md
@@ -152,6 +152,11 @@ not caught.
 A return value that is not an instance of `SuppressDecision` is
 handled the same way: WARNING-logged, treated as pass-through.
 
+Only the exception **type name** is logged; the exception message
+(`str(exception)`) is deliberately dropped because a suppressor
+receives the source line directly and could embed line text in its
+exception message, which would leak raw PHI to the log stream.
+
 This mirrors the recognizer-side boundary in
 `phi_scan.plugin_runtime._invoke_detect_with_isolation`.
 

--- a/docs/plugin-api-v1_1.md
+++ b/docs/plugin-api-v1_1.md
@@ -1,0 +1,245 @@
+# Plugin API v1.1 — Suppressor Hook
+
+This document defines the contract for third-party **suppressor**
+plugins that register under the `phi_scan.suppressors` entry-point
+group. It extends the v1.0 contract (`docs/plugin-api-v1.md`) with a
+second hook type; the v1.0 recognizer contract is unchanged.
+
+The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY in this
+document are to be interpreted as described in
+[RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+---
+
+## API Version Contract
+
+The host declares its suppressor API version as the string constant
+`SUPPRESSOR_API_VERSION` (currently `"1.1"`).
+
+Every suppressor plugin MUST declare the same version string on its
+`plugin_api_version` class attribute. The loader enforces an **exact
+match**: a mismatch causes the plugin to be skipped with a WARNING
+and the scan continues without it.
+
+```
+Host: SUPPRESSOR_API_VERSION = "1.1"
+Plugin: plugin_api_version = "1.1"   # exact match required
+```
+
+The v1.0 recognizer `PLUGIN_API_VERSION` and the v1.1 suppressor
+`SUPPRESSOR_API_VERSION` are **independent** version axes. A
+distribution may ship a v1.0 recognizer and a v1.1 suppressor in the
+same package.
+
+---
+
+## Public Surface
+
+Exported from `phi_scan.plugin_api`:
+
+```python
+from phi_scan.plugin_api import (
+    SUPPRESSOR_API_VERSION,
+    BaseSuppressor,
+    SuppressDecision,
+    SuppressorFindingView,
+)
+```
+
+### `SuppressorFindingView`
+
+Frozen dataclass passed to `evaluate` — a plugin-stable projection of
+the host finding. Host-internal fields (`value_hash`, `code_context`,
+`detection_layer`) are deliberately withheld so the API stays stable
+across future host refactors.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `entity_type` | `str` | Uppercase entity-type string of the finding. |
+| `confidence` | `float` | Host-computed confidence in `[0.0, 1.0]`. |
+| `line_number` | `int` | 1-indexed line number of the finding. |
+| `file_path` | `pathlib.Path` | Path of the scanned file (language-gating + logging only). |
+| `file_extension` | `str` | File extension including the leading dot; empty when absent. |
+
+### `SuppressDecision`
+
+Frozen dataclass returned by `evaluate`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `is_suppressed` | `bool` | `True` drops the finding before the confidence/severity gates. |
+| `reason` | `str` | Short human-readable rationale. MUST NOT contain raw PHI. |
+
+### `BaseSuppressor`
+
+Abstract base class. Subclasses declare:
+
+- `name` — lowercase snake_case identifier matching
+  `[a-z][a-z0-9_]*`.
+- `plugin_api_version` — must equal `SUPPRESSOR_API_VERSION`.
+- `version`, `description` — informational.
+
+The single abstract method:
+
+```python
+def evaluate(
+    self,
+    finding: SuppressorFindingView,
+    line: str,
+) -> SuppressDecision: ...
+```
+
+`line` is the full text of the source line containing the finding,
+without the trailing newline. It is the empty string when the line
+cannot be reconstructed.
+
+---
+
+## Pipeline Position
+
+Suppressor plugins run in `_apply_post_scan_filters` between the
+inline `phi-scan:ignore` filter and the confidence/severity
+thresholds:
+
+```
+detection
+   │
+   ▼
+inline `phi-scan:ignore` directives   (v0.3 — unchanged)
+   │
+   ▼
+suppressor plugins                    (v1.1 — new)
+   │
+   ▼
+confidence threshold
+   │
+   ▼
+severity threshold
+   │
+   ▼
+emitted findings
+```
+
+A finding dropped by a suppressor **never** reaches the
+confidence/severity gates, the audit log, or any output formatter.
+
+---
+
+## Execution Order
+
+Loaded suppressors are consulted in deterministic
+`(distribution_name, entry_point_name)` order, identical to the
+recognizer ordering rule in v1.0.
+
+For each surviving finding the host iterates the suppressor list and
+**short-circuits on the first `SuppressDecision` with
+`is_suppressed=True`** — later suppressors are not consulted for that
+finding.
+
+---
+
+## Isolation and Failure Semantics
+
+Third-party suppressor code runs at a documented isolation boundary.
+Any exception raised by `evaluate` is caught, logged at WARNING level
+through a per-suppressor rate-limited budget (default: 5 per scan
+plus one end-of-scan summary line), and the finding is treated as
+**not suppressed by that plugin** for that one call. Other
+suppressors and the surrounding scan proceed unaffected.
+`BaseException` (`KeyboardInterrupt`, `SystemExit`) is deliberately
+not caught.
+
+A return value that is not an instance of `SuppressDecision` is
+handled the same way: WARNING-logged, treated as pass-through.
+
+This mirrors the recognizer-side boundary in
+`phi_scan.plugin_runtime._invoke_detect_with_isolation`.
+
+---
+
+## Author Constraints
+
+Plugin authors MUST NOT:
+
+- Open, stat, or mutate `finding.file_path`.
+- Send any data to a remote service.
+- Mutate the passed `SuppressorFindingView` or `line` string.
+- Include raw PHI in `SuppressDecision.reason`.
+
+Plugin authors MAY:
+
+- Gate on `finding.file_extension` to skip languages the suppressor
+  does not understand.
+- Consult `finding.entity_type` and `finding.confidence` to implement
+  per-entity or per-confidence allowlists.
+
+---
+
+## Configuration
+
+v1.1 ships with **no** user-facing configuration flag. All discovered
+suppressors are loaded and executed. A `plugins.suppressors.enabled`
+config key is reserved for a follow-up release; see
+`docs/plugin-hooks-v1_1-backlog.md`.
+
+---
+
+## Minimal Example
+
+```python
+from phi_scan.plugin_api import (
+    SUPPRESSOR_API_VERSION,
+    BaseSuppressor,
+    SuppressDecision,
+    SuppressorFindingView,
+)
+
+
+class TestFixtureSuppressor(BaseSuppressor):
+    """Suppress findings in files under test-fixture directories."""
+
+    name = "test_fixture_suppressor"
+    plugin_api_version = SUPPRESSOR_API_VERSION
+    version = "0.1.0"
+    description = "Drop findings in tests/fixtures/**."
+
+    def evaluate(
+        self,
+        finding: SuppressorFindingView,
+        line: str,
+    ) -> SuppressDecision:
+        is_fixture = "tests/fixtures" in str(finding.file_path)
+        return SuppressDecision(
+            is_suppressed=is_fixture,
+            reason="file under tests/fixtures" if is_fixture else "not a fixture",
+        )
+```
+
+Register it via the publishing distribution's `pyproject.toml`:
+
+```toml
+[project.entry-points."phi_scan.suppressors"]
+test_fixture_suppressor = "my_package.suppressors:TestFixtureSuppressor"
+```
+
+Verify discovery:
+
+```
+$ phi-scan plugins list
+```
+
+The command prints a dedicated "Installed Suppressor Plugins" table
+and, with `--json`, a top-level `suppressors` array alongside the
+existing `plugins` array.
+
+---
+
+## Compatibility With v1.0
+
+- v1.0 recognizer plugins are unaffected. A host that discovers zero
+  suppressors behaves identically to the pre-v1.1 host.
+- The v1.0 `phi_scan.plugins` entry-point group and
+  `PLUGIN_API_VERSION = "1.0"` are unchanged.
+- Existing `phi-scan plugins list` output for recognizers is
+  preserved byte-for-byte when no suppressors are installed, apart
+  from a new one-line "No suppressor plugins discovered." footer.

--- a/docs/plugin-api-v1_1.md
+++ b/docs/plugin-api-v1_1.md
@@ -26,6 +26,11 @@ Host: SUPPRESSOR_API_VERSION = "1.1"
 Plugin: plugin_api_version = "1.1"   # exact match required
 ```
 
+The literal `"1.1"` appears in this prose/table form only. Plugin
+code MUST import and assign `SUPPRESSOR_API_VERSION` rather than
+hard-coding the version string, so a host version bump surfaces as
+an import-time change in the plugin instead of a silent drift.
+
 The v1.0 recognizer `PLUGIN_API_VERSION` and the v1.1 suppressor
 `SUPPRESSOR_API_VERSION` are **independent** version axes. A
 distribution may ship a v1.0 recognizer and a v1.1 suppressor in the
@@ -199,6 +204,24 @@ from phi_scan.plugin_api import (
     SuppressorFindingView,
 )
 
+# Path components that identify a test-fixture tree. Lifted to module
+# scope so the value is never inlined in logic (per project standards)
+# and so the match is performed on structured Path parts rather than
+# on a stringified path.
+_FIXTURE_PATH_COMPONENTS: tuple[str, ...] = ("tests", "fixtures")
+_REASON_IS_FIXTURE = "file under tests/fixtures"
+_REASON_NOT_FIXTURE = "not a fixture"
+
+
+def _is_under_fixture_tree(path_parts: tuple[str, ...]) -> bool:
+    # Structural match on Path.parts — plugins MUST NOT open or stat
+    # finding.file_path, and MUST NOT embed it in SuppressDecision.reason.
+    window = len(_FIXTURE_PATH_COMPONENTS)
+    for start in range(len(path_parts) - window + 1):
+        if path_parts[start : start + window] == _FIXTURE_PATH_COMPONENTS:
+            return True
+    return False
+
 
 class TestFixtureSuppressor(BaseSuppressor):
     """Suppress findings in files under test-fixture directories."""
@@ -213,10 +236,10 @@ class TestFixtureSuppressor(BaseSuppressor):
         finding: SuppressorFindingView,
         line: str,
     ) -> SuppressDecision:
-        is_fixture = "tests/fixtures" in str(finding.file_path)
+        is_fixture = _is_under_fixture_tree(finding.file_path.parts)
         return SuppressDecision(
             is_suppressed=is_fixture,
-            reason="file under tests/fixtures" if is_fixture else "not a fixture",
+            reason=_REASON_IS_FIXTURE if is_fixture else _REASON_NOT_FIXTURE,
         )
 ```
 

--- a/phi_scan/cli/plugins.py
+++ b/phi_scan/cli/plugins.py
@@ -13,6 +13,7 @@ from phi_scan.constants import EXIT_CODE_CLEAN
 from phi_scan.output import get_console
 from phi_scan.plugin_loader import (
     LoadedPlugin,
+    LoadedSuppressor,
     PluginRegistry,
     SkippedPlugin,
     discover_plugin_registry,
@@ -30,11 +31,13 @@ plugins_app = typer.Typer(
 # ---------------------------------------------------------------------------
 
 _NO_PLUGINS_MESSAGE: str = "No recognizer plugins discovered."
+_NO_SUPPRESSORS_MESSAGE: str = "No suppressor plugins discovered."
 
 _STATUS_LOADED: str = "loaded"
 _STATUS_SKIPPED: str = "skipped-invalid"
 
 _TABLE_TITLE: str = "Installed Recognizer Plugins"
+_SUPPRESSOR_TABLE_TITLE: str = "Installed Suppressor Plugins"
 _COLUMN_NAME: str = "Name"
 _COLUMN_VERSION: str = "Version"
 _COLUMN_API_VERSION: str = "API Version"
@@ -45,6 +48,7 @@ _ENTITY_TYPE_SEPARATOR: str = ", "
 _EMPTY_CELL: str = ""
 
 _JSON_KEY_PLUGINS: str = "plugins"
+_JSON_KEY_SUPPRESSORS: str = "suppressors"
 _JSON_KEY_NAME: str = "name"
 _JSON_KEY_VERSION: str = "version"
 _JSON_KEY_API_VERSION: str = "api_version"
@@ -85,11 +89,60 @@ def list_plugins(
 
 
 def _print_table_output(registry: PluginRegistry) -> None:
+    _print_recognizer_table(registry)
+    _print_suppressor_table(registry)
+
+
+def _print_recognizer_table(registry: PluginRegistry) -> None:
     if not registry.loaded and not registry.skipped:
         get_console().print(_NO_PLUGINS_MESSAGE)
         return
     table = _build_plugin_table(registry)
     get_console().print(table)
+
+
+def _print_suppressor_table(registry: PluginRegistry) -> None:
+    if not registry.loaded_suppressors and not registry.skipped_suppressors:
+        get_console().print(_NO_SUPPRESSORS_MESSAGE)
+        return
+    table = _build_suppressor_table(registry)
+    get_console().print(table)
+
+
+def _build_suppressor_table(registry: PluginRegistry) -> Table:
+    table = Table(
+        title=_SUPPRESSOR_TABLE_TITLE,
+        box=rich_box.ROUNDED,
+        show_lines=True,
+    )
+    table.add_column(_COLUMN_NAME, style="bold")
+    table.add_column(_COLUMN_VERSION)
+    table.add_column(_COLUMN_API_VERSION)
+    table.add_column(_COLUMN_STATUS)
+    for loaded_suppressor in registry.loaded_suppressors:
+        _add_loaded_suppressor_row(table, loaded_suppressor)
+    for skipped_suppressor in registry.skipped_suppressors:
+        _add_skipped_suppressor_row(table, skipped_suppressor)
+    return table
+
+
+def _add_loaded_suppressor_row(table: Table, loaded_suppressor: LoadedSuppressor) -> None:
+    suppressor = loaded_suppressor.suppressor
+    table.add_row(
+        suppressor.name,
+        suppressor.version,
+        suppressor.plugin_api_version,
+        f"[green]{_STATUS_LOADED}[/green]",
+    )
+
+
+def _add_skipped_suppressor_row(table: Table, skipped_suppressor: SkippedPlugin) -> None:
+    table.add_row(
+        skipped_suppressor.entry_point_name,
+        _EMPTY_CELL,
+        _EMPTY_CELL,
+        f"[red]{_STATUS_SKIPPED}: {escape_rich_markup(skipped_suppressor.reason)}[/red]",
+    )
 
 
 def _build_plugin_table(registry: PluginRegistry) -> Table:
@@ -138,8 +191,12 @@ def _add_skipped_row(table: Table, skipped_plugin: SkippedPlugin) -> None:
 
 def _print_json_output(registry: PluginRegistry) -> None:
     plugin_records = _build_json_records(registry)
+    suppressor_records = _build_suppressor_json_records(registry)
     serialized_output = json.dumps(
-        {_JSON_KEY_PLUGINS: plugin_records},
+        {
+            _JSON_KEY_PLUGINS: plugin_records,
+            _JSON_KEY_SUPPRESSORS: suppressor_records,
+        },
         indent=_JSON_INDENT,
     )
     get_console().print(serialized_output, highlight=False)
@@ -149,6 +206,24 @@ def _build_json_records(registry: PluginRegistry) -> list[dict[str, object]]:
     loaded_records = [_serialize_loaded_plugin(lp) for lp in registry.loaded]
     skipped_records = [_serialize_skipped_plugin(sp) for sp in registry.skipped]
     return loaded_records + skipped_records
+
+
+def _build_suppressor_json_records(registry: PluginRegistry) -> list[dict[str, object]]:
+    loaded_records = [_serialize_loaded_suppressor(ls) for ls in registry.loaded_suppressors]
+    skipped_records = [_serialize_skipped_plugin(sp) for sp in registry.skipped_suppressors]
+    return loaded_records + skipped_records
+
+
+def _serialize_loaded_suppressor(loaded_suppressor: LoadedSuppressor) -> dict[str, object]:
+    suppressor = loaded_suppressor.suppressor
+    return {
+        _JSON_KEY_NAME: suppressor.name,
+        _JSON_KEY_VERSION: suppressor.version,
+        _JSON_KEY_API_VERSION: suppressor.plugin_api_version,
+        _JSON_KEY_STATUS: _STATUS_LOADED,
+        _JSON_KEY_DISTRIBUTION: loaded_suppressor.distribution_name,
+        _JSON_KEY_ENTRY_POINT: loaded_suppressor.entry_point_name,
+    }
 
 
 def _serialize_loaded_plugin(loaded_plugin: LoadedPlugin) -> dict[str, object]:

--- a/phi_scan/cli/plugins.py
+++ b/phi_scan/cli/plugins.py
@@ -127,11 +127,11 @@ def _build_suppressor_table(registry: PluginRegistry) -> Table:
 
 
 def _add_loaded_suppressor_row(table: Table, loaded_suppressor: LoadedSuppressor) -> None:
-    suppressor = loaded_suppressor.suppressor
+    suppressor_instance = loaded_suppressor.suppressor
     table.add_row(
-        suppressor.name,
-        suppressor.version,
-        suppressor.plugin_api_version,
+        suppressor_instance.name,
+        suppressor_instance.version,
+        suppressor_instance.plugin_api_version,
         f"[green]{_STATUS_LOADED}[/green]",
     )
 

--- a/phi_scan/plugin_api.py
+++ b/phi_scan/plugin_api.py
@@ -42,12 +42,17 @@ from pathlib import Path
 
 __all__ = [
     "BaseRecognizer",
+    "BaseSuppressor",
     "PLUGIN_API_VERSION",
+    "SUPPRESSOR_API_VERSION",
     "ScanContext",
     "ScanFinding",
+    "SuppressDecision",
+    "SuppressorFindingView",
 ]
 
 PLUGIN_API_VERSION: str = "1.0"
+SUPPRESSOR_API_VERSION: str = "1.1"
 
 RECOGNIZER_NAME_PATTERN: re.Pattern[str] = re.compile(r"^[a-z][a-z0-9_]*$")
 ENTITY_TYPE_PATTERN: re.Pattern[str] = re.compile(r"^[A-Z][A-Z0-9_]*$")
@@ -246,4 +251,108 @@ class BaseRecognizer(ABC):
             Raising from ``detect`` is allowed; the host catches the
             exception and drops the batch for that line with a
             WARNING-level log entry.
+        """
+
+
+@dataclass(frozen=True)
+class SuppressorFindingView:
+    """Plugin-stable view of a host finding passed to ``BaseSuppressor.evaluate``.
+
+    Exposes only the fields a suppressor needs to make a decision. The
+    raw matched value is never included — suppressors operate on
+    metadata and the surrounding line text only. Host-internal fields
+    (``value_hash``, ``code_context``, ``detection_layer``) are
+    intentionally withheld so the API surface stays stable across
+    future host refactors.
+
+    Attributes:
+        entity_type: Uppercase entity-type string of the finding.
+        confidence: Host-computed confidence in [0.0, 1.0].
+        line_number: 1-indexed line number of the finding.
+        file_path: Path of the scanned file. Suppressors MUST NOT open
+            or stat this path; it is supplied for language-gating and
+            logging only.
+        file_extension: File extension including the leading dot (e.g.
+            ``".py"``); empty string when the file has no extension.
+    """
+
+    entity_type: str
+    confidence: float
+    line_number: int
+    file_path: Path
+    file_extension: str
+
+
+@dataclass(frozen=True)
+class SuppressDecision:
+    """Outcome of one ``BaseSuppressor.evaluate`` call.
+
+    Attributes:
+        is_suppressed: When ``True`` the finding is dropped before the
+            confidence and severity filters run. The first suppressor
+            whose decision sets this to ``True`` wins; later
+            suppressors for the same finding are not consulted.
+        reason: Short human-readable description of why the suppressor
+            chose this outcome. Logged for diagnostics and surfaced by
+            future audit tooling. Plugins MUST NOT include raw PHI in
+            the reason string.
+    """
+
+    is_suppressed: bool
+    reason: str
+
+
+class BaseSuppressor(ABC):
+    """Abstract base class for third-party suppressor plugins (API v1.1).
+
+    Suppressors run after inline ``phi-scan:ignore`` directives and
+    before the confidence and severity filters. Each loaded suppressor
+    is consulted once per surviving finding, in deterministic
+    ``(distribution_name, entry_point_name)`` order; the first
+    ``SuppressDecision`` with ``is_suppressed=True`` drops the finding.
+
+    Class attribute contract:
+
+        * ``name`` — lowercase snake_case identifier matching
+          ``RECOGNIZER_NAME_PATTERN``. Used as the collision key for
+          deduplicating suppressors across installed distributions.
+        * ``plugin_api_version`` — must equal the host's
+          ``SUPPRESSOR_API_VERSION`` constant (``"1.1"``) for the
+          plugin to be loaded.
+        * ``version`` — plugin's own semantic version, informational.
+        * ``description`` — one-line human description, informational.
+
+    Plugin authors MUST NOT:
+
+        * Open, stat, or mutate ``finding.file_path``.
+        * Send any data to a remote service.
+        * Mutate the passed ``SuppressorFindingView`` or ``line`` string.
+        * Include raw PHI in ``SuppressDecision.reason``.
+
+    Raising from ``evaluate`` is allowed; the host catches the
+    exception at the designated isolation boundary and treats the
+    suppressor as having decided ``is_suppressed=False`` for that one
+    finding. Other suppressors and findings are unaffected.
+    """
+
+    name: str
+    plugin_api_version: str = SUPPRESSOR_API_VERSION
+    version: str = _DEFAULT_PLUGIN_VERSION
+    description: str = _DEFAULT_PLUGIN_DESCRIPTION
+
+    @abstractmethod
+    def evaluate(self, finding: SuppressorFindingView, line: str) -> SuppressDecision:
+        """Decide whether ``finding`` should be suppressed.
+
+        Args:
+            finding: Plugin-stable projection of the host finding.
+            line: Full text of the source line containing the finding,
+                without the trailing newline. May be empty when the
+                line cannot be reconstructed.
+
+        Returns:
+            A ``SuppressDecision``. ``is_suppressed=True`` drops the
+            finding; ``False`` passes it through to the next
+            suppressor and ultimately to the confidence and severity
+            filters.
         """

--- a/phi_scan/plugin_loader.py
+++ b/phi_scan/plugin_loader.py
@@ -31,24 +31,33 @@ from phi_scan.plugin_api import (
     ENTITY_TYPE_PATTERN,
     PLUGIN_API_VERSION,
     RECOGNIZER_NAME_PATTERN,
+    SUPPRESSOR_API_VERSION,
     BaseRecognizer,
+    BaseSuppressor,
 )
 
 __all__ = [
     "LoadedPlugin",
+    "LoadedSuppressor",
     "PLUGIN_ENTRY_POINT_GROUP",
     "PluginRegistry",
+    "SUPPRESSOR_ENTRY_POINT_GROUP",
     "SkippedPlugin",
     "discover_plugin_registry",
     "load_plugin_registry",
 ]
 
 PLUGIN_ENTRY_POINT_GROUP: str = "phi_scan.plugins"
+SUPPRESSOR_ENTRY_POINT_GROUP: str = "phi_scan.suppressors"
 
 _UNKNOWN_DISTRIBUTION_LABEL: str = "<unknown distribution>"
 
 _NOT_A_CLASS_REASON: str = "entry point did not resolve to a class"
 _NOT_A_RECOGNIZER_REASON: str = "class does not inherit from BaseRecognizer"
+_NOT_A_SUPPRESSOR_REASON: str = "class does not inherit from BaseSuppressor"
+_SUPPRESSOR_API_VERSION_MISMATCH_REASON: str = (
+    "plugin_api_version {plugin_version!r} does not match host suppressor API {host_version!r}"
+)
 _MISSING_NAME_REASON: str = "class does not declare a 'name' attribute"
 _INVALID_NAME_REASON: str = "name {name!r} does not match pattern {pattern}"
 _MISSING_ENTITY_TYPES_REASON: str = "class does not declare 'entity_types'"
@@ -108,8 +117,26 @@ class SkippedPlugin:
 
 
 @dataclass(frozen=True)
+class LoadedSuppressor:
+    """A suppressor plugin that passed validation and was instantiated.
+
+    Attributes:
+        entry_point_name: Name field on the setuptools entry point.
+        distribution_name: Name of the installed distribution that
+            provided the entry point, or ``None`` if the metadata
+            was unavailable.
+        suppressor: The instantiated suppressor, ready to be invoked
+            by ``evaluate(finding_view, line)``.
+    """
+
+    entry_point_name: str
+    distribution_name: str | None
+    suppressor: BaseSuppressor
+
+
+@dataclass(frozen=True)
 class PluginRegistry:
-    """The result of one plugin-discovery pass over the entry-point group.
+    """The result of one plugin-discovery pass over the entry-point groups.
 
     Attributes:
         loaded: Tuple of recognizers that passed validation, in the
@@ -117,10 +144,16 @@ class PluginRegistry:
             name then entry-point name).
         skipped: Tuple of recognizers that were rejected, in the
             same deterministic order.
+        loaded_suppressors: Tuple of suppressor plugins that passed
+            validation, in deterministic discovery order.
+        skipped_suppressors: Tuple of suppressor plugins that were
+            rejected, in the same deterministic order.
     """
 
     loaded: tuple[LoadedPlugin, ...] = ()
     skipped: tuple[SkippedPlugin, ...] = ()
+    loaded_suppressors: tuple[LoadedSuppressor, ...] = ()
+    skipped_suppressors: tuple[SkippedPlugin, ...] = ()
 
 
 def discover_plugin_registry() -> PluginRegistry:
@@ -137,9 +170,17 @@ def discover_plugin_registry() -> PluginRegistry:
     """
     sorted_entry_points = _sort_entry_points_deterministically(_discover_entry_points())
     loaded_plugins, skipped_plugins = _classify_entry_points(sorted_entry_points)
+    sorted_suppressor_entry_points = _sort_entry_points_deterministically(
+        _discover_suppressor_entry_points()
+    )
+    loaded_suppressors, skipped_suppressors = _classify_suppressor_entry_points(
+        sorted_suppressor_entry_points
+    )
     return PluginRegistry(
         loaded=tuple(loaded_plugins),
         skipped=tuple(skipped_plugins),
+        loaded_suppressors=tuple(loaded_suppressors),
+        skipped_suppressors=tuple(skipped_suppressors),
     )
 
 
@@ -155,6 +196,8 @@ def load_plugin_registry() -> PluginRegistry:
     registry = discover_plugin_registry()
     for skipped_plugin in registry.skipped:
         _log_skipped_plugin(skipped_plugin)
+    for skipped_suppressor in registry.skipped_suppressors:
+        _log_skipped_plugin(skipped_suppressor)
     return registry
 
 
@@ -353,6 +396,111 @@ def _instantiate_recognizer(
     # and the reason string is logged at WARNING level.
     try:
         return recognizer_class()
+    except Exception as init_error:  # noqa: BLE001 — see comment above
+        raise PluginValidationError(
+            _INSTANTIATION_FAILURE_REASON.format(error_type=type(init_error).__name__)
+        ) from init_error
+
+
+def _discover_suppressor_entry_points() -> tuple[EntryPoint, ...]:
+    return tuple(entry_points(group=SUPPRESSOR_ENTRY_POINT_GROUP))
+
+
+def _classify_suppressor_entry_points(
+    sorted_entry_points: tuple[EntryPoint, ...],
+) -> tuple[list[LoadedSuppressor], list[SkippedPlugin]]:
+    loaded_suppressors: list[LoadedSuppressor] = []
+    skipped_suppressors: list[SkippedPlugin] = []
+    reserved_names: set[str] = set()
+    for entry_point in sorted_entry_points:
+        load_outcome = _load_or_skip_suppressor_entry_point(entry_point, reserved_names)
+        if isinstance(load_outcome, LoadedSuppressor):
+            loaded_suppressors.append(load_outcome)
+            reserved_names.add(load_outcome.suppressor.name)
+            continue
+        skipped_suppressors.append(load_outcome)
+    return loaded_suppressors, skipped_suppressors
+
+
+def _load_or_skip_suppressor_entry_point(
+    entry_point: EntryPoint,
+    reserved_names: set[str],
+) -> LoadedSuppressor | SkippedPlugin:
+    distribution_name = _resolve_distribution_name(entry_point)
+    try:
+        suppressor_class = _import_validated_suppressor_class(entry_point, reserved_names)
+        suppressor_instance = _instantiate_suppressor(suppressor_class)
+    except PluginValidationError as validation_error:
+        return SkippedPlugin(
+            entry_point_name=entry_point.name,
+            distribution_name=distribution_name,
+            reason=str(validation_error),
+        )
+    return LoadedSuppressor(
+        entry_point_name=entry_point.name,
+        distribution_name=distribution_name,
+        suppressor=suppressor_instance,
+    )
+
+
+def _import_validated_suppressor_class(
+    entry_point: EntryPoint,
+    reserved_names: set[str],
+) -> type[BaseSuppressor]:
+    entry_point_target = _import_entry_point_object(entry_point)
+    suppressor_class = _coerce_to_suppressor_class(entry_point_target)
+    _validate_suppressor_class(suppressor_class)
+    _reject_reserved_name(suppressor_class.name, reserved_names)
+    return suppressor_class
+
+
+def _coerce_to_suppressor_class(entry_point_target: object) -> type[BaseSuppressor]:
+    if not isinstance(entry_point_target, type):
+        raise PluginValidationError(_NOT_A_CLASS_REASON)
+    if not issubclass(entry_point_target, BaseSuppressor):
+        raise PluginValidationError(_NOT_A_SUPPRESSOR_REASON)
+    return entry_point_target
+
+
+def _validate_suppressor_class(suppressor_class: type[BaseSuppressor]) -> None:
+    _validate_suppressor_api_version(suppressor_class)
+    _validate_suppressor_name(suppressor_class)
+
+
+def _validate_suppressor_api_version(suppressor_class: type[BaseSuppressor]) -> None:
+    declared_version = suppressor_class.plugin_api_version
+    if declared_version != SUPPRESSOR_API_VERSION:
+        raise PluginValidationError(
+            _SUPPRESSOR_API_VERSION_MISMATCH_REASON.format(
+                plugin_version=declared_version,
+                host_version=SUPPRESSOR_API_VERSION,
+            )
+        )
+
+
+def _validate_suppressor_name(suppressor_class: type[BaseSuppressor]) -> None:
+    declared_name = getattr(suppressor_class, "name", None)
+    if declared_name is None:
+        raise PluginValidationError(_MISSING_NAME_REASON)
+    if not isinstance(declared_name, str) or not RECOGNIZER_NAME_PATTERN.match(declared_name):
+        raise PluginValidationError(
+            _INVALID_NAME_REASON.format(
+                name=declared_name,
+                pattern=RECOGNIZER_NAME_PATTERN.pattern,
+            )
+        )
+
+
+def _instantiate_suppressor(
+    suppressor_class: type[BaseSuppressor],
+) -> BaseSuppressor:
+    # Same trust-boundary behaviour as ``_instantiate_recognizer``: any
+    # constructor exception from a third-party plugin is converted into a
+    # skip outcome so the scan continues. Only the type name is embedded
+    # in the reason because a failing constructor may have read values
+    # from the environment that could incidentally contain PHI.
+    try:
+        return suppressor_class()
     except Exception as init_error:  # noqa: BLE001 — see comment above
         raise PluginValidationError(
             _INSTANTIATION_FAILURE_REASON.format(error_type=type(init_error).__name__)

--- a/phi_scan/plugin_loader.py
+++ b/phi_scan/plugin_loader.py
@@ -413,12 +413,14 @@ def _classify_suppressor_entry_points(
     skipped_suppressors: list[SkippedPlugin] = []
     reserved_names: set[str] = set()
     for entry_point in sorted_entry_points:
-        load_outcome = _load_or_skip_suppressor_entry_point(entry_point, reserved_names)
-        if isinstance(load_outcome, LoadedSuppressor):
-            loaded_suppressors.append(load_outcome)
-            reserved_names.add(load_outcome.suppressor.name)
+        loaded_or_skipped_suppressor = _load_or_skip_suppressor_entry_point(
+            entry_point, reserved_names
+        )
+        if isinstance(loaded_or_skipped_suppressor, LoadedSuppressor):
+            loaded_suppressors.append(loaded_or_skipped_suppressor)
+            reserved_names.add(loaded_or_skipped_suppressor.suppressor.name)
             continue
-        skipped_suppressors.append(load_outcome)
+        skipped_suppressors.append(loaded_or_skipped_suppressor)
     return loaded_suppressors, skipped_suppressors
 
 

--- a/phi_scan/plugin_loader.py
+++ b/phi_scan/plugin_loader.py
@@ -218,7 +218,11 @@ def _classify_entry_points(
 
 
 def _discover_entry_points() -> tuple[EntryPoint, ...]:
-    return tuple(entry_points(group=PLUGIN_ENTRY_POINT_GROUP))
+    return _discover_entry_points_for_group(PLUGIN_ENTRY_POINT_GROUP)
+
+
+def _discover_entry_points_for_group(group: str) -> tuple[EntryPoint, ...]:
+    return tuple(entry_points(group=group))
 
 
 def _sort_entry_points_deterministically(
@@ -267,8 +271,8 @@ def _import_validated_recognizer_class(
     entry_point: EntryPoint,
     reserved_names: set[str],
 ) -> type[BaseRecognizer]:
-    entry_point_target = _import_entry_point_object(entry_point)
-    recognizer_class = _coerce_to_recognizer_class(entry_point_target)
+    imported_entry_point = _import_entry_point_object(entry_point)
+    recognizer_class = _coerce_to_recognizer_class(imported_entry_point)
     _validate_recognizer_class(recognizer_class)
     _reject_reserved_name(recognizer_class.name, reserved_names)
     return recognizer_class
@@ -290,12 +294,12 @@ def _import_entry_point_object(entry_point: EntryPoint) -> object:
         ) from load_error
 
 
-def _coerce_to_recognizer_class(entry_point_target: object) -> type[BaseRecognizer]:
-    if not isinstance(entry_point_target, type):
+def _coerce_to_recognizer_class(imported_entry_point: object) -> type[BaseRecognizer]:
+    if not isinstance(imported_entry_point, type):
         raise PluginValidationError(_NOT_A_CLASS_REASON)
-    if not issubclass(entry_point_target, BaseRecognizer):
+    if not issubclass(imported_entry_point, BaseRecognizer):
         raise PluginValidationError(_NOT_A_RECOGNIZER_REASON)
-    return entry_point_target
+    return imported_entry_point
 
 
 def _validate_recognizer_class(recognizer_class: type[BaseRecognizer]) -> None:
@@ -403,7 +407,7 @@ def _instantiate_recognizer(
 
 
 def _discover_suppressor_entry_points() -> tuple[EntryPoint, ...]:
-    return tuple(entry_points(group=SUPPRESSOR_ENTRY_POINT_GROUP))
+    return _discover_entry_points_for_group(SUPPRESSOR_ENTRY_POINT_GROUP)
 
 
 def _classify_suppressor_entry_points(
@@ -413,14 +417,12 @@ def _classify_suppressor_entry_points(
     skipped_suppressors: list[SkippedPlugin] = []
     reserved_names: set[str] = set()
     for entry_point in sorted_entry_points:
-        loaded_or_skipped_suppressor = _load_or_skip_suppressor_entry_point(
-            entry_point, reserved_names
-        )
-        if isinstance(loaded_or_skipped_suppressor, LoadedSuppressor):
-            loaded_suppressors.append(loaded_or_skipped_suppressor)
-            reserved_names.add(loaded_or_skipped_suppressor.suppressor.name)
+        load_outcome = _load_or_skip_suppressor_entry_point(entry_point, reserved_names)
+        if isinstance(load_outcome, LoadedSuppressor):
+            loaded_suppressors.append(load_outcome)
+            reserved_names.add(load_outcome.suppressor.name)
             continue
-        skipped_suppressors.append(loaded_or_skipped_suppressor)
+        skipped_suppressors.append(load_outcome)
     return loaded_suppressors, skipped_suppressors
 
 
@@ -449,19 +451,19 @@ def _import_validated_suppressor_class(
     entry_point: EntryPoint,
     reserved_names: set[str],
 ) -> type[BaseSuppressor]:
-    entry_point_target = _import_entry_point_object(entry_point)
-    suppressor_class = _coerce_to_suppressor_class(entry_point_target)
+    imported_entry_point = _import_entry_point_object(entry_point)
+    suppressor_class = _coerce_to_suppressor_class(imported_entry_point)
     _validate_suppressor_class(suppressor_class)
     _reject_reserved_name(suppressor_class.name, reserved_names)
     return suppressor_class
 
 
-def _coerce_to_suppressor_class(entry_point_target: object) -> type[BaseSuppressor]:
-    if not isinstance(entry_point_target, type):
+def _coerce_to_suppressor_class(imported_entry_point: object) -> type[BaseSuppressor]:
+    if not isinstance(imported_entry_point, type):
         raise PluginValidationError(_NOT_A_CLASS_REASON)
-    if not issubclass(entry_point_target, BaseSuppressor):
+    if not issubclass(imported_entry_point, BaseSuppressor):
         raise PluginValidationError(_NOT_A_SUPPRESSOR_REASON)
-    return entry_point_target
+    return imported_entry_point
 
 
 def _validate_suppressor_class(suppressor_class: type[BaseSuppressor]) -> None:

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -676,24 +676,11 @@ def _apply_post_scan_filters(
     Returns:
         Findings that passed suppression, confidence, and severity filtering.
     """
+    plugin_registry = _load_cached_plugin_registry()
     filtered = _apply_suppression_filter(raw_findings, file_content)
-    filtered = _apply_suppressor_plugin_filter(filtered, file_content)
+    filtered = apply_suppressor_pass(filtered, plugin_registry, file_content)
     filtered = _apply_confidence_filter(filtered, config.confidence_threshold)
     return _apply_severity_filter(filtered, config.severity_threshold)
-
-
-def _apply_suppressor_plugin_filter(
-    findings: list[ScanFinding],
-    file_content: str,
-) -> list[ScanFinding]:
-    """Run loaded suppressor plugins against ``findings`` between inline
-    suppression and the confidence/severity filters.
-
-    Reuses the scan-scoped plugin registry populated by the recognizer
-    pass so a scan invocation performs a single discovery pass.
-    """
-    registry = _load_cached_plugin_registry()
-    return apply_suppressor_pass(findings, registry, file_content)
 
 
 def _preprocess_content_for_scan(file_content: str, file_path: Path) -> str:

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -636,49 +636,48 @@ def _compose_file_findings(
     confidence, and severity filters. Shared by the cache-hit, cache-miss,
     and archive-member paths so that a single composition stays drift-free.
     """
-    plugin_findings = _execute_plugin_pass_for_file(scan_inputs.file_content, scan_inputs.file_path)
-    return _apply_post_scan_filters(
-        scan_inputs.raw_findings + plugin_findings,
-        scan_inputs.file_content,
-        config,
+    plugin_registry = _load_cached_plugin_registry()
+    plugin_findings = _execute_plugin_pass_for_file(
+        scan_inputs.file_content, scan_inputs.file_path, plugin_registry
     )
+    filter_inputs = _PostScanFilterInputs(
+        merged_findings=scan_inputs.raw_findings + plugin_findings,
+        file_content=scan_inputs.file_content,
+        plugin_registry=plugin_registry,
+    )
+    return _apply_post_scan_filters(filter_inputs, config)
 
 
-def _execute_plugin_pass_for_file(file_content: str, file_path: Path) -> list[ScanFinding]:
-    """Run the scan-scoped plugin pass against one file and return findings.
+def _execute_plugin_pass_for_file(
+    file_content: str, file_path: Path, plugin_registry: PluginRegistry
+) -> list[ScanFinding]:
+    """Thin seam over ``execute_plugin_pass`` kept as a patch target for tests."""
+    return execute_plugin_pass(file_content, file_path, plugin_registry)
 
-    ``execute_scan`` clears the registry cache synchronously before any
-    worker threads are spawned. The first worker to reach this function
-    populates the cache via ``functools.cache``, whose underlying
-    ``lru_cache`` lock serialises concurrent callers so
-    ``load_plugin_registry`` runs at most once per scan; subsequent
-    readers hit the populated cache directly.
-    """
-    registry = _load_cached_plugin_registry()
-    return execute_plugin_pass(file_content, file_path, registry)
+
+@dataclass(frozen=True)
+class _PostScanFilterInputs:
+    """Bundle of inputs threaded through the post-scan filter chain."""
+
+    merged_findings: list[ScanFinding]
+    file_content: str
+    plugin_registry: PluginRegistry
 
 
 def _apply_post_scan_filters(
-    raw_findings: list[ScanFinding],
-    file_content: str,
+    filter_inputs: _PostScanFilterInputs,
     config: ScanConfig,
 ) -> list[ScanFinding]:
-    """Apply suppression, confidence, and severity filters to raw detection findings.
+    """Apply inline suppression, plugin suppressors, confidence, and severity filters.
 
-    Called after detection (fresh scan) and after cache retrieval so that
-    threshold or suppression changes take effect even when returning cached results.
-
-    Args:
-        raw_findings: Unfiltered findings from detect_phi_in_text_content.
-        file_content: Raw file content used to parse suppression directives.
-        config: Scan configuration controlling the confidence and severity thresholds.
-
-    Returns:
-        Findings that passed suppression, confidence, and severity filtering.
+    The plugin registry is received rather than fetched so the filter
+    chain has a single responsibility (filtering) and is trivially
+    testable with a synthetic registry.
     """
-    plugin_registry = _load_cached_plugin_registry()
-    filtered = _apply_suppression_filter(raw_findings, file_content)
-    filtered = apply_suppressor_pass(filtered, plugin_registry, file_content)
+    filtered = _apply_suppression_filter(filter_inputs.merged_findings, filter_inputs.file_content)
+    filtered = apply_suppressor_pass(
+        filtered, filter_inputs.plugin_registry, filter_inputs.file_content
+    )
     filtered = _apply_confidence_filter(filtered, config.confidence_threshold)
     return _apply_severity_filter(filtered, config.severity_threshold)
 

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -56,6 +56,7 @@ from phi_scan.models import ScanConfig, ScanFinding, ScanResult
 from phi_scan.plugin_loader import PluginRegistry, load_plugin_registry
 from phi_scan.plugin_runtime import execute_plugin_pass
 from phi_scan.suppression import is_finding_suppressed, load_suppressions
+from phi_scan.suppressor_runtime import apply_suppressor_pass
 
 __all__ = [
     "MAX_WORKER_COUNT",
@@ -676,8 +677,23 @@ def _apply_post_scan_filters(
         Findings that passed suppression, confidence, and severity filtering.
     """
     filtered = _apply_suppression_filter(raw_findings, file_content)
+    filtered = _apply_suppressor_plugin_filter(filtered, file_content)
     filtered = _apply_confidence_filter(filtered, config.confidence_threshold)
     return _apply_severity_filter(filtered, config.severity_threshold)
+
+
+def _apply_suppressor_plugin_filter(
+    findings: list[ScanFinding],
+    file_content: str,
+) -> list[ScanFinding]:
+    """Run loaded suppressor plugins against ``findings`` between inline
+    suppression and the confidence/severity filters.
+
+    Reuses the scan-scoped plugin registry populated by the recognizer
+    pass so a scan invocation performs a single discovery pass.
+    """
+    registry = _load_cached_plugin_registry()
+    return apply_suppressor_pass(findings, registry, file_content)
 
 
 def _preprocess_content_for_scan(file_content: str, file_path: Path) -> str:

--- a/phi_scan/scanner.py
+++ b/phi_scan/scanner.py
@@ -641,7 +641,7 @@ def _compose_file_findings(
         scan_inputs.file_content, scan_inputs.file_path, plugin_registry
     )
     filter_inputs = _PostScanFilterInputs(
-        merged_findings=scan_inputs.raw_findings + plugin_findings,
+        merged_findings=tuple(scan_inputs.raw_findings) + tuple(plugin_findings),
         file_content=scan_inputs.file_content,
         plugin_registry=plugin_registry,
     )
@@ -659,7 +659,7 @@ def _execute_plugin_pass_for_file(
 class _PostScanFilterInputs:
     """Bundle of inputs threaded through the post-scan filter chain."""
 
-    merged_findings: list[ScanFinding]
+    merged_findings: tuple[ScanFinding, ...]
     file_content: str
     plugin_registry: PluginRegistry
 
@@ -674,7 +674,9 @@ def _apply_post_scan_filters(
     chain has a single responsibility (filtering) and is trivially
     testable with a synthetic registry.
     """
-    filtered = _apply_suppression_filter(filter_inputs.merged_findings, filter_inputs.file_content)
+    filtered = _apply_suppression_filter(
+        list(filter_inputs.merged_findings), filter_inputs.file_content
+    )
     filtered = apply_suppressor_pass(
         filtered, filter_inputs.plugin_registry, filter_inputs.file_content
     )

--- a/phi_scan/suppressor_runtime.py
+++ b/phi_scan/suppressor_runtime.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import logging
 from collections import Counter
 from dataclasses import dataclass
+from pathlib import Path
 
 from phi_scan.models import ScanFinding
 from phi_scan.plugin_api import (
@@ -37,18 +38,27 @@ _SUPPRESSOR_WARNING_LOG: str = "Suppressor %r at %s:%d — %s"
 _SUPPRESSOR_SUMMARY_LOG: str = (
     "Suppressor %r produced %d warnings during this scan (first %d shown above)"
 )
-_EVALUATE_EXCEPTION_ERROR: str = "evaluate() raised {error_type}: {error_message}"
+_EVALUATE_EXCEPTION_ERROR: str = "evaluate() raised {error_type}"
 _INVALID_RETURN_TYPE_ERROR: str = "returned {actual_type} instead of SuppressDecision"
 
 
 @dataclass(frozen=True)
-class _SuppressorInvocation:
-    """One suppressor's invocation against one host finding."""
+class _SuppressorCallContext:
+    """Inputs needed to invoke one suppressor on one host finding.
+
+    Carries only the fields the isolation boundary consumes — the
+    plugin-stable view plus the source line and the (file_path,
+    line_number) logging location. The full host ``ScanFinding`` is
+    deliberately not stored here so the boundary cannot read host
+    fields (``value_hash``, ``code_context``) that the Plugin API
+    withholds from suppressors.
+    """
 
     loaded_suppressor: LoadedSuppressor
     finding_view: SuppressorFindingView
     line_text: str
-    finding: ScanFinding
+    file_path: Path
+    line_number: int
 
 
 class _SuppressorWarningBudget:
@@ -56,27 +66,31 @@ class _SuppressorWarningBudget:
 
     def __init__(self, limit: int = _MAX_WARNINGS_PER_SUPPRESSOR) -> None:
         self._limit = limit
-        self._counts: Counter[str] = Counter()
+        self._warning_counts_by_suppressor_name: Counter[str] = Counter()
 
     def claim_suppressor_warning_slot(self, suppressor_name: str) -> bool:
-        self._counts[suppressor_name] += 1
-        return self._counts[suppressor_name] <= self._limit
+        self._warning_counts_by_suppressor_name[suppressor_name] += 1
+        return self._warning_counts_by_suppressor_name[suppressor_name] <= self._limit
 
     def log_suppressor_warning(
-        self, suppressor_name: str, finding: ScanFinding, message: str
+        self,
+        suppressor_name: str,
+        file_path: Path,
+        line_number: int,
+        message: str,
     ) -> None:
         if not self.claim_suppressor_warning_slot(suppressor_name):
             return
         _LOG.warning(
             _SUPPRESSOR_WARNING_LOG,
             suppressor_name,
-            finding.file_path,
-            finding.line_number,
+            file_path,
+            line_number,
             message,
         )
 
     def emit_suppressor_warning_summary(self) -> None:
-        for suppressor_name, total_count in self._counts.items():
+        for suppressor_name, total_count in self._warning_counts_by_suppressor_name.items():
             if total_count > self._limit:
                 _LOG.warning(
                     _SUPPRESSOR_SUMMARY_LOG,
@@ -140,13 +154,14 @@ def _is_finding_suppressed(
     finding_view = _build_finding_view(finding)
     line_text = _resolve_line_text(finding, file_lines)
     for loaded_suppressor in loaded_suppressors:
-        invocation = _SuppressorInvocation(
+        call_context = _SuppressorCallContext(
             loaded_suppressor=loaded_suppressor,
             finding_view=finding_view,
             line_text=line_text,
-            finding=finding,
+            file_path=finding.file_path,
+            line_number=finding.line_number,
         )
-        decision = _evaluate_suppressor_with_isolation(invocation, warning_budget)
+        decision = _evaluate_suppressor_with_isolation(call_context, warning_budget)
         if decision is not None and decision.is_suppressed:
             return True
     return False
@@ -170,7 +185,7 @@ def _resolve_line_text(finding: ScanFinding, file_lines: list[str]) -> str:
 
 
 def _evaluate_suppressor_with_isolation(
-    invocation: _SuppressorInvocation,
+    call_context: _SuppressorCallContext,
     warning_budget: _SuppressorWarningBudget,
 ) -> SuppressDecision | None:
     """Call ``suppressor.evaluate`` under exception isolation.
@@ -185,24 +200,30 @@ def _evaluate_suppressor_with_isolation(
     ``BaseException`` (``KeyboardInterrupt``, ``SystemExit``) is
     deliberately not caught. A non-``SuppressDecision`` return value
     is treated the same way.
+
+    Only the exception's type name is logged. The ``str(exception)``
+    message is deliberately dropped because a third-party suppressor
+    receives the source line directly and may embed line content in
+    its exception message; logging that text would risk exfiltrating
+    raw PHI to the log stream. Same rationale as
+    ``_instantiate_suppressor`` in ``plugin_loader``.
     """
-    suppressor: BaseSuppressor = invocation.loaded_suppressor.suppressor
+    suppressor: BaseSuppressor = call_context.loaded_suppressor.suppressor
     try:
-        decision = suppressor.evaluate(invocation.finding_view, invocation.line_text)
+        decision = suppressor.evaluate(call_context.finding_view, call_context.line_text)
     except Exception as exception:  # noqa: BLE001 — suppressor isolation boundary (see docstring)
         warning_budget.log_suppressor_warning(
             suppressor.name,
-            invocation.finding,
-            _EVALUATE_EXCEPTION_ERROR.format(
-                error_type=type(exception).__name__,
-                error_message=str(exception),
-            ),
+            call_context.file_path,
+            call_context.line_number,
+            _EVALUATE_EXCEPTION_ERROR.format(error_type=type(exception).__name__),
         )
         return None
     if not isinstance(decision, SuppressDecision):
         warning_budget.log_suppressor_warning(
             suppressor.name,
-            invocation.finding,
+            call_context.file_path,
+            call_context.line_number,
             _INVALID_RETURN_TYPE_ERROR.format(actual_type=type(decision).__name__),
         )
         return None

--- a/phi_scan/suppressor_runtime.py
+++ b/phi_scan/suppressor_runtime.py
@@ -1,0 +1,209 @@
+"""Suppressor runtime — execute loaded suppressor plugins against host findings.
+
+Integrates the Plugin API v1.1 ``BaseSuppressor`` hook with the scan
+pipeline. Each loaded suppressor is consulted once per surviving
+finding in deterministic ``(distribution_name, entry_point_name)``
+order. The first ``SuppressDecision`` with ``is_suppressed=True``
+drops the finding; later suppressors for the same finding are not
+consulted.
+
+Exception isolation mirrors ``phi_scan.plugin_runtime`` exactly: a
+broad ``except Exception`` at one designated boundary per suppressor
+invocation, rate-limited warning emission per suppressor, and a final
+summary line when the budget was exceeded.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from dataclasses import dataclass
+
+from phi_scan.models import ScanFinding
+from phi_scan.plugin_api import (
+    BaseSuppressor,
+    SuppressDecision,
+    SuppressorFindingView,
+)
+from phi_scan.plugin_loader import LoadedSuppressor, PluginRegistry
+
+__all__ = ["apply_suppressor_pass"]
+
+_LOG: logging.Logger = logging.getLogger(__name__)
+
+_MAX_WARNINGS_PER_SUPPRESSOR: int = 5
+
+_SUPPRESSOR_WARNING_LOG: str = "Suppressor %r at %s:%d — %s"
+_SUPPRESSOR_SUMMARY_LOG: str = (
+    "Suppressor %r produced %d warnings during this scan (first %d shown above)"
+)
+_EVALUATE_EXCEPTION_ERROR: str = "evaluate() raised {error_type}: {error_message}"
+_INVALID_RETURN_TYPE_ERROR: str = "returned {actual_type} instead of SuppressDecision"
+
+
+@dataclass(frozen=True)
+class _SuppressorInvocation:
+    """One suppressor's invocation against one host finding."""
+
+    loaded_suppressor: LoadedSuppressor
+    finding_view: SuppressorFindingView
+    line_text: str
+    finding: ScanFinding
+
+
+class _SuppressorWarningBudget:
+    """Tracks warning emissions per suppressor for the duration of one scan."""
+
+    def __init__(self, limit: int = _MAX_WARNINGS_PER_SUPPRESSOR) -> None:
+        self._limit = limit
+        self._counts: Counter[str] = Counter()
+
+    def claim_suppressor_warning_slot(self, suppressor_name: str) -> bool:
+        self._counts[suppressor_name] += 1
+        return self._counts[suppressor_name] <= self._limit
+
+    def log_suppressor_warning(
+        self, suppressor_name: str, finding: ScanFinding, message: str
+    ) -> None:
+        if not self.claim_suppressor_warning_slot(suppressor_name):
+            return
+        _LOG.warning(
+            _SUPPRESSOR_WARNING_LOG,
+            suppressor_name,
+            finding.file_path,
+            finding.line_number,
+            message,
+        )
+
+    def emit_suppressor_warning_summary(self) -> None:
+        for suppressor_name, total_count in self._counts.items():
+            if total_count > self._limit:
+                _LOG.warning(
+                    _SUPPRESSOR_SUMMARY_LOG,
+                    suppressor_name,
+                    total_count,
+                    self._limit,
+                )
+
+
+def apply_suppressor_pass(
+    findings: list[ScanFinding],
+    registry: PluginRegistry,
+    file_content: str,
+) -> list[ScanFinding]:
+    """Filter ``findings`` through every loaded suppressor in deterministic order.
+
+    Args:
+        findings: Host findings that have already passed inline
+            ``phi-scan:ignore`` suppression. May be empty.
+        registry: The scan-scoped plugin registry. Only
+            ``registry.loaded_suppressors`` is consulted.
+        file_content: Decoded text of the scanned file; used to
+            reconstruct the line text passed to ``evaluate``.
+
+    Returns:
+        The subset of ``findings`` that no suppressor chose to drop,
+        in input order. Empty list when every finding was suppressed
+        or when ``findings`` was empty.
+    """
+    if not registry.loaded_suppressors or not findings:
+        return findings
+    file_lines = file_content.splitlines()
+    warning_budget = _SuppressorWarningBudget()
+    retained_findings = _retain_unsuppressed_findings(
+        findings, registry.loaded_suppressors, file_lines, warning_budget
+    )
+    warning_budget.emit_suppressor_warning_summary()
+    return retained_findings
+
+
+def _retain_unsuppressed_findings(
+    findings: list[ScanFinding],
+    loaded_suppressors: tuple[LoadedSuppressor, ...],
+    file_lines: list[str],
+    warning_budget: _SuppressorWarningBudget,
+) -> list[ScanFinding]:
+    retained_findings: list[ScanFinding] = []
+    for finding in findings:
+        if _is_finding_suppressed(finding, loaded_suppressors, file_lines, warning_budget):
+            continue
+        retained_findings.append(finding)
+    return retained_findings
+
+
+def _is_finding_suppressed(
+    finding: ScanFinding,
+    loaded_suppressors: tuple[LoadedSuppressor, ...],
+    file_lines: list[str],
+    warning_budget: _SuppressorWarningBudget,
+) -> bool:
+    finding_view = _build_finding_view(finding)
+    line_text = _resolve_line_text(finding, file_lines)
+    for loaded_suppressor in loaded_suppressors:
+        invocation = _SuppressorInvocation(
+            loaded_suppressor=loaded_suppressor,
+            finding_view=finding_view,
+            line_text=line_text,
+            finding=finding,
+        )
+        decision = _evaluate_suppressor_with_isolation(invocation, warning_budget)
+        if decision is not None and decision.is_suppressed:
+            return True
+    return False
+
+
+def _build_finding_view(finding: ScanFinding) -> SuppressorFindingView:
+    return SuppressorFindingView(
+        entity_type=finding.entity_type,
+        confidence=finding.confidence,
+        line_number=finding.line_number,
+        file_path=finding.file_path,
+        file_extension=finding.file_path.suffix.lower(),
+    )
+
+
+def _resolve_line_text(finding: ScanFinding, file_lines: list[str]) -> str:
+    line_index = finding.line_number - 1
+    if 0 <= line_index < len(file_lines):
+        return file_lines[line_index]
+    return ""
+
+
+def _evaluate_suppressor_with_isolation(
+    invocation: _SuppressorInvocation,
+    warning_budget: _SuppressorWarningBudget,
+) -> SuppressDecision | None:
+    """Call ``suppressor.evaluate`` under exception isolation.
+
+    This is the single designated suppressor-plugin exception boundary
+    (mirroring ``plugin_runtime._invoke_detect_with_isolation``). Any
+    exception raised by ``evaluate`` is caught, logged through the
+    rate-limited warning budget, and the finding is treated as not
+    suppressed by this plugin — other suppressors and the surrounding
+    scan proceed unaffected. The broad ``except Exception`` is
+    required by the suppressor-plugin failure-semantics contract;
+    ``BaseException`` (``KeyboardInterrupt``, ``SystemExit``) is
+    deliberately not caught. A non-``SuppressDecision`` return value
+    is treated the same way.
+    """
+    suppressor: BaseSuppressor = invocation.loaded_suppressor.suppressor
+    try:
+        decision = suppressor.evaluate(invocation.finding_view, invocation.line_text)
+    except Exception as exception:  # noqa: BLE001 — suppressor isolation boundary (see docstring)
+        warning_budget.log_suppressor_warning(
+            suppressor.name,
+            invocation.finding,
+            _EVALUATE_EXCEPTION_ERROR.format(
+                error_type=type(exception).__name__,
+                error_message=str(exception),
+            ),
+        )
+        return None
+    if not isinstance(decision, SuppressDecision):
+        warning_budget.log_suppressor_warning(
+            suppressor.name,
+            invocation.finding,
+            _INVALID_RETURN_TYPE_ERROR.format(actual_type=type(decision).__name__),
+        )
+        return None
+    return decision

--- a/tests/test_cli_plugins.py
+++ b/tests/test_cli_plugins.py
@@ -15,8 +15,20 @@ from typer.testing import CliRunner  # phi-scan:ignore
 
 from phi_scan.cli import app
 from phi_scan.constants import EXIT_CODE_CLEAN
-from phi_scan.plugin_api import PLUGIN_API_VERSION, BaseRecognizer, ScanContext, ScanFinding
-from phi_scan.plugin_loader import PLUGIN_ENTRY_POINT_GROUP
+from phi_scan.plugin_api import (
+    PLUGIN_API_VERSION,
+    SUPPRESSOR_API_VERSION,
+    BaseRecognizer,
+    BaseSuppressor,
+    ScanContext,
+    ScanFinding,
+    SuppressDecision,
+    SuppressorFindingView,
+)
+from phi_scan.plugin_loader import (
+    PLUGIN_ENTRY_POINT_GROUP,
+    SUPPRESSOR_ENTRY_POINT_GROUP,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -43,6 +55,13 @@ _STATUS_LOADED_LABEL: str = "loaded"
 _STATUS_SKIPPED: str = "skipped-invalid"
 
 _JSON_KEY_PLUGINS: str = "plugins"
+_JSON_KEY_SUPPRESSORS: str = "suppressors"
+
+_SUPPRESSOR_NAME: str = "test_suppressor"
+_SUPPRESSOR_DISTRIBUTION: str = "phi-scan-ext-suppressor"
+_SUPPRESSOR_ENTRY_POINT_NAME: str = "test_suppressor_entry"
+_INVALID_SUPPRESSOR_NAME: str = "invalid_suppressor_entry"
+_INVALID_SUPPRESSOR_DISTRIBUTION: str = "phi-scan-ext-invalid-suppressor"
 _JSON_KEY_NAME: str = "name"
 _JSON_KEY_VERSION: str = "version"
 _JSON_KEY_API_VERSION: str = "api_version"
@@ -133,6 +152,24 @@ class _BetaRecognizer(BaseRecognizer):
         return []
 
 
+class _TestSuppressor(BaseSuppressor):
+    name = _SUPPRESSOR_NAME
+    plugin_api_version = SUPPRESSOR_API_VERSION
+
+    def evaluate(self, finding: SuppressorFindingView, line: str) -> SuppressDecision:
+        del finding, line
+        return SuppressDecision(is_suppressed=False, reason="noop")
+
+
+class _MismatchedVersionSuppressor(BaseSuppressor):
+    name = "mismatched_suppressor"
+    plugin_api_version = "9.9"
+
+    def evaluate(self, finding: SuppressorFindingView, line: str) -> SuppressDecision:
+        del finding, line
+        return SuppressDecision(is_suppressed=False, reason="noop")
+
+
 class _MismatchedVersionRecognizer(BaseRecognizer):
     name = "mismatched_version"
     entity_types = ["MISMATCHED_TYPE"]
@@ -151,11 +188,16 @@ class _MismatchedVersionRecognizer(BaseRecognizer):
 def _patch_entry_point_discovery(
     monkeypatch: pytest.MonkeyPatch,
     entry_point_stubs: list[_EntryPointStub],
+    suppressor_entry_point_stubs: list[_EntryPointStub] | None = None,
 ) -> None:
+    resolved_suppressor_stubs = suppressor_entry_point_stubs or []
+
     def _return_stub_entry_points(*, group: str) -> list[_EntryPointStub]:
-        if group != PLUGIN_ENTRY_POINT_GROUP:
-            return []
-        return list(entry_point_stubs)
+        if group == PLUGIN_ENTRY_POINT_GROUP:
+            return list(entry_point_stubs)
+        if group == SUPPRESSOR_ENTRY_POINT_GROUP:
+            return list(resolved_suppressor_stubs)
+        return []
 
     monkeypatch.setattr(_ENTRY_POINTS_PATCH_TARGET, _return_stub_entry_points)
 
@@ -165,8 +207,9 @@ def _invoke_plugins_list(
     entry_point_stubs: list[_EntryPointStub],
     *,
     is_json: bool = False,
+    suppressor_entry_point_stubs: list[_EntryPointStub] | None = None,
 ) -> str:
-    _patch_entry_point_discovery(monkeypatch, entry_point_stubs)
+    _patch_entry_point_discovery(monkeypatch, entry_point_stubs, suppressor_entry_point_stubs)
     monkeypatch.setenv("COLUMNS", _WIDE_TERMINAL_COLUMNS)
     cli_arguments = ["plugins", "list"]
     if is_json:
@@ -398,3 +441,79 @@ class TestCommandIntegration:
         runner = CliRunner()
         invocation_result = runner.invoke(app, ["plugins", "--help"])
         assert "list" in invocation_result.output
+
+
+# ---------------------------------------------------------------------------
+# Tests — suppressor plugins in `plugins list`
+# ---------------------------------------------------------------------------
+
+
+class TestSuppressorPluginsListed:
+    def test_no_suppressors_shows_empty_message(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        output = _invoke_plugins_list(monkeypatch, [])
+        assert "No suppressor plugins discovered" in output
+
+    def test_loaded_suppressor_name_appears_in_output(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        suppressor_stubs = [
+            _EntryPointStub(
+                _SUPPRESSOR_ENTRY_POINT_NAME, _TestSuppressor, _SUPPRESSOR_DISTRIBUTION
+            ),
+        ]
+        output = _invoke_plugins_list(
+            monkeypatch, [], suppressor_entry_point_stubs=suppressor_stubs
+        )
+        assert _SUPPRESSOR_NAME in output
+
+    def test_loaded_suppressor_shows_loaded_status(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        suppressor_stubs = [
+            _EntryPointStub(
+                _SUPPRESSOR_ENTRY_POINT_NAME, _TestSuppressor, _SUPPRESSOR_DISTRIBUTION
+            ),
+        ]
+        output = _invoke_plugins_list(
+            monkeypatch, [], suppressor_entry_point_stubs=suppressor_stubs
+        )
+        assert _STATUS_LOADED_LABEL in output
+
+    def test_invalid_suppressor_shows_skipped_status(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        suppressor_stubs = [
+            _EntryPointStub(
+                _INVALID_SUPPRESSOR_NAME,
+                _MismatchedVersionSuppressor,
+                _INVALID_SUPPRESSOR_DISTRIBUTION,
+            ),
+        ]
+        output = _invoke_plugins_list(
+            monkeypatch, [], suppressor_entry_point_stubs=suppressor_stubs
+        )
+        assert _STATUS_SKIPPED in output
+
+
+class TestSuppressorJsonOutput:
+    def test_json_has_suppressors_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        output = _invoke_plugins_list(monkeypatch, [], is_json=True)
+        parsed_output = json.loads(output)
+        assert _JSON_KEY_SUPPRESSORS in parsed_output
+
+    def test_empty_suppressors_json_is_empty_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        output = _invoke_plugins_list(monkeypatch, [], is_json=True)
+        parsed_output = json.loads(output)
+        assert parsed_output[_JSON_KEY_SUPPRESSORS] == []
+
+    def test_loaded_suppressor_json_has_metadata(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        suppressor_stubs = [
+            _EntryPointStub(
+                _SUPPRESSOR_ENTRY_POINT_NAME, _TestSuppressor, _SUPPRESSOR_DISTRIBUTION
+            ),
+        ]
+        output = _invoke_plugins_list(
+            monkeypatch, [], is_json=True, suppressor_entry_point_stubs=suppressor_stubs
+        )
+        parsed_output = json.loads(output)
+        suppressor_record = parsed_output[_JSON_KEY_SUPPRESSORS][0]
+        assert suppressor_record[_JSON_KEY_NAME] == _SUPPRESSOR_NAME
+        assert suppressor_record[_JSON_KEY_API_VERSION] == SUPPRESSOR_API_VERSION
+        assert suppressor_record[_JSON_KEY_STATUS] == _STATUS_LOADED_LABEL
+        assert suppressor_record[_JSON_KEY_DISTRIBUTION] == _SUPPRESSOR_DISTRIBUTION

--- a/tests/test_suppressor_runtime.py
+++ b/tests/test_suppressor_runtime.py
@@ -220,7 +220,19 @@ def test_raising_suppressor_does_not_abort_scan(caplog: pytest.LogCaptureFixture
     with caplog.at_level(logging.WARNING, logger="phi_scan.suppressor_runtime"):
         result = apply_suppressor_pass([_build_finding()], registry, _SAMPLE_LINE)
     assert len(result) == 1
-    assert any("simulated suppressor failure" in record.message for record in caplog.records)
+    assert any("RuntimeError" in record.message for record in caplog.records)
+
+
+def test_raising_suppressor_log_does_not_leak_exception_message(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Exception .args content must never reach the log stream (PHI exfiltration risk)."""
+    registry = _build_registry(_RaisingSuppressor())
+    with caplog.at_level(logging.WARNING, logger="phi_scan.suppressor_runtime"):
+        apply_suppressor_pass([_build_finding()], registry, _SAMPLE_LINE)
+    assert not any(
+        "simulated suppressor failure" in record.getMessage() for record in caplog.records
+    )
 
 
 def test_raising_suppressor_does_not_block_later_suppressor_that_suppresses(
@@ -248,9 +260,7 @@ def test_warnings_are_rate_limited_per_suppressor(caplog: pytest.LogCaptureFixtu
     findings = [_build_finding(line_number=i + 1) for i in range(_RATE_LIMIT_TEST_FINDING_COUNT)]
     with caplog.at_level(logging.WARNING, logger="phi_scan.suppressor_runtime"):
         apply_suppressor_pass(findings, registry, _SAMPLE_LINE)
-    per_finding_records = [
-        record for record in caplog.records if "simulated suppressor failure" in record.message
-    ]
+    per_finding_records = [record for record in caplog.records if "RuntimeError" in record.message]
     summary_records = [
         record
         for record in caplog.records

--- a/tests/test_suppressor_runtime.py
+++ b/tests/test_suppressor_runtime.py
@@ -1,0 +1,361 @@
+"""Runtime execution tests for the Plugin API v1.1 suppressor hook.
+
+Covers the suppressor pipeline stage: suppressors are consulted in
+deterministic order, the first ``is_suppressed=True`` wins, exceptions
+in ``evaluate`` are isolated per finding, malformed return values are
+dropped with a warning, and the stage runs after inline suppression
+but before the confidence/severity filters.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from phi_scan.constants import DetectionLayer, PhiCategory, SeverityLevel
+from phi_scan.models import ScanConfig, ScanFinding
+from phi_scan.plugin_api import (
+    PLUGIN_API_VERSION,
+    SUPPRESSOR_API_VERSION,
+    BaseRecognizer,
+    BaseSuppressor,
+    ScanContext,
+    SuppressDecision,
+    SuppressorFindingView,
+)
+from phi_scan.plugin_api import ScanFinding as PluginScanFinding
+from phi_scan.plugin_loader import LoadedPlugin, LoadedSuppressor, PluginRegistry
+from phi_scan.scanner import _load_cached_plugin_registry, execute_scan
+from phi_scan.suppressor_runtime import (
+    _MAX_WARNINGS_PER_SUPPRESSOR,
+    apply_suppressor_pass,
+)
+
+_SAMPLE_LINE: str = "employee_id = EMP-123456"
+_SAMPLE_FILE_NAME: str = "source.py"
+_EMP_ENTITY_TYPE: str = "ACME_EMPLOYEE_ID"
+_EMP_RECOGNIZER_NAME: str = "acme_employee_id"
+_EMP_CONFIDENCE: float = 0.9
+_VALUE_HASH_STUB: str = "0" * 64
+_REDACTED_CONTEXT_STUB: str = "employee_id = [REDACTED]"
+_REMEDIATION_HINT_STUB: str = "Review the value."
+_RATE_LIMIT_TEST_FINDING_COUNT: int = 20
+_ZERO_CONFIDENCE: float = 0.0
+
+
+def _build_finding(line_number: int = 1, entity_type: str = _EMP_ENTITY_TYPE) -> ScanFinding:
+    return ScanFinding(
+        file_path=Path(_SAMPLE_FILE_NAME),
+        line_number=line_number,
+        entity_type=entity_type,
+        hipaa_category=PhiCategory.UNIQUE_ID,
+        confidence=_EMP_CONFIDENCE,
+        detection_layer=DetectionLayer.PLUGIN,
+        value_hash=_VALUE_HASH_STUB,
+        severity=SeverityLevel.MEDIUM,
+        code_context=_REDACTED_CONTEXT_STUB,
+        remediation_hint=_REMEDIATION_HINT_STUB,
+    )
+
+
+class _SuppressAllSuppressor(BaseSuppressor):
+    name = "suppress_all"
+    plugin_api_version = SUPPRESSOR_API_VERSION
+
+    def evaluate(self, finding: SuppressorFindingView, line: str) -> SuppressDecision:
+        del finding, line
+        return SuppressDecision(is_suppressed=True, reason="suppressed by test")
+
+
+class _PassThroughSuppressor(BaseSuppressor):
+    name = "pass_through"
+    plugin_api_version = SUPPRESSOR_API_VERSION
+
+    def evaluate(self, finding: SuppressorFindingView, line: str) -> SuppressDecision:
+        del finding, line
+        return SuppressDecision(is_suppressed=False, reason="no opinion")
+
+
+class _RaisingSuppressor(BaseSuppressor):
+    name = "raising_suppressor"
+    plugin_api_version = SUPPRESSOR_API_VERSION
+
+    def evaluate(self, finding: SuppressorFindingView, line: str) -> SuppressDecision:
+        del finding, line
+        raise RuntimeError("simulated suppressor failure")
+
+
+class _MalformedReturnSuppressor(BaseSuppressor):
+    name = "malformed_return"
+    plugin_api_version = SUPPRESSOR_API_VERSION
+
+    def evaluate(self, finding: SuppressorFindingView, line: str) -> SuppressDecision:
+        del finding, line
+        return "not a decision"  # type: ignore[return-value]
+
+
+class _OrderRecordingSuppressor(BaseSuppressor):
+    """Records evaluation order in a class-level list for determinism tests."""
+
+    name = "order_recorder"
+    plugin_api_version = SUPPRESSOR_API_VERSION
+    evaluation_log: list[str] = []
+
+    def __init__(self, tag: str, is_suppressed: bool = False) -> None:
+        self._tag = tag
+        self._is_suppressed = is_suppressed
+
+    def evaluate(self, finding: SuppressorFindingView, line: str) -> SuppressDecision:
+        del finding, line
+        self.evaluation_log.append(self._tag)
+        return SuppressDecision(is_suppressed=self._is_suppressed, reason=self._tag)
+
+
+def _build_registry(*suppressors: BaseSuppressor) -> PluginRegistry:
+    loaded_suppressors = tuple(
+        LoadedSuppressor(
+            entry_point_name=suppressor.name,
+            distribution_name=f"{suppressor.name}-dist",
+            suppressor=suppressor,
+        )
+        for suppressor in suppressors
+    )
+    return PluginRegistry(loaded_suppressors=loaded_suppressors)
+
+
+# ---------------------------------------------------------------------------
+# Type-signature sanity
+# ---------------------------------------------------------------------------
+
+
+def test_suppress_decision_is_frozen_dataclass() -> None:
+    decision = SuppressDecision(is_suppressed=True, reason="why")
+    with pytest.raises(Exception):
+        decision.reason = "mutated"  # type: ignore[misc]
+
+
+def test_finding_view_exposes_plugin_stable_fields() -> None:
+    view = SuppressorFindingView(
+        entity_type="EMAIL_ADDRESS",
+        confidence=0.8,
+        line_number=3,
+        file_path=Path("a.py"),
+        file_extension=".py",
+    )
+    assert view.entity_type == "EMAIL_ADDRESS"
+    assert view.confidence == 0.8
+
+
+def test_base_suppressor_defaults_to_suppressor_api_version() -> None:
+    assert _SuppressAllSuppressor.plugin_api_version == SUPPRESSOR_API_VERSION
+
+
+# ---------------------------------------------------------------------------
+# apply_suppressor_pass unit behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_apply_suppressor_pass_returns_input_when_no_suppressors_loaded() -> None:
+    findings = [_build_finding()]
+    result = apply_suppressor_pass(findings, PluginRegistry(), _SAMPLE_LINE)
+    assert result == findings
+
+
+def test_apply_suppressor_pass_drops_finding_when_any_suppressor_says_suppress() -> None:
+    registry = _build_registry(_SuppressAllSuppressor())
+    result = apply_suppressor_pass([_build_finding()], registry, _SAMPLE_LINE)
+    assert result == []
+
+
+def test_apply_suppressor_pass_retains_finding_when_all_suppressors_pass_through() -> None:
+    registry = _build_registry(_PassThroughSuppressor())
+    findings = [_build_finding()]
+    result = apply_suppressor_pass(findings, registry, _SAMPLE_LINE)
+    assert result == findings
+
+
+def test_apply_suppressor_pass_first_suppressor_decision_wins() -> None:
+    _OrderRecordingSuppressor.evaluation_log = []
+    first = _OrderRecordingSuppressor(tag="first", is_suppressed=True)
+    second = _OrderRecordingSuppressor(tag="second", is_suppressed=False)
+    registry = _build_registry(first, second)
+    apply_suppressor_pass([_build_finding()], registry, _SAMPLE_LINE)
+    assert _OrderRecordingSuppressor.evaluation_log == ["first"]
+
+
+def test_apply_suppressor_pass_consults_all_when_none_suppress() -> None:
+    _OrderRecordingSuppressor.evaluation_log = []
+    first = _OrderRecordingSuppressor(tag="first", is_suppressed=False)
+    second = _OrderRecordingSuppressor(tag="second", is_suppressed=False)
+    registry = _build_registry(first, second)
+    apply_suppressor_pass([_build_finding()], registry, _SAMPLE_LINE)
+    assert _OrderRecordingSuppressor.evaluation_log == ["first", "second"]
+
+
+def test_apply_suppressor_pass_preserves_registry_order_across_findings() -> None:
+    _OrderRecordingSuppressor.evaluation_log = []
+    first = _OrderRecordingSuppressor(tag="a", is_suppressed=False)
+    second = _OrderRecordingSuppressor(tag="b", is_suppressed=False)
+    registry = _build_registry(first, second)
+    apply_suppressor_pass(
+        [_build_finding(line_number=1), _build_finding(line_number=2)],
+        registry,
+        _SAMPLE_LINE,
+    )
+    assert _OrderRecordingSuppressor.evaluation_log == ["a", "b", "a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# Isolation semantics
+# ---------------------------------------------------------------------------
+
+
+def test_raising_suppressor_does_not_abort_scan(caplog: pytest.LogCaptureFixture) -> None:
+    registry = _build_registry(_RaisingSuppressor())
+    with caplog.at_level(logging.WARNING, logger="phi_scan.suppressor_runtime"):
+        result = apply_suppressor_pass([_build_finding()], registry, _SAMPLE_LINE)
+    assert len(result) == 1
+    assert any("simulated suppressor failure" in record.message for record in caplog.records)
+
+
+def test_raising_suppressor_does_not_block_later_suppressor_that_suppresses(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    registry = _build_registry(_RaisingSuppressor(), _SuppressAllSuppressor())
+    with caplog.at_level(logging.WARNING, logger="phi_scan.suppressor_runtime"):
+        result = apply_suppressor_pass([_build_finding()], registry, _SAMPLE_LINE)
+    assert result == []
+
+
+def test_malformed_return_value_is_treated_as_pass_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    registry = _build_registry(_MalformedReturnSuppressor())
+    findings = [_build_finding()]
+    with caplog.at_level(logging.WARNING, logger="phi_scan.suppressor_runtime"):
+        result = apply_suppressor_pass(findings, registry, _SAMPLE_LINE)
+    assert result == findings
+    assert any("instead of SuppressDecision" in record.message for record in caplog.records)
+
+
+def test_warnings_are_rate_limited_per_suppressor(caplog: pytest.LogCaptureFixture) -> None:
+    registry = _build_registry(_RaisingSuppressor())
+    findings = [_build_finding(line_number=i + 1) for i in range(_RATE_LIMIT_TEST_FINDING_COUNT)]
+    with caplog.at_level(logging.WARNING, logger="phi_scan.suppressor_runtime"):
+        apply_suppressor_pass(findings, registry, _SAMPLE_LINE)
+    per_finding_records = [
+        record for record in caplog.records if "simulated suppressor failure" in record.message
+    ]
+    summary_records = [
+        record
+        for record in caplog.records
+        if "produced" in record.message and "warnings" in record.message
+    ]
+    assert len(per_finding_records) == _MAX_WARNINGS_PER_SUPPRESSOR
+    assert len(summary_records) == 1
+
+
+# ---------------------------------------------------------------------------
+# Pipeline integration — confirms position before confidence/severity gates
+# ---------------------------------------------------------------------------
+
+
+class _EmpRecognizer(BaseRecognizer):
+    name = _EMP_RECOGNIZER_NAME
+    entity_types = (_EMP_ENTITY_TYPE,)
+    plugin_api_version = PLUGIN_API_VERSION
+
+    def detect(self, line: str, context: ScanContext) -> list[PluginScanFinding]:
+        del context
+        match = re.search(r"\bEMP-\d{6}\b", line)
+        if match is None:
+            return []
+        return [
+            PluginScanFinding(
+                entity_type=_EMP_ENTITY_TYPE,
+                start_offset=match.start(),
+                end_offset=match.end(),
+                confidence=_EMP_CONFIDENCE,
+            )
+        ]
+
+
+class _DropEmpSuppressor(BaseSuppressor):
+    name = "drop_emp"
+    plugin_api_version = SUPPRESSOR_API_VERSION
+
+    def evaluate(self, finding: SuppressorFindingView, line: str) -> SuppressDecision:
+        del line
+        return SuppressDecision(
+            is_suppressed=finding.entity_type == _EMP_ENTITY_TYPE,
+            reason="drop EMP",
+        )
+
+
+@pytest.fixture(autouse=True)
+def _clear_scan_registry_cache() -> Iterator[None]:
+    _load_cached_plugin_registry.cache_clear()
+    yield
+    _load_cached_plugin_registry.cache_clear()
+
+
+@pytest.fixture
+def sample_file(tmp_path: Path) -> Path:
+    target = tmp_path / _SAMPLE_FILE_NAME
+    target.write_text(_SAMPLE_LINE + "\n", encoding="utf-8")
+    return target
+
+
+@pytest.fixture
+def permissive_scan_config() -> ScanConfig:
+    return ScanConfig(confidence_threshold=_ZERO_CONFIDENCE, severity_threshold=SeverityLevel.INFO)
+
+
+def test_suppressor_runs_before_confidence_filter(
+    sample_file: Path, permissive_scan_config: ScanConfig
+) -> None:
+    """A finding dropped by a suppressor never reaches confidence/severity gates."""
+    registry = PluginRegistry(
+        loaded=(
+            LoadedPlugin(
+                entry_point_name=_EMP_RECOGNIZER_NAME,
+                distribution_name="acme-dist",
+                recognizer=_EmpRecognizer(),
+            ),
+        ),
+        loaded_suppressors=(
+            LoadedSuppressor(
+                entry_point_name="drop_emp",
+                distribution_name="drop-dist",
+                suppressor=_DropEmpSuppressor(),
+            ),
+        ),
+    )
+    with patch("phi_scan.scanner.load_plugin_registry", return_value=registry):
+        result = execute_scan([sample_file], permissive_scan_config)
+    plugin_findings = [f for f in result.findings if f.detection_layer == DetectionLayer.PLUGIN]
+    assert plugin_findings == []
+
+
+def test_suppressor_pipeline_is_no_op_without_suppressors(
+    sample_file: Path, permissive_scan_config: ScanConfig
+) -> None:
+    """Existing v1.0 recognizer-only behaviour is preserved."""
+    registry = PluginRegistry(
+        loaded=(
+            LoadedPlugin(
+                entry_point_name=_EMP_RECOGNIZER_NAME,
+                distribution_name="acme-dist",
+                recognizer=_EmpRecognizer(),
+            ),
+        ),
+    )
+    with patch("phi_scan.scanner.load_plugin_registry", return_value=registry):
+        result = execute_scan([sample_file], permissive_scan_config)
+    plugin_findings = [f for f in result.findings if f.detection_layer == DetectionLayer.PLUGIN]
+    assert len(plugin_findings) == 1


### PR DESCRIPTION
## Summary

- Ships the Plugin API v1.1 suppressor hook: `BaseSuppressor.evaluate(finding, line) -> SuppressDecision`, entry-point group `phi_scan.suppressors`, deterministic `(distribution_name, entry_point_name)` ordering, first-`is_suppressed=True`-wins semantics.
- Inserts the suppressor stage in `_apply_post_scan_filters` **after** inline `phi-scan:ignore` suppression and **before** the confidence/severity gates.
- Mirrors the recognizer isolation boundary exactly: single per-invocation `except Exception` + `# noqa: BLE001` + docstring rationale, rate-limited warning budget (5/suppressor + summary), `BaseException` never caught.
- Extends `phi-scan plugins list` to show suppressors in both table and `--json` output (additive `suppressors` top-level key; existing `plugins` contract preserved byte-for-byte).
- New canonical contract doc `docs/plugin-api-v1_1.md`; pointer added to `docs/plugin-api-v1.md`. v1.0 recognizer contract is unchanged.

### Scope (per PR 4 guardrails)

- BaseOutputSink deferred.
- `plugins.suppressors.enabled` config flag deferred — v1.1 loads and runs all discovered suppressors by default.
- No recognizer rewrites; v1.0 recognizer plugins and their loader path are untouched.
- `PluginRegistry` suppressor fields default to `()`, so existing constructor calls continue to work unchanged.

## Test plan

- [x] `uv run ruff check .` — pass
- [x] `uv run ruff format .` — pass
- [x] `uv run mypy phi_scan` — pass (89 files)
- [x] `uv run pytest -q` — 2044 passed, 3 skipped, coverage 91.31% (`phi_scan/suppressor_runtime.py` and `phi_scan/plugin_api.py` at 100%)
- [x] New tests: 14 in `tests/test_suppressor_runtime.py` (type sanity, ordering, first-decision-wins, isolation, malformed return, rate-limit, pipeline position via `execute_scan`) + 7 in `tests/test_cli_plugins.py` (suppressor table, JSON key, metadata).
- [x] Non-regression: all pre-existing recognizer and CLI plugins tests green.