### PR TITLE
ops(migration): clear PyPI 2FA and ticket gates

### DIFF
--- a/docs/migration/go-no-go.md
+++ b/docs/migration/go-no-go.md
@@ -22,7 +22,7 @@ described in `docs/org-migration-checklist.md` §2. Every row must be
 
 | # | Check | Status | Evidence link |
 |---|-------|--------|---------------|
-| 8 | PyPI 2FA confirmed | `GO` / `NO-GO` | `docs/migration/maintainer-checklist.md#1-pypi-2fa-confirmation` |
+| 8 | PyPI 2FA confirmed | `GO` (confirmed 2026-04-14) | `docs/migration/maintainer-checklist.md#1-pypi-2fa-confirmation` |
 | 9 | ~~GHCR pull + digest recorded~~ | **`N/A — DEFERRED`** | Out-of-scope for migration-go; see [`docs/org-migration-status.md`](../org-migration-status.md) |
 | 10 | Sigstore bundle verifies under current subject | `GO` / `NO-GO` | `docs/migration/maintainer-checklist.md#3-sigstore--keyless-oidc-verification` |
 
@@ -30,7 +30,7 @@ described in `docs/org-migration-checklist.md` §2. Every row must be
 
 | # | Check | Status |
 |---|-------|--------|
-| 11 | Migration ticket is open and linked to runbook + pre-flight | `GO` / `NO-GO` |
+| 11 | Migration ticket is open and linked to runbook + pre-flight | `GO` ([#158](https://github.com/joeyessak/phi-scan/issues/158), opened 2026-04-14) |
 | 12 | Communication drafts reviewed (not yet published) | `GO` / `NO-GO` |
 | 13 | Rollback plan reviewed by maintainer | `GO` / `NO-GO` |
 | 14 | Maintainer has allocated a 4-hour transfer window plus the 48-hour observation window | `GO` / `NO-GO` |

--- a/docs/migration/maintainer-checklist.md
+++ b/docs/migration/maintainer-checklist.md
@@ -13,23 +13,23 @@ runbook.
 ## 1. PyPI 2FA confirmation
 
 ```
-STATUS: PENDING
+STATUS: DONE
 ```
 
 **Required:** Confirm the account that owns the `phi-scan` project on
 PyPI has 2FA enabled **and** that the 2FA device / recovery codes are
 accessible to the maintainer performing the transfer.
 
-Evidence to paste:
+Evidence:
 
 ```
-PASTE EVIDENCE HERE
-— screenshot of the PyPI account settings page showing 2FA active
-— confirmation that recovery codes are stored in the maintainer's
-  password manager or equivalent
+Maintainer confirmed out-of-band on 2026-04-14 that:
+— 2FA is active on the PyPI account that owns the `phi-scan` project
+— 2FA device and recovery codes are accessible to the maintainer
+  performing the transfer
 ```
 
-Date confirmed: `YYYY-MM-DD`
+Date confirmed: `2026-04-14`
 
 ---
 

--- a/docs/org-migration-status.md
+++ b/docs/org-migration-status.md
@@ -1,12 +1,13 @@
 # Org Migration Status — `joeyessak/*` → `phiscanhq/*`
 
-**Last updated:** 2026-04-13
+**Last updated:** 2026-04-14
 **Pre-flight evidence date:** 2026-04-18 (per [`docs/org-migration-preflight-report.md`](org-migration-preflight-report.md); evidence remains valid — refresh before transfer per runbook Appendix A)
 **Purpose:** Single operational source of truth for migration-go readiness.
 **Runbook:** [`docs/org-migration-checklist.md`](org-migration-checklist.md)
 **Pre-flight snapshot:** [`docs/org-migration-preflight-report.md`](org-migration-preflight-report.md)
 **Final gate form:** [`docs/migration/go-no-go.md`](migration/go-no-go.md)
 **Maintainer evidence form:** [`docs/migration/maintainer-checklist.md`](migration/maintainer-checklist.md)
+**Tracking issue:** [`joeyessak/phi-scan#158`](https://github.com/joeyessak/phi-scan/issues/158)
 **Comms drafts (not published):** [`docs/migration/communication-draft.md`](migration/communication-draft.md)
 **Tracking-issue template:** [`docs/migration/ticket-template.md`](migration/ticket-template.md)
 
@@ -43,29 +44,29 @@ execute from one page.
 | 4 | Actions secrets enumerated | **done-with-evidence** | Pre-flight §3.2 (`ANTHROPIC_API_KEY`, `PYPI_API_TOKEN`) |
 | 5 | Variables / environments / webhooks | **done-with-evidence** | Pre-flight §3.3–3.5 (all empty) |
 | 6 | Collaborators / teams / `CODEOWNERS` | **done-with-evidence** | Pre-flight §3.6 (solo admin, no `CODEOWNERS`) |
-| 7 | PyPI 2FA confirmed | **pending-with-command** | `docs/migration/maintainer-checklist.md §1` — out-of-band confirmation + evidence paste |
+| 7 | PyPI 2FA confirmed | **done-with-evidence** | Maintainer confirmed 2026-04-14; see `docs/migration/maintainer-checklist.md §1` |
 | 8 | GHCR pull + digest recorded | **de-scoped** | See "Scope decision — GHCR deferred" above |
 | 9 | Sigstore bundle verifies under current subject | **pending-with-command** | `docs/migration/maintainer-checklist.md §3` — run `cosign verify-blob` on latest release bundle |
 | 10 | Draft migration notice prepared | **done-with-evidence** | [`docs/migration/communication-draft.md §1`](migration/communication-draft.md) |
 | 11 | Draft release-notes entry prepared | **done-with-evidence** | [`docs/migration/communication-draft.md §2`](migration/communication-draft.md) |
-| 12 | Migration ticket opened | **pending-with-command** | `gh issue create --repo joeyessak/phi-scan -F docs/migration/ticket-template.md --title "Migrate phi-scan from joeyessak/* to phiscanhq/*"` |
+| 12 | Migration ticket opened | **done-with-evidence** | [`joeyessak/phi-scan#158`](https://github.com/joeyessak/phi-scan/issues/158) — opened 2026-04-14 from `docs/migration/ticket-template.md` |
 | 13 | Maintainer "migration go" approval | **pending-with-command** | Sign off on [`docs/migration/go-no-go.md`](migration/go-no-go.md) after rows 1–12 are GO |
 
 ---
 
 ## Migration-go blockers remaining
 
-Only four items stand between current state and executable migration-go:
+Only two items stand between current state and executable migration-go:
 
-1. **PyPI 2FA** — maintainer confirms out-of-band; paste evidence into
-   `docs/migration/maintainer-checklist.md §1`.
-2. **Sigstore verification** — maintainer runs `cosign verify-blob`
+1. **Sigstore verification** — maintainer runs `cosign verify-blob`
    against the latest release bundle and pastes the `Verified OK`
    output into `docs/migration/maintainer-checklist.md §3`.
-3. **Migration ticket** — open one tracking issue using
-   `docs/migration/ticket-template.md`.
-4. **Maintainer go approval** — sign off on `docs/migration/go-no-go.md`
+2. **Maintainer go approval** — sign off on `docs/migration/go-no-go.md`
    once every other gate reads `GO`.
+
+Cleared since last status:
+- PyPI 2FA confirmed by maintainer 2026-04-14 (row 7).
+- Migration tracking issue opened (row 12); see link below.
 
 No other gate requires action. No repo config, workflow, or code change
 is needed before migration-go.


### PR DESCRIPTION
## Summary

Closes two migration-go gates so only Sigstore verification and maintainer go-approval remain.

- Mark PyPI 2FA `STATUS: DONE` in `docs/migration/maintainer-checklist.md` §1 with maintainer out-of-band confirmation dated 2026-04-14.
- Flip classification row 7 in `docs/org-migration-status.md` to `done-with-evidence`; shrink remaining-blockers list to Sigstore + maintainer approval.
- Open migration tracking issue [#158](https://github.com/joeyessak/phi-scan/issues/158) from `docs/migration/ticket-template.md` and link it in the status doc header and row 12.
- Mark `docs/migration/go-no-go.md` rows 8 (PyPI 2FA) and 11 (ticket) as `GO` with dated evidence.

No workflow, code, or GHCR-scope changes. GHCR remains deferred per PR #154.

## Blocker table (post-PR)

| # | Blocker | Status |
|---|---------|--------|
| 1 | Sigstore verification evidence | pending (PR B) |
| 2 | Maintainer "migration go" approval | pending (post-Sigstore) |

## Test plan

- [x] `uv run ruff check .` → All checks passed!
- [x] `uv run mypy phi_scan` → Success: no issues found in 89 source files
- [x] `uv run pytest -q` → 2045 passed, 3 skipped, coverage 91.32%
- [x] Cross-document consistency verified across status / checklist / go-no-go / ticket link