### PR TITLE
fix(release): use --notes-file for GitHub Release creation; bump 0.6.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,10 +72,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}
+          RELEASE_NOTES: ${{ steps.changelog.outputs.notes }}
         run: |
+          printf '%s\n' "$RELEASE_NOTES" > /tmp/release-notes.md
           gh release create "$TAG_NAME" \
             --title "phi-scan $TAG_NAME" \
-            --notes "${{ steps.changelog.outputs.notes }}" \
+            --notes-file /tmp/release-notes.md \
             dist/*.whl \
             dist/*.tar.gz \
             dist/*.sigstore.json \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No changes yet._
 
-## [0.6.0] - TBD
+## [0.6.1] - TBD
 
-_Release date is set at tag time. This section collects every change
+### Fixed
+
+- **Release workflow GitHub Release creation:** The `Create GitHub Release`
+  step in `.github/workflows/release.yml` passed changelog content via
+  `--notes "${{ steps.changelog.outputs.notes }}"`, which expanded multi-line
+  text directly into the shell command before parsing. Tokens like
+  `phi_scan.output.console:` were interpreted as shell commands, crashing the
+  step. Fixed by writing notes to a temp file and using `--notes-file`. This
+  caused the v0.6.0 GitHub Release to never be created (PyPI publish
+  succeeded; Sigstore bundle was generated but never uploaded).
+
+## [0.6.0] - 2026-04-15
+
+_First S11-signed release. This section collects every change
 shipped on `main` since `v0.5.0` (2026-04-04), including the public
 Plugin API v1 / v1.1 surface that motivates the minor-version bump._
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "phi-scan"
-version = "0.6.0"
+version = "0.6.1"
 description = "PHI/PII Scanner for CI/CD pipelines. HIPAA & FHIR compliant. Local execution only."
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -4,7 +4,7 @@ import phi_scan
 
 
 def test_version_is_defined() -> None:
-    assert phi_scan.__version__ == "0.6.0"
+    assert phi_scan.__version__ == "0.6.1"
 
 
 def test_app_name_is_defined() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1493,7 +1493,7 @@ wheels = [
 
 [[package]]
 name = "phi-scan"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary
- Fix the `Create GitHub Release` step in `.github/workflows/release.yml` that crashed on v0.6.0 due to unquoted changelog expansion in shell.
- Bump version 0.6.0 → 0.6.1 (patch) since PyPI will not accept a re-upload of `phi_scan-0.6.0-py3-none-any.whl`.

## Root cause
Line 78 of `release.yml` passed changelog content via `--notes "${{ steps.changelog.outputs.notes }}"`. The `${{ }}` expression is expanded **before** shell parsing, so multi-line changelog text containing tokens like `phi_scan.output.console:`, `findings.py`, and `SECURITY.md` was interpreted as shell commands. Result: `gh release create` never ran; the GitHub Release was never created; the Sigstore bundle (generated successfully in step S11) was never uploaded.

## Fix
Write the notes to a temp file via an environment variable (`$RELEASE_NOTES` → `printf` → `/tmp/release-notes.md`) and pass `--notes-file /tmp/release-notes.md` to `gh release create`. The env-var approach keeps expansion inside GitHub Actions' expression engine where multi-line values are safe, and `printf` into a file avoids further shell-parsing hazard.

## Incident impact
- `phi-scan 0.6.0` was published to PyPI (irreversible).
- No GitHub Release exists for v0.6.0 — no `.sigstore.json` or SBOM was uploaded.
- v0.6.1 is the recovery release with the workflow fix.

## Files changed
| File | Change |
|------|--------|
| `.github/workflows/release.yml` | `--notes` → `--notes-file` flow |
| `pyproject.toml` | 0.6.0 → 0.6.1 |
| `uv.lock` | phi-scan 0.6.0 → 0.6.1 |
| `CHANGELOG.md` | New `[0.6.1]` Fixed section; `[0.6.0]` date set to 2026-04-15 |
| `tests/test_package.py` | Version assertion → 0.6.1 |

## Test plan
- [x] `uv run ruff check .` → All checks passed
- [x] `uv run mypy phi_scan` → Success: no issues found in 89 source files
- [x] `uv run pytest -q` → 2045 passed, 3 skipped, coverage 91.36%
- [ ] Post-merge: tag v0.6.1, push, verify full release workflow produces GitHub Release with `.sigstore.json` + `sbom.cyclonedx.json` assets.