### PR TITLE
release-prep: bump to 0.6.0, align CHANGELOG (no publish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,39 +72,7 @@ Plugin API v1 / v1.1 surface that motivates the minor-version bump._
 - **Corrected security documentation:** README tagline and Why PhiScan section now
   accurately reflect that the "no external network calls" guarantee applies by
   default; the optional AI review layer is explicitly qualified as an opt-in
-  exception. Archive members are now validated against
-  two guards before being read into memory: an absolute uncompressed size limit
-  (`ARCHIVE_MAX_MEMBER_UNCOMPRESSED_BYTES`, 100 MB) and a compression ratio ceiling
-  (`ARCHIVE_MAX_COMPRESSION_RATIO`, 200:1). Members that exceed either limit are
-  skipped with a `WARNING` log; scanning continues with remaining members.
-- **Webhook SSRF protection:** Webhook URLs are validated before any HTTP request.
-  `http://` scheme is rejected (only `https://` permitted). Requests to RFC1918,
-  loopback, link-local, CGNAT, and cloud metadata IP ranges are blocked by default.
-  Set `notifications.is_private_webhook_url_allowed: true` to permit self-hosted targets
-  on private networks.
-- **HTML email escaping:** All dynamic fields in email notification templates
-  (`repo`, `branch`, `file_path`, `category`, `severity`, `risk_level`) are now
-  escaped with `html.escape()` before interpolation, preventing XSS via crafted
-  branch or repository names.
-- **Corrected security documentation:** README tagline and Why PhiScan section now
-  accurately reflect that the "no external network calls" guarantee applies by
-  default; the optional AI review layer is explicitly qualified as an opt-in
   exception.
-
-### Added
-
-- **Multi-provider AI support:** AI confidence review now supports Anthropic, OpenAI, and
-  Google AI providers. Provider is inferred automatically from the model name:
-  `claude-*` → Anthropic, `gpt-*`/`o1`/`o3`/`o4` → OpenAI, `gemini-*` → Google.
-  Install the matching extra: `phi-scan[ai-anthropic]`, `phi-scan[ai-openai]`, or
-  `phi-scan[ai-google]`. The existing `phi-scan[ai]` meta-extra continues to install Anthropic.
-- **Provider-neutral configuration:** New `ai.enable_ai_review` key replaces the deprecated
-  `ai.enable_claude_review`; new `ai.model` field selects the model and determines the provider.
-  API keys are read from `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GOOGLE_API_KEY` environment
-  variables — storing keys in `.phi-scanner.yml` is explicitly rejected with a clear error.
-- **AI token usage in audit log:** Each scan that uses AI review records `prompt_tokens`,
-  `completion_tokens`, and `estimated_cost_usd` in the SQLite audit trail for cost tracking
-  and compliance reporting.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No changes yet._
+
+## [0.6.0] - TBD
+
+_Release date is set at tag time. This section collects every change
+shipped on `main` since `v0.5.0` (2026-04-04), including the public
+Plugin API v1 / v1.1 surface that motivates the minor-version bump._
+
+### Added
+
+- **Plugin API v1 — recognizer surface (A1–A4):** Public, entry-point-based
+  extension contract for custom PHI/PII recognizers. `BaseRecognizer`,
+  `ScanContext`, `ScanFinding`, `PLUGIN_API_VERSION` are exported from
+  `phi_scan`; plugins register via the `phi_scan.recognizers` entry-point
+  group; `phi-scan plugins list` (with `--json`) enumerates discovered
+  plugins. Per-plugin isolation boundary in
+  `phi_scan.plugin_runtime._invoke_detect_with_isolation` documented in
+  `CLAUDE.md`. Canonical contract: `docs/plugin-api-v1.md`.
+- **Plugin API v1.1 — suppressor surface:** `BaseSuppressor.evaluate(finding,
+  line) -> SuppressDecision`, entry-point group `phi_scan.suppressors`,
+  deterministic `(distribution_name, entry_point_name)` ordering,
+  first-`is_suppressed=True`-wins semantics. The suppressor stage runs in
+  `_apply_post_scan_filters` after inline `phi-scan:ignore` and before the
+  confidence/severity gates. Mirrors the recognizer isolation boundary.
+  `phi-scan plugins list` now reports suppressors in both table and
+  `--json` output (additive `suppressors` top-level key; existing
+  `plugins` contract preserved byte-for-byte). Canonical contract:
+  `docs/plugin-api-v1_1.md`.
+- **Multi-provider AI support:** AI confidence review now supports Anthropic, OpenAI, and
+  Google AI providers. Provider is inferred automatically from the model name:
+  `claude-*` → Anthropic, `gpt-*`/`o1`/`o3`/`o4` → OpenAI, `gemini-*` → Google.
+  Install the matching extra: `phi-scan[ai-anthropic]`, `phi-scan[ai-openai]`, or
+  `phi-scan[ai-google]`. The existing `phi-scan[ai]` meta-extra continues to install Anthropic.
+- **Provider-neutral configuration:** New `ai.enable_ai_review` key replaces the deprecated
+  `ai.enable_claude_review`; new `ai.model` field selects the model and determines the provider.
+  API keys are read from `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GOOGLE_API_KEY` environment
+  variables — storing keys in `.phi-scanner.yml` is explicitly rejected with a clear error.
+- **AI token usage in audit log:** Each scan that uses AI review records `prompt_tokens`,
+  `completion_tokens`, and `estimated_cost_usd` in the SQLite audit trail for cost tracking
+  and compliance reporting.
+
 ### Security
 
+- **Supply-chain gates (S9/S10/S11):** `pip-audit` dependency vulnerability
+  gate in CI (S9); CycloneDX SBOM generated per release (S10); wheel and
+  sdist signed with Sigstore keyless OIDC and bundles (`*.sigstore.json`)
+  attached to each GitHub Release (S11). First release built with S11 is
+  this one (`v0.6.0`).
 - **ZIP decompression bomb protection:** Archive members are now validated against
+  two guards before being read into memory: an absolute uncompressed size limit
+  (`ARCHIVE_MAX_MEMBER_UNCOMPRESSED_BYTES`, 100 MB) and a compression ratio ceiling
+  (`ARCHIVE_MAX_COMPRESSION_RATIO`, 200:1). Members that exceed either limit are
+  skipped with a `WARNING` log; scanning continues with remaining members.
+- **Webhook SSRF protection:** Webhook URLs are validated before any HTTP request.
+  `http://` scheme is rejected (only `https://` permitted). Requests to RFC1918,
+  loopback, link-local, CGNAT, and cloud metadata IP ranges are blocked by default.
+  Set `notifications.is_private_webhook_url_allowed: true` to permit self-hosted targets
+  on private networks.
+- **HTML email escaping:** All dynamic fields in email notification templates
+  (`repo`, `branch`, `file_path`, `category`, `severity`, `risk_level`) are now
+  escaped with `html.escape()` before interpolation, preventing XSS via crafted
+  branch or repository names.
+- **Corrected security documentation:** README tagline and Why PhiScan section now
+  accurately reflect that the "no external network calls" guarantee applies by
+  default; the optional AI review layer is explicitly qualified as an opt-in
+  exception. Archive members are now validated against
   two guards before being read into memory: an absolute uncompressed size limit
   (`ARCHIVE_MAX_MEMBER_UNCOMPRESSED_BYTES`, 100 MB) and a compression ratio ceiling
   (`ARCHIVE_MAX_COMPRESSION_RATIO`, 200:1). Members that exceed either limit are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "phi-scan"
-version = "0.5.0"
+version = "0.6.0"
 description = "PHI/PII Scanner for CI/CD pipelines. HIPAA & FHIR compliant. Local execution only."
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -4,7 +4,7 @@ import phi_scan
 
 
 def test_version_is_defined() -> None:
-    assert phi_scan.__version__ == "0.5.0"
+    assert phi_scan.__version__ == "0.6.0"
 
 
 def test_app_name_is_defined() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1493,7 +1493,7 @@ wheels = [
 
 [[package]]
 name = "phi-scan"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` version 0.5.0 → 0.6.0. The motivating public surface change is the Plugin API v1.1 `BaseSuppressor` hook shipped in #157; minor bump is required per semver.
- `CHANGELOG.md`: collapse the long `[Unreleased]` block into a dated-TBD `[0.6.0]` section and add explicit **Plugin API v1** (recognizers — #124/#125/#136) and **Plugin API v1.1** (suppressors — #157) entries under `### Added`, plus a single `### Security` bullet for the S9/S10/S11 supply-chain gates added in #123 (`pip-audit`, CycloneDX SBOM, Sigstore signing). All prior `[Unreleased]` content is preserved verbatim under `[0.6.0]`. A fresh empty `[Unreleased]` section remains on top for future drift.
- `uv.lock` regenerated via `uv sync` (`phi-scan 0.5.0` → `0.6.0`).
- `tests/test_package.py::test_version_is_defined` assertion updated.

## What this PR deliberately does NOT do
- No `git tag v0.6.0`, no `uv publish`, no GitHub Release creation.
- CHANGELOG entry uses `## [0.6.0] - TBD` — release date is set at tag time.
- No changes to user-facing pins (README pre-commit `rev: v0.5.0`, `docs/ci-cd-integration.md`, `docs/getting-started.md` sample output). v0.5.0 remains the latest published release on PyPI; flipping those now would falsely imply v0.6.0 is available to install.
- No BaseOutputSink, no config-surface expansion for suppressors (out of scope per migration-gate plan).
- No transfer actions.

## Coherence check
- `pyproject.toml` version = `phi_scan.__version__` resolution = CHANGELOG `[0.6.0]` entry.
- `docs/migration/maintainer-checklist.md §3` gate (merged in #160) binds Sigstore verification to "first S11-signed release (≥ v0.6.0)" — publishing this version (separate future decision) is the unblock path.

## Test plan
- [x] `uv run ruff check .` → All checks passed
- [x] `uv run mypy phi_scan` → Success: no issues found in 89 source files
- [x] `uv run pytest -q` → 2045 passed, 3 skipped, coverage 91.32%
- [x] `uv sync` clean, `uv.lock` diff limited to the phi-scan self-reference version line.