### PR TITLE
docs(readme): soften compliance language and bump to 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No changes yet._
 
+## [0.6.2] - TBD
+
+### Changed
+
+- **README project description:** Softened compliance language throughout the
+  README and the `pyproject.toml` short description. Removed the "HIPAA & FHIR
+  compliant" phrasing from both the README tagline and the PyPI short
+  description; replaced with language that describes PhiScan as designed for
+  HIPAA-aligned and FHIR-based environments rather than claiming certification
+  or guaranteed compliance. The "HIPAA audit trail" feature bullet is now
+  "Audit trail designed for HIPAA-sensitive environments." No functional or
+  API changes — PyPI long description and short summary will be refreshed on
+  the next tagged release.
+
 ## [0.6.1] - TBD
 
 ### Fixed
@@ -223,7 +237,8 @@ Plugin API v1 / v1.1 surface that motivates the minor-version bump._
 - Git diff file extraction (`--diff` mode)
 - `.phi-scanignore` exclusion pattern support (gitignore-style via pathspec)
 
-[Unreleased]: https://github.com/phiscanhq/phi-scan/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/phiscanhq/phi-scan/compare/v0.6.2...HEAD
+[0.6.2]: https://github.com/phiscanhq/phi-scan/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/phiscanhq/phi-scan/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/phiscanhq/phi-scan/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/phiscanhq/phi-scan/compare/v0.3.0...v0.5.0

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/phiscanhq/phi-scan/actions/workflows/ci.yml/badge.svg)](https://github.com/phiscanhq/phi-scan/actions/workflows/ci.yml)
 
-**HIPAA & FHIR compliant PHI/PII scanner for CI/CD pipelines. Local execution only — no PHI ever leaves your infrastructure (unless AI review is explicitly enabled).**
-
-PhiScan scans source code, configuration files, and structured data for Protected Health Information (PHI) and Personally Identifiable Information (PII) before it reaches your main branch. It integrates into any CI/CD pipeline and blocks pull requests that expose patient data.
+PHI/PII scanner designed for HIPAA-aligned and FHIR-based environments. Built for CI/CD pipelines with local-first execution—no PHI ever leaves your infrastructure unless explicitly configured. PhiScan analyzes source code, configuration files, and structured data to detect sensitive information before it reaches your main branch, helping teams reduce compliance risk and prevent accidental data exposure.
 
 ---
 
@@ -36,7 +34,7 @@ PHI found → exit code 1 → commit blocked.
 - **Baseline mode.** Adopt incrementally in existing codebases — only new findings block CI.
 - **9 output formats.** Table, JSON, SARIF, CSV, JUnit, GitLab Code Quality, GitLab SAST, PDF, and HTML enterprise reports.
 - **Inline suppression.** `# phi-scan:ignore` comments let developers acknowledge false positives without disabling the scanner.
-- **HIPAA audit trail.** Every scan is recorded in an immutable SQLite log. SHA-256 hashes only — raw PHI values are never stored.
+- **Audit trail designed for HIPAA-sensitive environments.** Every scan is recorded in an immutable SQLite log. SHA-256 hashes only — raw PHI values are never stored.
 - **Free forever.** All detection layers, output formats, CI integrations, compliance annotations, baseline mode, audit trail, and the plugin API ship in the MIT-licensed Community tier and will never be paywalled or intentionally degraded. See [docs/community-pro-cloud-matrix.md](docs/community-pro-cloud-matrix.md) for the full feature boundary.
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "phi-scan"
-version = "0.6.1"
-description = "PHI/PII Scanner for CI/CD pipelines. HIPAA & FHIR compliant. Local execution only."
+version = "0.6.2"
+description = "PHI/PII scanner for HIPAA-aligned and FHIR-based environments. Local-first execution for CI/CD pipelines."
 readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = ">=3.12"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -4,7 +4,7 @@ import phi_scan
 
 
 def test_version_is_defined() -> None:
-    assert phi_scan.__version__ == "0.6.1"
+    assert phi_scan.__version__ == "0.6.2"
 
 
 def test_app_name_is_defined() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1493,7 +1493,7 @@ wheels = [
 
 [[package]]
 name = "phi-scan"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

- Replace "HIPAA & FHIR compliant" language in the README tagline and `pyproject.toml` short description with safer, accuracy-matching wording.
- Approved opening paragraph replaces both the old tagline and the old prose intro (which said nearly the same thing).
- Soften the "HIPAA audit trail" feature bullet to "Audit trail designed for HIPAA-sensitive environments."
- Leave compliance-framework annotation wording alone — those describe the tool's feature, not a compliance claim.
- Leave historical CHANGELOG entries and the `compliance` keyword tag alone.
- Bump version `0.6.1` → `0.6.2` so the next tagged release republishes the corrected PyPI page.

## Files changed

| File | Change |
|------|--------|
| `README.md` | Approved opening paragraph replaces lines 8 + 10; line 39 softened |
| `pyproject.toml` | `version` → `0.6.2`; `description` rewritten |
| `tests/test_package.py` | Version assertion bumped to `0.6.2` |
| `CHANGELOG.md` | New `[0.6.2]` section in `### Changed`; compare-link footer updated |
| `uv.lock` | Self-package entry refreshed to `0.6.2` |

## Release path

- `pyproject.toml` has `readme = "README.md"` → feeds PyPI long description ✅
- `.github/workflows/release.yml` uses `UV_PUBLISH_TOKEN: \${{ secrets.PYPI_API_TOKEN }}` + `uv publish` on `push: tags: v*` ✅
- No workflow changes needed.
- The next `v0.6.2` tag push will refresh both the PyPI short description (above) and the long description (README) on the project page.

## Test plan

- [ ] CI passes on all platforms (pytest + ruff + mypy)
- [ ] `test_version_is_defined` asserts `0.6.2`
- [ ] Verified locally: `uv run pytest tests/test_package.py` → 2 passed
- [ ] Verified locally: `uv run ruff check phi_scan tests` → All checks passed

## Not included (intentional)

- No git tag cut and no publish in this PR — preparation only. Will happen on explicit instruction.
- No changes to the compliance-framework annotation feature documentation.
- No changes to historical CHANGELOG entries (shipped history).