### PR TITLE
ops(migration): record v0.6.1 Sigstore evidence and clear go/no-go row 10

### DIFF
--- a/docs/migration/go-no-go.md
+++ b/docs/migration/go-no-go.md
@@ -24,7 +24,7 @@ described in `docs/org-migration-checklist.md` §2. Every row must be
 |---|-------|--------|---------------|
 | 8 | PyPI 2FA confirmed | `GO` (confirmed 2026-04-14) | `docs/migration/maintainer-checklist.md#1-pypi-2fa-confirmation` |
 | 9 | ~~GHCR pull + digest recorded~~ | **`N/A — DEFERRED`** | Out-of-scope for migration-go; see [`docs/org-migration-status.md`](../org-migration-status.md) |
-| 10 | Sigstore bundle verifies under current subject | `PENDING-UNTIL-SIGNED-RELEASE` | Bound to the first S11-signed release (≥ v0.6.0). `v0.5.0` pre-dates S11 signing (PR #123, 2026-04-11) and carries no `.sigstore.json`. See `docs/migration/maintainer-checklist.md#3-sigstore--keyless-oidc-verification`. |
+| 10 | Sigstore bundle verifies under current subject | `GO` (v0.6.1, verified 2026-04-15) | Both wheel + sdist bundles `Verified OK` via `cosign verify-blob`. See `docs/migration/maintainer-checklist.md#3-sigstore--keyless-oidc-verification`. |
 
 ## Operational gates
 

--- a/docs/migration/maintainer-checklist.md
+++ b/docs/migration/maintainer-checklist.md
@@ -75,53 +75,67 @@ Record the post-transfer digest here after §2.5 of the runbook completes.
 ## 3. Sigstore / keyless OIDC verification
 
 ```
-STATUS: PENDING-UNTIL-SIGNED-RELEASE
+STATUS: DONE
 ```
 
-**Historical gap (recorded 2026-04-15):** The latest release at the time
-of this checklist — `v0.5.0`, tagged 2026-04-04 — pre-dates the S11
-Sigstore signing step added to `.github/workflows/release.yml` in PR
-#123 (commit `7c7a21d`, merged 2026-04-11). Verified by
-`git merge-base --is-ancestor 7c7a21d v0.5.0` returning non-zero and
-by `gh release view v0.5.0 --json assets` listing only the `.whl` and
-`.tar.gz` — no `.sigstore.json` bundle is attached. As a result, no
-Sigstore evidence can be captured against `v0.5.0`, and this gate
-cannot clear under the current latest release.
+**Historical gap (recorded 2026-04-15):** `v0.5.0` (tagged 2026-04-04)
+pre-dates the S11 Sigstore signing step (PR #123, merged 2026-04-11)
+and has no `.sigstore.json` bundle. The gate was bound to the first
+S11-signed release (≥ v0.6.0). `v0.6.0` was published to PyPI on
+2026-04-15 but its GitHub Release creation failed (release-workflow
+notes-escaping bug, fixed in #163); `v0.6.1` is the first release
+with a complete GitHub Release + Sigstore bundles attached.
 
-**Binding rule:** This gate is bound to the **first S11-signed release
-(≥ v0.6.0)**. Evidence below must be captured against that release,
-not against `v0.5.0`. Migration-go cannot be approved until this row
-is `STATUS: DONE` with evidence from a release whose workflow run
-executed the `Sign wheel and sdist with Sigstore (S11)` step.
-
-**Command pack (unchanged; run once a signed release exists).** Replace
-`<version>` with the first version ≥ 0.6.0 whose GitHub Release assets
-include `phi_scan-<version>-py3-none-any.whl.sigstore.json`:
+**Commands executed against v0.6.1:**
 
 ```bash
-gh release download v<version> --repo joeyessak/phi-scan
+gh release download v0.6.1 --repo joeyessak/phi-scan
 
 cosign verify-blob \
-  --cert-identity "https://github.com/joeyessak/phi-scan/.github/workflows/release.yml@refs/tags/v<version>" \
+  --cert-identity "https://github.com/joeyessak/phi-scan/.github/workflows/release.yml@refs/tags/v0.6.1" \
   --cert-oidc-issuer "https://token.actions.githubusercontent.com" \
-  --bundle phi_scan-<version>-py3-none-any.whl.sigstore.json \
-  phi_scan-<version>-py3-none-any.whl
+  --bundle phi_scan-0.6.1-py3-none-any.whl.sigstore.json \
+  phi_scan-0.6.1-py3-none-any.whl
 ```
 
-This bundle is the **pre-transfer baseline** whose OIDC subject
-(`repo:joeyessak/phi-scan:…`) the post-transfer bundle
-(`repo:phiscanhq/phi-scan:…`) will be compared against.
-
-Evidence to paste (after a signed release exists):
+**Evidence — wheel verification:**
 
 ```
-PASTE EVIDENCE HERE
-— released version (must be ≥ 0.6.0 and carry a .sigstore.json asset)
-— full `cosign verify-blob` stdout, including the "Verified OK" line
-— the OIDC subject embedded in the cert
+Verified OK
 ```
 
-Date confirmed: `YYYY-MM-DD`
+```bash
+cosign verify-blob \
+  --cert-identity "https://github.com/joeyessak/phi-scan/.github/workflows/release.yml@refs/tags/v0.6.1" \
+  --cert-oidc-issuer "https://token.actions.githubusercontent.com" \
+  --bundle phi_scan-0.6.1.tar.gz.sigstore.json \
+  phi_scan-0.6.1.tar.gz
+```
+
+**Evidence — sdist verification:**
+
+```
+Verified OK
+```
+
+**GitHub Release assets confirmed (v0.6.1):**
+
+```
+phi_scan-0.6.1-py3-none-any.whl
+phi_scan-0.6.1-py3-none-any.whl.sigstore.json
+phi_scan-0.6.1.tar.gz
+phi_scan-0.6.1.tar.gz.sigstore.json
+sbom.cyclonedx.json
+```
+
+**OIDC subject:** `repo:joeyessak/phi-scan:…` (pre-transfer baseline).
+Post-transfer bundles will verify under `repo:phiscanhq/phi-scan:…`.
+
+**Cosign version:** v3.0.6 (linux/amd64)
+
+**Release workflow run:** https://github.com/joeyessak/phi-scan/actions/runs/24487133619 (all 13 steps SUCCESS)
+
+Date confirmed: `2026-04-15`
 
 ---
 
@@ -131,10 +145,10 @@ Rows §1 (PyPI 2FA) and §3 (Sigstore) must be `STATUS: DONE` before the
 maintainer gives the "migration go" approval referenced in §1.6 of the
 runbook. Row §2 (GHCR) is **deferred** and is not a migration-go gate.
 
-Row §3 is currently `PENDING-UNTIL-SIGNED-RELEASE`: it cannot clear
-until a release ≥ v0.6.0 (the first release built with the S11 signing
-step) has been published and its Sigstore bundle verified with the
-command pack above.
+Row §3 cleared on 2026-04-15: `v0.6.1` is the first release with a
+complete GitHub Release + Sigstore bundles. Both wheel and sdist
+bundles verified with `cosign verify-blob` → `Verified OK`. All
+required rows (§1, §3) are now `STATUS: DONE`.
 
 Signed off by: `MAINTAINER_NAME`
 Date: `YYYY-MM-DD`

--- a/docs/org-migration-preflight-report.md
+++ b/docs/org-migration-preflight-report.md
@@ -248,7 +248,7 @@ confirmed by the maintainer out-of-band (maintainer-run check).
 | 6 | Collaborators / teams / `CODEOWNERS` enumerated | **READY** | §3.6 — solo admin, no `CODEOWNERS` |
 | 7 | PyPI owner + 2FA confirmed | **PENDING MAINTAINER** | Owner email confirmed via public API; 2FA status needs out-of-band check |
 | 8 | GHCR manifest reachable and current | **DEFERRED** | Out-of-scope for migration-go — see [`docs/org-migration-status.md`](org-migration-status.md). Post-migration hardening only. |
-| 9 | Sigstore bundle verifies under current subject | **PENDING-UNTIL-SIGNED-RELEASE** | `v0.5.0` (2026-04-04) pre-dates S11 signing (PR #123, merged 2026-04-11) and has no `.sigstore.json` asset; gate bound to first release ≥ v0.6.0. Commands listed in §4.3. |
+| 9 | Sigstore bundle verifies under current subject | **DONE** | `v0.6.1` wheel + sdist verified 2026-04-15 via `cosign verify-blob` → `Verified OK`. Evidence in `docs/migration/maintainer-checklist.md §3`. |
 | 10 | Draft migration notice prepared | **DONE** | [`docs/migration/communication-draft.md §1`](migration/communication-draft.md) |
 | 11 | Draft release-notes entry prepared | **DONE** | [`docs/migration/communication-draft.md §2`](migration/communication-draft.md) |
 | 12 | Migration ticket opened | **NOT STARTED** | §1.6 of checklist |

--- a/docs/org-migration-status.md
+++ b/docs/org-migration-status.md
@@ -47,7 +47,7 @@ execute from one page.
 | 6 | Collaborators / teams / `CODEOWNERS` | **done-with-evidence** | Pre-flight §3.6 (solo admin, no `CODEOWNERS`) |
 | 7 | PyPI 2FA confirmed | **done-with-evidence** | Maintainer confirmed 2026-04-14; see `docs/migration/maintainer-checklist.md §1` |
 | 8 | GHCR pull + digest recorded | **de-scoped** | See "Scope decision — GHCR deferred" above |
-| 9 | Sigstore bundle verifies under current subject | **pending-until-signed-release** | Bound to first S11-signed release (≥ v0.6.0); `v0.5.0` pre-dates S11 (PR #123, 2026-04-11) and has no `.sigstore.json` asset. Command pack retained in `docs/migration/maintainer-checklist.md §3`. |
+| 9 | Sigstore bundle verifies under current subject | **done-with-evidence** | `v0.6.1` wheel + sdist bundles verified 2026-04-15 via `cosign verify-blob` → `Verified OK`. Evidence in `docs/migration/maintainer-checklist.md §3`. |
 | 10 | Draft migration notice prepared | **done-with-evidence** | [`docs/migration/communication-draft.md §1`](migration/communication-draft.md) |
 | 11 | Draft release-notes entry prepared | **done-with-evidence** | [`docs/migration/communication-draft.md §2`](migration/communication-draft.md) |
 | 12 | Migration ticket opened | **done-with-evidence** | [`joeyessak/phi-scan#158`](https://github.com/joeyessak/phi-scan/issues/158) — opened 2026-04-14 from `docs/migration/ticket-template.md` |
@@ -57,19 +57,11 @@ execute from one page.
 
 ## Migration-go blockers remaining
 
-Only two items stand between current state and executable migration-go:
+Only one item stands between current state and executable migration-go:
 
-1. **Sigstore verification** — bound to the **first S11-signed release
-   (≥ v0.6.0)**. The latest release `v0.5.0` was tagged 2026-04-04,
-   before the S11 Sigstore signing step was merged to
-   `.github/workflows/release.yml` in PR #123 on 2026-04-11, so no
-   `.sigstore.json` bundle exists for `v0.5.0`. Once a release ≥ v0.6.0
-   is cut, the maintainer runs the command pack in
-   `docs/migration/maintainer-checklist.md §3` and pastes the
-   `Verified OK` stdout into that section. Publishing v0.6.0 is a
-   separate go/no-go decision outside this status doc.
-2. **Maintainer go approval** — sign off on `docs/migration/go-no-go.md`
-   once every other gate reads `GO`.
+1. **Maintainer go approval** — sign off on `docs/migration/go-no-go.md`
+   once every row in the automated, maintainer-run, and operational
+   sections reads `GO` (or `N/A` for deferred items).
 
 Cleared since last status:
 - PyPI 2FA confirmed by maintainer 2026-04-14 (row 7).
@@ -77,6 +69,9 @@ Cleared since last status:
 - Sigstore gate language tightened 2026-04-15: rebound row 9 to the
   first S11-signed release (≥ v0.6.0) after confirming `v0.5.0` carries
   no Sigstore bundle.
+- Sigstore gate cleared 2026-04-15: `v0.6.1` wheel and sdist bundles
+  verified via `cosign verify-blob` → `Verified OK`; evidence pasted
+  in `docs/migration/maintainer-checklist.md §3` (row 9).
 
 No other gate requires action. No repo config, workflow, or code change
 is needed before migration-go.


### PR DESCRIPTION
## Summary
- Record v0.6.1 Sigstore verification evidence (both wheel + sdist: `Verified OK`).
- Move Sigstore gate from `pending-until-signed-release` → `done-with-evidence` / `GO` across all four migration docs.
- v0.6.1 is the first release with a complete GitHub Release + Sigstore bundles (v0.6.0 published to PyPI but GitHub Release creation failed; fixed in #163).

## Evidence captured
- **Artifact:** `phi_scan-0.6.1-py3-none-any.whl` — `Verified OK`
- **Artifact:** `phi_scan-0.6.1.tar.gz` — `Verified OK`
- **OIDC subject:** `repo:joeyessak/phi-scan:…` (pre-transfer baseline)
- **Cosign version:** v3.0.6 (linux/amd64)
- **Release workflow run:** https://github.com/joeyessak/phi-scan/actions/runs/24487133619 (all 13 steps SUCCESS)
- **GitHub Release assets:** `.whl`, `.whl.sigstore.json`, `.tar.gz`, `.tar.gz.sigstore.json`, `sbom.cyclonedx.json`

## Files updated
| File | Change |
|------|--------|
| `docs/migration/maintainer-checklist.md` | §3 PENDING → DONE with full evidence; §4 roll-up updated |
| `docs/migration/go-no-go.md` | Row 10 → `GO` (v0.6.1, verified 2026-04-15) |
| `docs/org-migration-status.md` | Row 9 → done-with-evidence; blockers reduced to 1 (maintainer go) |
| `docs/org-migration-preflight-report.md` | Row 9 → DONE |

## Remaining migration-go blocker
Only **maintainer "migration go" approval signature** in `docs/migration/go-no-go.md`.

## Test plan
- [x] `uv run ruff check .` → All checks passed
- [x] `uv run mypy phi_scan` → Success: no issues found in 89 source files
- [x] `uv run pytest -q` → 2045 passed, 3 skipped, coverage 91.32%