### PR TITLE
ops(migration): bind sigstore gate to first S11-signed release (>=v0.6.0)

### DIFF
--- a/docs/migration/go-no-go.md
+++ b/docs/migration/go-no-go.md
@@ -24,7 +24,7 @@ described in `docs/org-migration-checklist.md` §2. Every row must be
 |---|-------|--------|---------------|
 | 8 | PyPI 2FA confirmed | `GO` (confirmed 2026-04-14) | `docs/migration/maintainer-checklist.md#1-pypi-2fa-confirmation` |
 | 9 | ~~GHCR pull + digest recorded~~ | **`N/A — DEFERRED`** | Out-of-scope for migration-go; see [`docs/org-migration-status.md`](../org-migration-status.md) |
-| 10 | Sigstore bundle verifies under current subject | `GO` / `NO-GO` | `docs/migration/maintainer-checklist.md#3-sigstore--keyless-oidc-verification` |
+| 10 | Sigstore bundle verifies under current subject | `PENDING-UNTIL-SIGNED-RELEASE` | Bound to the first S11-signed release (≥ v0.6.0). `v0.5.0` pre-dates S11 signing (PR #123, 2026-04-11) and carries no `.sigstore.json`. See `docs/migration/maintainer-checklist.md#3-sigstore--keyless-oidc-verification`. |
 
 ## Operational gates
 

--- a/docs/migration/maintainer-checklist.md
+++ b/docs/migration/maintainer-checklist.md
@@ -75,15 +75,28 @@ Record the post-transfer digest here after §2.5 of the runbook completes.
 ## 3. Sigstore / keyless OIDC verification
 
 ```
-STATUS: PENDING
+STATUS: PENDING-UNTIL-SIGNED-RELEASE
 ```
 
-**Required:** Verify the latest release's Sigstore bundle against the
-current OIDC subject (`repo:joeyessak/phi-scan:…`) and capture the output.
-This is the pre-transfer baseline that the post-transfer bundle will be
-compared against (with the subject flipped to `repo:phiscanhq/phi-scan:…`).
+**Historical gap (recorded 2026-04-15):** The latest release at the time
+of this checklist — `v0.5.0`, tagged 2026-04-04 — pre-dates the S11
+Sigstore signing step added to `.github/workflows/release.yml` in PR
+#123 (commit `7c7a21d`, merged 2026-04-11). Verified by
+`git merge-base --is-ancestor 7c7a21d v0.5.0` returning non-zero and
+by `gh release view v0.5.0 --json assets` listing only the `.whl` and
+`.tar.gz` — no `.sigstore.json` bundle is attached. As a result, no
+Sigstore evidence can be captured against `v0.5.0`, and this gate
+cannot clear under the current latest release.
 
-Commands to run (replace `<version>` with the latest released version):
+**Binding rule:** This gate is bound to the **first S11-signed release
+(≥ v0.6.0)**. Evidence below must be captured against that release,
+not against `v0.5.0`. Migration-go cannot be approved until this row
+is `STATUS: DONE` with evidence from a release whose workflow run
+executed the `Sign wheel and sdist with Sigstore (S11)` step.
+
+**Command pack (unchanged; run once a signed release exists).** Replace
+`<version>` with the first version ≥ 0.6.0 whose GitHub Release assets
+include `phi_scan-<version>-py3-none-any.whl.sigstore.json`:
 
 ```bash
 gh release download v<version> --repo joeyessak/phi-scan
@@ -95,10 +108,15 @@ cosign verify-blob \
   phi_scan-<version>-py3-none-any.whl
 ```
 
-Evidence to paste:
+This bundle is the **pre-transfer baseline** whose OIDC subject
+(`repo:joeyessak/phi-scan:…`) the post-transfer bundle
+(`repo:phiscanhq/phi-scan:…`) will be compared against.
+
+Evidence to paste (after a signed release exists):
 
 ```
 PASTE EVIDENCE HERE
+— released version (must be ≥ 0.6.0 and carry a .sigstore.json asset)
 — full `cosign verify-blob` stdout, including the "Verified OK" line
 — the OIDC subject embedded in the cert
 ```
@@ -112,6 +130,11 @@ Date confirmed: `YYYY-MM-DD`
 Rows §1 (PyPI 2FA) and §3 (Sigstore) must be `STATUS: DONE` before the
 maintainer gives the "migration go" approval referenced in §1.6 of the
 runbook. Row §2 (GHCR) is **deferred** and is not a migration-go gate.
+
+Row §3 is currently `PENDING-UNTIL-SIGNED-RELEASE`: it cannot clear
+until a release ≥ v0.6.0 (the first release built with the S11 signing
+step) has been published and its Sigstore bundle verified with the
+command pack above.
 
 Signed off by: `MAINTAINER_NAME`
 Date: `YYYY-MM-DD`

--- a/docs/org-migration-preflight-report.md
+++ b/docs/org-migration-preflight-report.md
@@ -207,8 +207,12 @@ confirmed by the maintainer out-of-band (maintainer-run check).
 
 - Current signing subject derived from OIDC claim issued to workflow
   runs: `repo:joeyessak/phi-scan:…`.
-- Verification command per `docs/supply-chain.md` line 246 (maintainer
-  may run against the latest `.sigstore.json` bundle before transfer):
+- Verification command per `docs/supply-chain.md` line 246. Note:
+  `v0.5.0` was built before the S11 Sigstore signing step was added
+  (PR #123, 2026-04-11) and therefore has no `.sigstore.json` bundle.
+  This command must be run against the first release ≥ v0.6.0 whose
+  workflow run executed the `Sign wheel and sdist with Sigstore (S11)`
+  step and whose GitHub Release assets include the bundle:
 
   ```bash
   cosign verify-blob \
@@ -244,15 +248,16 @@ confirmed by the maintainer out-of-band (maintainer-run check).
 | 6 | Collaborators / teams / `CODEOWNERS` enumerated | **READY** | §3.6 — solo admin, no `CODEOWNERS` |
 | 7 | PyPI owner + 2FA confirmed | **PENDING MAINTAINER** | Owner email confirmed via public API; 2FA status needs out-of-band check |
 | 8 | GHCR manifest reachable and current | **DEFERRED** | Out-of-scope for migration-go — see [`docs/org-migration-status.md`](org-migration-status.md). Post-migration hardening only. |
-| 9 | Sigstore bundle verifies under current subject | **PENDING MAINTAINER** | Commands listed in §4.3 |
+| 9 | Sigstore bundle verifies under current subject | **PENDING-UNTIL-SIGNED-RELEASE** | `v0.5.0` (2026-04-04) pre-dates S11 signing (PR #123, merged 2026-04-11) and has no `.sigstore.json` asset; gate bound to first release ≥ v0.6.0. Commands listed in §4.3. |
 | 10 | Draft migration notice prepared | **DONE** | [`docs/migration/communication-draft.md §1`](migration/communication-draft.md) |
 | 11 | Draft release-notes entry prepared | **DONE** | [`docs/migration/communication-draft.md §2`](migration/communication-draft.md) |
 | 12 | Migration ticket opened | **NOT STARTED** | §1.6 of checklist |
 | 13 | Maintainer "migration go" approval | **NOT GIVEN** | §1.6 of checklist — requested after this report is merged |
 
-**Overall:** No P0 blockers found. Six automated gates READY; two
-require maintainer-run verification (PyPI 2FA, Sigstore) before
-transfer; GHCR is **deferred** as out-of-scope for migration-go;
+**Overall:** No P0 blockers found. Six automated gates READY;
+PyPI 2FA cleared 2026-04-14; the Sigstore gate is **pending-until-
+signed-release** (bound to the first release ≥ v0.6.0 — see row 9 /
+§4.3); GHCR is **deferred** as out-of-scope for migration-go;
 drafts (rows 10, 11) are complete; the remaining operational tasks
 (rows 12, 13) are executed during §1.5–§1.6 of the checklist. Live
 status tracked in [`docs/org-migration-status.md`](org-migration-status.md).

--- a/docs/org-migration-status.md
+++ b/docs/org-migration-status.md
@@ -1,6 +1,6 @@
 # Org Migration Status — `joeyessak/*` → `phiscanhq/*`
 
-**Last updated:** 2026-04-14
+**Last updated:** 2026-04-15
 **Pre-flight evidence date:** 2026-04-18 (per [`docs/org-migration-preflight-report.md`](org-migration-preflight-report.md); evidence remains valid — refresh before transfer per runbook Appendix A)
 **Purpose:** Single operational source of truth for migration-go readiness.
 **Runbook:** [`docs/org-migration-checklist.md`](org-migration-checklist.md)
@@ -46,7 +46,7 @@ execute from one page.
 | 6 | Collaborators / teams / `CODEOWNERS` | **done-with-evidence** | Pre-flight §3.6 (solo admin, no `CODEOWNERS`) |
 | 7 | PyPI 2FA confirmed | **done-with-evidence** | Maintainer confirmed 2026-04-14; see `docs/migration/maintainer-checklist.md §1` |
 | 8 | GHCR pull + digest recorded | **de-scoped** | See "Scope decision — GHCR deferred" above |
-| 9 | Sigstore bundle verifies under current subject | **pending-with-command** | `docs/migration/maintainer-checklist.md §3` — run `cosign verify-blob` on latest release bundle |
+| 9 | Sigstore bundle verifies under current subject | **pending-until-signed-release** | Bound to first S11-signed release (≥ v0.6.0); `v0.5.0` pre-dates S11 (PR #123, 2026-04-11) and has no `.sigstore.json` asset. Command pack retained in `docs/migration/maintainer-checklist.md §3`. |
 | 10 | Draft migration notice prepared | **done-with-evidence** | [`docs/migration/communication-draft.md §1`](migration/communication-draft.md) |
 | 11 | Draft release-notes entry prepared | **done-with-evidence** | [`docs/migration/communication-draft.md §2`](migration/communication-draft.md) |
 | 12 | Migration ticket opened | **done-with-evidence** | [`joeyessak/phi-scan#158`](https://github.com/joeyessak/phi-scan/issues/158) — opened 2026-04-14 from `docs/migration/ticket-template.md` |
@@ -58,15 +58,24 @@ execute from one page.
 
 Only two items stand between current state and executable migration-go:
 
-1. **Sigstore verification** — maintainer runs `cosign verify-blob`
-   against the latest release bundle and pastes the `Verified OK`
-   output into `docs/migration/maintainer-checklist.md §3`.
+1. **Sigstore verification** — bound to the **first S11-signed release
+   (≥ v0.6.0)**. The latest release `v0.5.0` was tagged 2026-04-04,
+   before the S11 Sigstore signing step was merged to
+   `.github/workflows/release.yml` in PR #123 on 2026-04-11, so no
+   `.sigstore.json` bundle exists for `v0.5.0`. Once a release ≥ v0.6.0
+   is cut, the maintainer runs the command pack in
+   `docs/migration/maintainer-checklist.md §3` and pastes the
+   `Verified OK` stdout into that section. Publishing v0.6.0 is a
+   separate go/no-go decision outside this status doc.
 2. **Maintainer go approval** — sign off on `docs/migration/go-no-go.md`
    once every other gate reads `GO`.
 
 Cleared since last status:
 - PyPI 2FA confirmed by maintainer 2026-04-14 (row 7).
 - Migration tracking issue opened (row 12); see link below.
+- Sigstore gate language tightened 2026-04-15: rebound row 9 to the
+  first S11-signed release (≥ v0.6.0) after confirming `v0.5.0` carries
+  no Sigstore bundle.
 
 No other gate requires action. No repo config, workflow, or code change
 is needed before migration-go.


### PR DESCRIPTION
## Summary
- Record the historical gap: `v0.5.0` (tagged 2026-04-04) pre-dates the S11 Sigstore signing step added in PR #123 (commit `7c7a21d`, merged 2026-04-11) and ships no `.sigstore.json` bundle, so pre-transfer `cosign verify-blob` evidence cannot be captured against it.
- Rebind the Sigstore migration-go gate to the **first S11-signed release (≥ v0.6.0)**; rename status from `pending-with-command` → `pending-until-signed-release`.
- Retain the `cosign verify-blob` command pack unchanged so the gate clears automatically once a signed release exists.
- No code changes, no transfer actions, no publish.

## Files updated for internal consistency
- `docs/migration/maintainer-checklist.md` §3 + §4 roll-up
- `docs/migration/go-no-go.md` row 10
- `docs/org-migration-status.md` row 9 + blocker list + last-updated date
- `docs/org-migration-preflight-report.md` row 9 + §4.3 + overall summary

## Evidence for the historical gap
- `gh release view v0.5.0 --json assets` → only `.whl` + `.tar.gz`; no `.sigstore.json`.
- `git merge-base --is-ancestor 7c7a21d v0.5.0` → non-zero (S11 commit is not in v0.5.0).
- v0.5.0 release workflow log (`gh api repos/joeyessak/phi-scan/actions/jobs/69978875586/logs`) jumps from tests to `gh release create`; no sigstore/SBOM steps ran.

## Test plan
- [x] `uv run ruff check .` → All checks passed
- [x] `uv run mypy phi_scan` → Success: no issues found in 89 source files
- [x] `uv run pytest -q` → 2045 passed, 3 skipped; coverage 91.32%
- [x] Docs cross-references verified: maintainer-checklist §3 ↔ go-no-go row 10 ↔ status row 9 ↔ preflight row 9 all state the same binding and same historical gap.