### PR TITLE
docs(transfer): flip canonical URLs from joeyessak/* to phiscanhq/*

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
         run: bash scripts/verify_phi_scan_config.sh
 
       - name: Scan for PHI/PII
-        uses: joeyessak/phi-scan-action@b17418799d4cf730cf57676b49d4828a579930ed  # v0.1.0
+        uses: phiscanhq/phi-scan-action@b17418799d4cf730cf57676b49d4828a579930ed  # v0.1.0
         with:
           severity_threshold: medium
           diff_ref: ${{ github.event_name == 'pull_request' && 'origin/main' || '' }}

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
 # Add the hook to your project by creating or editing .pre-commit-config.yaml:
 #
 #   repos:
-#     - repo: https://github.com/joeyessak/phi-scan
+#     - repo: https://github.com/phiscanhq/phi-scan
 #       rev: v0.1.0
 #       hooks:
 #         - id: phi-scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,7 +223,9 @@ Plugin API v1 / v1.1 surface that motivates the minor-version bump._
 - Git diff file extraction (`--diff` mode)
 - `.phi-scanignore` exclusion pattern support (gitignore-style via pathspec)
 
-[Unreleased]: https://github.com/joeyessak/phi-scan/compare/v0.5.0...HEAD
-[0.5.0]: https://github.com/joeyessak/phi-scan/compare/v0.3.0...v0.5.0
-[0.3.0]: https://github.com/joeyessak/phi-scan/compare/v0.1.0...v0.3.0
-[0.1.0]: https://github.com/joeyessak/phi-scan/releases/tag/v0.1.0
+[Unreleased]: https://github.com/phiscanhq/phi-scan/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/phiscanhq/phi-scan/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/phiscanhq/phi-scan/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/phiscanhq/phi-scan/compare/v0.3.0...v0.5.0
+[0.3.0]: https://github.com/phiscanhq/phi-scan/compare/v0.1.0...v0.3.0
+[0.1.0]: https://github.com/phiscanhq/phi-scan/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ setup, code standards, testing requirements, and pull request process.
 ### Clone and Install
 
 ```bash
-git clone https://github.com/joeyessak/phi-scan.git
+git clone https://github.com/phiscanhq/phi-scan.git
 cd phi-scan
 uv sync --extra nlp --extra hl7      # install with optional layers
 phi-scan setup                        # download spaCy model

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/phi-scan.svg)](https://pypi.org/project/phi-scan/)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![CI](https://github.com/joeyessak/phi-scan/actions/workflows/ci.yml/badge.svg)](https://github.com/joeyessak/phi-scan/actions/workflows/ci.yml)
+[![CI](https://github.com/phiscanhq/phi-scan/actions/workflows/ci.yml/badge.svg)](https://github.com/phiscanhq/phi-scan/actions/workflows/ci.yml)
 
 **HIPAA & FHIR compliant PHI/PII scanner for CI/CD pipelines. Local execution only — no PHI ever leaves your infrastructure (unless AI review is explicitly enabled).**
 
@@ -226,8 +226,8 @@ Full syntax: [docs/ignore-patterns.md](docs/ignore-patterns.md)
 ```yaml
 # .pre-commit-config.yaml
 repos:
-  - repo: https://github.com/joeyessak/phi-scan
-    rev: v0.5.0
+  - repo: https://github.com/phiscanhq/phi-scan
+    rev: v0.6.1
     hooks:
       - id: phi-scan
 ```
@@ -263,7 +263,7 @@ repos:
 
 Copy-paste templates for all CI platforms: [docs/ci-cd-integration.md](docs/ci-cd-integration.md)
 
-> **GitHub Action:** The [`phi-scan-action`](https://github.com/joeyessak/phi-scan-action)
+> **GitHub Action:** The [`phi-scan-action`](https://github.com/phiscanhq/phi-scan-action)
 > composite action provides one-liner GitHub CI/CD integration with SARIF upload,
 > PR comment, diff-only scanning, and AI review support. GitHub Marketplace
 > publication is deferred pending org migration completion + post-pristine signoff.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -110,7 +110,7 @@ Drop-in CI/CD templates for all major platforms and a production Docker image.
 
 - Native templates: GitHub Actions, GitLab CI, Azure Pipelines, Bitbucket Pipelines,
   CircleCI orb, AWS CodeBuild — each with native report group and annotation support
-- `joeyessak/phi-scan-action` composite action — one-liner GitHub CI/CD integration
+- `phiscanhq/phi-scan-action` composite action — one-liner GitHub CI/CD integration
   with SARIF upload, PR comment, diff-only scanning, and AI review support
 - Multi-arch Docker image (`ghcr.io/joeyessak/phi-scan`, amd64/arm64)
 
@@ -130,7 +130,7 @@ operates at full capability without this phase.
 - ✅ Disabled by default; opt-in via `ai.enable_ai_review: true` in `.phi-scanner.yml`
 
 > **Note:** GitHub Marketplace publication of
-> [`phi-scan-action`](https://github.com/joeyessak/phi-scan-action) is deferred
+> [`phi-scan-action`](https://github.com/phiscanhq/phi-scan-action) is deferred
 > until the GitHub org migration is complete. The composite action is fully
 > functional; only the Marketplace listing is pending.
 

--- a/docs/ci-cd-integration.md
+++ b/docs/ci-cd-integration.md
@@ -47,8 +47,8 @@ committed configuration shared across the whole team.
 ```yaml
 # .pre-commit-config.yaml
 repos:
-  - repo: https://github.com/joeyessak/phi-scan
-    rev: v0.5.0
+  - repo: https://github.com/phiscanhq/phi-scan
+    rev: v0.6.1
     hooks:
       - id: phi-scan
 ```
@@ -70,8 +70,8 @@ With options:
 
 ```yaml
 repos:
-  - repo: https://github.com/joeyessak/phi-scan
-    rev: v0.5.0
+  - repo: https://github.com/phiscanhq/phi-scan
+    rev: v0.6.1
     hooks:
       - id: phi-scan
         args:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -87,7 +87,7 @@ phi-scan scan --file path/to/patient_handler.py
 A clean scan:
 
 ```
-PhiScan v0.5.0
+PhiScan v0.6.1
 Scanning: ./src (42 files)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%
 
@@ -97,7 +97,7 @@ Scanning: ./src (42 files)
 A scan with findings:
 
 ```
-PhiScan v0.5.0
+PhiScan v0.6.1
 Scanning: ./src (42 files)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%
 

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -236,14 +236,17 @@ the `sigstore` CLI:
 
 ```bash
 # Fetch the artifacts and bundles from the release
-gh release download v<version> --repo joeyessak/phi-scan \
+gh release download v<version> --repo phiscanhq/phi-scan \
     --pattern "*.whl" \
     --pattern "*.tar.gz" \
     --pattern "*.sigstore.json"
 
 # Verify each wheel against the expected GitHub Actions workload identity
+# Note: releases signed before the repository transfer (≤ v0.6.1) verify
+# under the old subject repo:joeyessak/phi-scan:…; releases signed after
+# transfer verify under repo:phiscanhq/phi-scan:…
 sigstore verify github \
-    --cert-identity "https://github.com/joeyessak/phi-scan/.github/workflows/release.yml@refs/tags/v<version>" \
+    --cert-identity "https://github.com/phiscanhq/phi-scan/.github/workflows/release.yml@refs/tags/v<version>" \
     --cert-oidc-issuer "https://token.actions.githubusercontent.com" \
     phi_scan-<version>-py3-none-any.whl
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -341,7 +341,7 @@ phi-scan explain config      # configuration reference
 ## Reporting a Bug
 
 If you encounter a bug not covered here, open an issue at
-[github.com/joeyessak/phi-scan/issues](https://github.com/joeyessak/phi-scan/issues)
+[github.com/phiscanhq/phi-scan/issues](https://github.com/phiscanhq/phi-scan/issues)
 and include:
 
 - PhiScan version: `phi-scan --version`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,10 +40,10 @@ dependencies = [
 phi-scan = "phi_scan.cli:app"
 
 [project.urls]
-Homepage = "https://github.com/joeyessak/phi-scan"
-Repository = "https://github.com/joeyessak/phi-scan"
-Issues = "https://github.com/joeyessak/phi-scan/issues"
-Changelog = "https://github.com/joeyessak/phi-scan/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/phiscanhq/phi-scan"
+Repository = "https://github.com/phiscanhq/phi-scan"
+Issues = "https://github.com/phiscanhq/phi-scan/issues"
+Changelog = "https://github.com/phiscanhq/phi-scan/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 nlp = ["presidio-analyzer>=2.0", "presidio-anonymizer>=2.0", "spacy>=3.7"]


### PR DESCRIPTION
## Summary
Apply the post-transfer patch pack (`docs/migration/post-transfer-patch-pack.md`) as a single squash PR. Every `joeyessak/*` reference in non-migration docs is flipped to `phiscanhq/*`.

## Files changed (11)
| File | Change |
|------|--------|
| `pyproject.toml` | Homepage/Repository/Issues/Changelog URLs |
| `README.md` | CI badge, pre-commit `rev: v0.6.1`, phi-scan-action link |
| `.github/workflows/ci.yml` | `uses: phiscanhq/phi-scan-action@…` |
| `.pre-commit-hooks.yaml` | Example repo URL comment |
| `CONTRIBUTING.md` | Clone URL |
| `docs/ci-cd-integration.md` | Pre-commit sample URLs + rev bump |
| `docs/supply-chain.md` | `gh release --repo` + `--cert-identity` + dual-subject note |
| `docs/troubleshooting.md` | Issues link |
| `ROADMAP.md` | phi-scan-action refs (GHCR line left per deferred scope) |
| `CHANGELOG.md` | Compare-URL footer (historical release bullets preserved) |
| `docs/getting-started.md` | Sample output version → v0.6.1 |

## Carve-outs (intentionally NOT changed)
- GHCR image paths — deferred to post-migration hardening
- Historical CHANGELOG bullets under `[0.5.0]` — release-time URLs preserved
- Migration runbook docs (`docs/migration/*`, `docs/org-migration-*`) — closeout PR scope
- `ROADMAP.md:188` migration-narrative line — reclassified in closeout

## Residue verification
```
grep -rn "joeyessak" --include="*.md" --include="*.yml" --include="*.yaml" --include="*.toml" --include="*.py" --exclude-dir=docs/migration . | grep -v "docs/org-migration"
```
Remaining hits: ROADMAP GHCR line (deferred), ROADMAP migration narrative (closeout), CHANGELOG historical bullets. All accounted for in patch-pack carve-outs.

## Test plan
- [x] `uv run ruff check .` → All checks passed
- [x] `uv run mypy phi_scan` → Success: no issues found in 89 source files
- [x] `uv run pytest -q` → 2045 passed, 3 skipped, coverage 91.32%