### PR TITLE
feat(report): v2 terminal report renderer behind --report-format v2

### DIFF
--- a/phi_scan/cli/report.py
+++ b/phi_scan/cli/report.py
@@ -207,6 +207,7 @@ def display_rich_scan_results(scan_result: ScanResult) -> None:
 # V2 renderer dispatch
 # ---------------------------------------------------------------------------
 
+
 def _dispatch_v2_renderer(scan_result: ScanResult, options: ScanOutputOptions) -> None:
     """Dispatch to the v2 terminal report renderer."""
     from phi_scan.constants import SeverityLevel

--- a/phi_scan/cli/report.py
+++ b/phi_scan/cli/report.py
@@ -125,6 +125,9 @@ class ScanOutputOptions:
     report_path: Path | None
     scan_target: Path = field(default_factory=lambda: Path("."))
     framework_annotations: Mapping[int, tuple[ComplianceControl, ...]] | None = None
+    is_v2: bool = False
+    is_verbose: bool = False
+    severity_threshold_value: str = "low"
 
 
 # ---------------------------------------------------------------------------
@@ -201,6 +204,25 @@ def display_rich_scan_results(scan_result: ScanResult) -> None:
 
 
 # ---------------------------------------------------------------------------
+# V2 renderer dispatch
+# ---------------------------------------------------------------------------
+
+def _dispatch_v2_renderer(scan_result: ScanResult, options: ScanOutputOptions) -> None:
+    """Dispatch to the v2 terminal report renderer."""
+    from phi_scan.constants import SeverityLevel
+    from phi_scan.report.v2.console import display_rich_scan_results_v2
+
+    severity_threshold = SeverityLevel(options.severity_threshold_value)
+    display_rich_scan_results_v2(
+        scan_result,
+        scan_target=str(options.scan_target),
+        severity_threshold=severity_threshold,
+        is_verbose=options.is_verbose,
+        report_path=options.report_path,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Scan output dispatch
 # ---------------------------------------------------------------------------
 
@@ -223,7 +245,10 @@ def emit_scan_output(scan_result: ScanResult, options: ScanOutputOptions) -> Non
             typer.echo(_REPORT_PATH_TABLE_FORMAT_ERROR, err=True)
             raise typer.Exit(code=EXIT_CODE_ERROR)
         if options.is_rich_mode:
-            display_rich_scan_results(scan_result)
+            if options.is_v2:
+                _dispatch_v2_renderer(scan_result, options)
+            else:
+                display_rich_scan_results(scan_result)
         return
     if options.output_format in (OutputFormat.PDF, OutputFormat.HTML):
         write_binary_report(scan_result, options)

--- a/phi_scan/cli/report.py
+++ b/phi_scan/cli/report.py
@@ -31,6 +31,7 @@ from phi_scan.constants import (
     EXIT_CODE_VIOLATION,
     IMPLEMENTED_OUTPUT_FORMATS,
     OutputFormat,
+    SeverityLevel,
 )
 from phi_scan.exceptions import BaselineError
 from phi_scan.output import (
@@ -127,7 +128,7 @@ class ScanOutputOptions:
     framework_annotations: Mapping[int, tuple[ComplianceControl, ...]] | None = None
     is_v2: bool = False
     is_verbose: bool = False
-    severity_threshold_value: str = "low"
+    severity_threshold: SeverityLevel = SeverityLevel.LOW
 
 
 # ---------------------------------------------------------------------------
@@ -210,14 +211,12 @@ def display_rich_scan_results(scan_result: ScanResult) -> None:
 
 def _dispatch_v2_renderer(scan_result: ScanResult, options: ScanOutputOptions) -> None:
     """Dispatch to the v2 terminal report renderer."""
-    from phi_scan.constants import SeverityLevel
     from phi_scan.report.v2.console import display_rich_scan_results_v2
 
-    severity_threshold = SeverityLevel(options.severity_threshold_value)
     display_rich_scan_results_v2(
         scan_result,
         scan_target=str(options.scan_target),
-        severity_threshold=severity_threshold,
+        severity_threshold=options.severity_threshold,
         is_verbose=options.is_verbose,
         report_path=options.report_path,
     )

--- a/phi_scan/cli/scan.py
+++ b/phi_scan/cli/scan.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Annotated
 
@@ -126,6 +127,14 @@ _SCAN_WORKERS_HELP: str = (
     f"Values above 1 enable concurrent scanning up to {MAX_WORKER_COUNT}. "
     "Output ordering is deterministic regardless of thread completion order."
 )
+_SCAN_REPORT_FORMAT_HELP: str = (
+    "Terminal report format: v1 (current default) or v2 (redesigned grouped output). "
+    "Also settable via PHI_SCAN_REPORT_V2=1 environment variable."
+)
+_REPORT_FORMAT_V2: str = "v2"
+_REPORT_FORMAT_V1: str = "v1"
+_REPORT_FORMAT_ENV_VAR: str = "PHI_SCAN_REPORT_V2"
+_REPORT_FORMAT_ENV_TRUTHY: str = "1"
 
 _AUDIT_WRITE_FAILURE_WARNING: str = "Audit log write failed — scan result not persisted: {error}"
 _AUDIT_KEY_MISSING_DEBUG: str = (
@@ -296,6 +305,9 @@ def scan(
     worker_count: Annotated[
         int, typer.Option("--workers", help=_SCAN_WORKERS_HELP)
     ] = _DEFAULT_WORKER_COUNT,
+    report_format: Annotated[
+        str, typer.Option("--report-format", help=_SCAN_REPORT_FORMAT_HELP)
+    ] = _REPORT_FORMAT_V1,
 ) -> None:
     """Scan a directory or file for PHI/PII.
 
@@ -309,9 +321,13 @@ def scan(
     output_format_enum = resolve_output_format(output_format)
     enabled_frameworks = _resolve_framework_flag(framework)
     is_rich_mode = not is_quiet and output_format_enum is OutputFormat.TABLE
+    is_v2 = (
+        report_format == _REPORT_FORMAT_V2
+        or os.environ.get(_REPORT_FORMAT_ENV_VAR) == _REPORT_FORMAT_ENV_TRUTHY
+    )
     with display_status_spinner(_SPINNER_CONFIG_LOAD_MESSAGE, is_active=is_rich_mode):
         scan_config = load_scan_config(config_path, severity_threshold)
-    if is_rich_mode:
+    if is_rich_mode and not is_v2:
         display_banner()
         display_scan_header(path, scan_config)
     if single_file is None and path.is_file():
@@ -328,12 +344,16 @@ def scan(
     framework_annotations = (
         annotate_findings(scan_result.findings, enabled_frameworks) if enabled_frameworks else None
     )
+    effective_threshold = severity_threshold if severity_threshold is not None else "low"
     output_options = ScanOutputOptions(
         output_format=output_format_enum,
         is_rich_mode=is_rich_mode,
         report_path=report_path,
         scan_target=path,
         framework_annotations=framework_annotations,
+        is_v2=is_v2,
+        is_verbose=is_verbose,
+        severity_threshold_value=effective_threshold,
     )
     phase_options = _ScanPhaseOptions(
         is_verbose=is_verbose,
@@ -348,5 +368,6 @@ def scan(
         should_import_to_security_hub=should_import_to_security_hub,
     )
     dispatch_ci_integrations(scan_result, integration_options, is_rich_mode)
-    display_report_phase_header(output_options, phase_options.is_verbose)
+    if not is_v2:
+        display_report_phase_header(output_options, phase_options.is_verbose)
     emit_report_output(scan_result, output_options, phase_options.should_use_baseline)

--- a/phi_scan/cli/scan.py
+++ b/phi_scan/cli/scan.py
@@ -42,7 +42,7 @@ from phi_scan.compliance import (
     annotate_findings,
     parse_framework_flag,
 )
-from phi_scan.constants import EXIT_CODE_ERROR, OutputFormat
+from phi_scan.constants import EXIT_CODE_ERROR, OutputFormat, SeverityLevel
 from phi_scan.exceptions import AuditKeyMissingError, AuditLogError, NotificationError
 from phi_scan.logging_config import get_logger
 from phi_scan.models import ScanConfig, ScanResult
@@ -344,7 +344,9 @@ def scan(
     framework_annotations = (
         annotate_findings(scan_result.findings, enabled_frameworks) if enabled_frameworks else None
     )
-    effective_threshold = severity_threshold if severity_threshold is not None else "low"
+    effective_threshold = (
+        SeverityLevel(severity_threshold) if severity_threshold is not None else SeverityLevel.LOW
+    )
     output_options = ScanOutputOptions(
         output_format=output_format_enum,
         is_rich_mode=is_rich_mode,
@@ -353,7 +355,7 @@ def scan(
         framework_annotations=framework_annotations,
         is_v2=is_v2,
         is_verbose=is_verbose,
-        severity_threshold_value=effective_threshold,
+        severity_threshold=effective_threshold,
     )
     phase_options = _ScanPhaseOptions(
         is_verbose=is_verbose,

--- a/phi_scan/report/v2/__init__.py
+++ b/phi_scan/report/v2/__init__.py
@@ -1,0 +1,1 @@
+"""V2 terminal report renderer — redesigned terminal output for phi-scan findings."""

--- a/phi_scan/report/v2/aggregation.py
+++ b/phi_scan/report/v2/aggregation.py
@@ -1,0 +1,219 @@
+"""Aggregation logic: group findings by line, deduplicate remediations, rank actions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from phi_scan.constants import SEVERITY_RANK, PhiCategory, SeverityLevel
+from phi_scan.models import ScanFinding
+from phi_scan.report.v2.models import FileAggregate, LineAggregate, RemediationAction
+
+_TOP_ACTIONS_COUNT: int = 5
+
+_ACTION_TITLE_MAP: dict[PhiCategory, str] = {
+    PhiCategory.SSN: "Remove Social Security Numbers",
+    PhiCategory.NAME: "Remove or fake patient names",
+    PhiCategory.DATE: "Replace full dates with year only",
+    PhiCategory.PHONE: "Replace phone numbers with synthetic values",
+    PhiCategory.FAX: "Replace fax numbers with synthetic values",
+    PhiCategory.EMAIL: "Fake email addresses",
+    PhiCategory.MRN: "Replace Medical Record Numbers",
+    PhiCategory.HEALTH_PLAN: "Synthesize health-plan numbers",
+    PhiCategory.ACCOUNT: "Replace account numbers with synthetic values",
+    PhiCategory.CERTIFICATE: "Replace certificate/license numbers",
+    PhiCategory.GEOGRAPHIC: "Truncate geographic data to state or 3-digit ZIP",
+    PhiCategory.IP: "Scrub IPv4 addresses from logs",
+    PhiCategory.URL: "Review URLs with patient-identifying paths",
+    PhiCategory.VEHICLE: "Replace vehicle identifiers",
+    PhiCategory.DEVICE: "Replace device identifiers",
+    PhiCategory.BIOMETRIC: "Remove biometric identifiers",
+    PhiCategory.PHOTO: "Remove full-face photographs",
+    PhiCategory.UNIQUE_ID: "Replace unique identifying numbers",
+    PhiCategory.SUBSTANCE_USE_DISORDER: "Remove Substance Use Disorder records",
+    PhiCategory.QUASI_IDENTIFIER_COMBINATION: "Break up quasi-identifier combinations",
+}
+
+
+def _highest_severity(findings: tuple[ScanFinding, ...] | list[ScanFinding]) -> SeverityLevel:
+    """Return the highest severity level from a collection of findings."""
+    best = SeverityLevel.INFO
+    best_rank = SEVERITY_RANK[best]
+    for finding in findings:
+        rank = SEVERITY_RANK[finding.severity]
+        if rank > best_rank:
+            best = finding.severity
+            best_rank = rank
+    return best
+
+
+def _build_category_counts(findings: tuple[ScanFinding, ...]) -> dict[str, int]:
+    """Count occurrences of each entity_type on a line."""
+    counts: dict[str, int] = {}
+    for finding in findings:
+        counts[finding.entity_type] = counts.get(finding.entity_type, 0) + 1
+    return counts
+
+
+def _combine_fixes(findings: tuple[ScanFinding, ...]) -> str:
+    """Join unique remediation hints with semicolons."""
+    seen: list[str] = []
+    for finding in findings:
+        if finding.remediation_hint and finding.remediation_hint not in seen:
+            seen.append(finding.remediation_hint)
+    return "; ".join(seen)
+
+
+def group_by_line(findings: tuple[ScanFinding, ...]) -> list[LineAggregate]:
+    """Group findings by (file_path, line_number) into LineAgggregates."""
+    buckets: dict[tuple[Path, int], list[ScanFinding]] = {}
+    for finding in findings:
+        key = (finding.file_path, finding.line_number)
+        if key not in buckets:
+            buckets[key] = []
+        buckets[key].append(finding)
+
+    aggregates: list[LineAggregate] = []
+    for (file_path, line_number), line_findings in buckets.items():
+        frozen_findings = tuple(line_findings)
+        aggregates.append(
+            LineAggregate(
+                file_path=file_path,
+                line_number=line_number,
+                findings=frozen_findings,
+                highest_severity=_highest_severity(line_findings),
+                category_counts=_build_category_counts(frozen_findings),
+                combined_code_context=line_findings[0].code_context,
+                combined_fix=_combine_fixes(frozen_findings),
+            )
+        )
+    return aggregates
+
+
+def group_by_file(line_aggregates: list[LineAggregate]) -> list[FileAggregate]:
+    """Group line aggregates by file, sorting lines within each file."""
+    file_buckets: dict[Path, list[LineAggregate]] = {}
+    for line_agg in line_aggregates:
+        if line_agg.file_path not in file_buckets:
+            file_buckets[line_agg.file_path] = []
+        file_buckets[line_agg.file_path].append(line_agg)
+
+    file_aggregates: list[FileAggregate] = []
+    for file_path, lines in sorted(file_buckets.items()):
+        sorted_lines = sorted(
+            lines,
+            key=lambda la: (-la.severity_rank, -la.finding_count, la.line_number),
+        )
+        all_findings = [f for la in sorted_lines for f in la.findings]
+        file_aggregates.append(
+            FileAggregate(
+                file_path=file_path,
+                line_aggregates=tuple(sorted_lines),
+                total_finding_count=sum(la.finding_count for la in sorted_lines),
+                highest_severity=_highest_severity(all_findings),
+            )
+        )
+    return file_aggregates
+
+
+def dedupe_remediations(findings: tuple[ScanFinding, ...]) -> list[RemediationAction]:
+    """Group findings by remediation_hint into deduplicated RemediationActions."""
+    buckets: dict[str, list[ScanFinding]] = {}
+    for finding in findings:
+        hint = finding.remediation_hint
+        if not hint:
+            continue
+        if hint not in buckets:
+            buckets[hint] = []
+        buckets[hint].append(finding)
+
+    actions: list[RemediationAction] = []
+    for hint, grouped_findings in buckets.items():
+        highest_sev = _highest_severity(grouped_findings)
+        mean_conf = sum(f.confidence for f in grouped_findings) / len(grouped_findings)
+        affected: list[tuple[Path, int]] = []
+        seen_lines: set[tuple[Path, int]] = set()
+        for finding in grouped_findings:
+            key = (finding.file_path, finding.line_number)
+            if key not in seen_lines:
+                seen_lines.add(key)
+                affected.append(key)
+        affected.sort(key=lambda pair: (pair[0], pair[1]))
+        primary_category = grouped_findings[0].hipaa_category
+        title = _ACTION_TITLE_MAP.get(primary_category, hint[:60])
+
+        actions.append(
+            RemediationAction(
+                remediation_hint=hint,
+                title=title,
+                hipaa_category=primary_category,
+                finding_count=len(grouped_findings),
+                highest_severity=highest_sev,
+                mean_confidence=mean_conf,
+                affected_lines=tuple(affected),
+                severity_weight_score=SEVERITY_RANK[highest_sev] * len(grouped_findings),
+            )
+        )
+
+    actions.sort(key=lambda a: (-a.severity_rank, -a.finding_count))
+    return actions
+
+
+def rank_top_actions(
+    actions: list[RemediationAction],
+) -> list[RemediationAction]:
+    """Return the top N actions ranked by severity_weight_score descending."""
+    ranked = sorted(actions, key=lambda a: (-a.severity_weight_score, -a.severity_rank))
+    return ranked[:_TOP_ACTIONS_COUNT]
+
+
+def compute_hotspot_count(line_aggregates: list[LineAggregate]) -> int:
+    """Count lines with 2 or more distinct PHI categories."""
+    _hotspot_category_threshold = 2
+    return sum(
+        1 for la in line_aggregates if len(la.category_counts) >= _hotspot_category_threshold
+    )
+
+
+def compute_category_severity_distribution(
+    findings: tuple[ScanFinding, ...],
+) -> dict[str, dict[SeverityLevel, int]]:
+    """Build per-category severity distribution for the category breakdown bars."""
+    distribution: dict[str, dict[SeverityLevel, int]] = {}
+    for finding in findings:
+        category_name = finding.hipaa_category.value
+        if category_name not in distribution:
+            distribution[category_name] = {}
+        sev_counts = distribution[category_name]
+        sev_counts[finding.severity] = sev_counts.get(finding.severity, 0) + 1
+    return distribution
+
+
+def build_line_title(line_aggregate: LineAggregate) -> str:
+    """Build a human-readable title for a line aggregate."""
+    categories = list(line_aggregate.category_counts.keys())
+
+    _quasi_combo_threshold = 5
+    if len(categories) >= _quasi_combo_threshold:
+        return f"Quasi-identifier cluster  ({len(categories)} categories co-located)"
+
+    has_date = any("DATE" in c for c in categories)
+    has_zip = any("ZIP" in c or "GEOGRAPHIC" in c for c in categories)
+    has_age = any("AGE" in c for c in categories)
+    has_ssn = any("SSN" in c for c in categories)
+
+    if has_date and has_zip and has_age:
+        return "DOB + ZIP + age-over-90  (Sweeney re-id risk)"
+    if has_date and has_zip:
+        return "DOB + ZIP  (quasi-identifier risk)"
+    if has_ssn:
+        return "Social Security Number"
+
+    readable_names: list[str] = []
+    for category in categories:
+        name = category.lower().replace("_", " ")
+        readable_names.append(name)
+
+    combined = " + ".join(readable_names[:3])
+    if len(readable_names) > 3:
+        combined += f" +{len(readable_names) - 3} more"
+    return combined.title()

--- a/phi_scan/report/v2/aggregation.py
+++ b/phi_scan/report/v2/aggregation.py
@@ -9,6 +9,9 @@ from phi_scan.models import ScanFinding
 from phi_scan.report.v2.models import FileAggregate, LineAggregate, RemediationAction
 
 _TOP_ACTIONS_COUNT: int = 5
+_HOTSPOT_CATEGORY_THRESHOLD: int = 2
+_QUASI_COMBO_THRESHOLD: int = 5
+_HINT_TRUNCATION_LENGTH: int = 60
 
 _ACTION_TITLE_MAP: dict[PhiCategory, str] = {
     PhiCategory.SSN: "Remove Social Security Numbers",
@@ -54,7 +57,7 @@ def _build_category_counts(findings: tuple[ScanFinding, ...]) -> dict[str, int]:
     return counts
 
 
-def _combine_fixes(findings: tuple[ScanFinding, ...]) -> str:
+def _combine_remediation_hints(findings: tuple[ScanFinding, ...]) -> str:
     """Join unique remediation hints with semicolons."""
     seen: list[str] = []
     for finding in findings:
@@ -82,8 +85,8 @@ def group_by_line(findings: tuple[ScanFinding, ...]) -> list[LineAggregate]:
                 findings=frozen_findings,
                 highest_severity=_highest_severity(line_findings),
                 category_counts=_build_category_counts(frozen_findings),
-                combined_code_context=line_findings[0].code_context,
-                combined_fix=_combine_fixes(frozen_findings),
+                display_context=line_findings[0].code_context,
+                combined_fix=_combine_remediation_hints(frozen_findings),
             )
         )
     return aggregates
@@ -103,13 +106,13 @@ def group_by_file(line_aggregates: list[LineAggregate]) -> list[FileAggregate]:
             lines,
             key=lambda la: (-la.severity_rank, -la.finding_count, la.line_number),
         )
-        all_findings = [f for la in sorted_lines for f in la.findings]
+        file_findings = [f for la in sorted_lines for f in la.findings]
         file_aggregates.append(
             FileAggregate(
                 file_path=file_path,
                 line_aggregates=tuple(sorted_lines),
                 total_finding_count=sum(la.finding_count for la in sorted_lines),
-                highest_severity=_highest_severity(all_findings),
+                highest_severity=_highest_severity(file_findings),
             )
         )
     return file_aggregates
@@ -129,7 +132,7 @@ def dedupe_remediations(findings: tuple[ScanFinding, ...]) -> list[RemediationAc
     actions: list[RemediationAction] = []
     for hint, grouped_findings in buckets.items():
         highest_sev = _highest_severity(grouped_findings)
-        mean_conf = sum(f.confidence for f in grouped_findings) / len(grouped_findings)
+        mean_confidence = sum(f.confidence for f in grouped_findings) / len(grouped_findings)
         affected: list[tuple[Path, int]] = []
         seen_lines: set[tuple[Path, int]] = set()
         for finding in grouped_findings:
@@ -139,7 +142,7 @@ def dedupe_remediations(findings: tuple[ScanFinding, ...]) -> list[RemediationAc
                 affected.append(key)
         affected.sort(key=lambda pair: (pair[0], pair[1]))
         primary_category = grouped_findings[0].hipaa_category
-        title = _ACTION_TITLE_MAP.get(primary_category, hint[:60])
+        title = _ACTION_TITLE_MAP.get(primary_category, hint[:_HINT_TRUNCATION_LENGTH])
 
         actions.append(
             RemediationAction(
@@ -148,7 +151,7 @@ def dedupe_remediations(findings: tuple[ScanFinding, ...]) -> list[RemediationAc
                 hipaa_category=primary_category,
                 finding_count=len(grouped_findings),
                 highest_severity=highest_sev,
-                mean_confidence=mean_conf,
+                mean_confidence=mean_confidence,
                 affected_lines=tuple(affected),
                 severity_weight_score=SEVERITY_RANK[highest_sev] * len(grouped_findings),
             )
@@ -168,9 +171,8 @@ def rank_top_actions(
 
 def compute_hotspot_count(line_aggregates: list[LineAggregate]) -> int:
     """Count lines with 2 or more distinct PHI categories."""
-    _hotspot_category_threshold = 2
     return sum(
-        1 for la in line_aggregates if len(la.category_counts) >= _hotspot_category_threshold
+        1 for la in line_aggregates if len(la.category_counts) >= _HOTSPOT_CATEGORY_THRESHOLD
     )
 
 
@@ -192,8 +194,7 @@ def build_line_title(line_aggregate: LineAggregate) -> str:
     """Build a human-readable title for a line aggregate."""
     categories = list(line_aggregate.category_counts.keys())
 
-    _quasi_combo_threshold = 5
-    if len(categories) >= _quasi_combo_threshold:
+    if len(categories) >= _QUASI_COMBO_THRESHOLD:
         return f"Quasi-identifier cluster  ({len(categories)} categories co-located)"
 
     has_date = any("DATE" in c for c in categories)

--- a/phi_scan/report/v2/console.py
+++ b/phi_scan/report/v2/console.py
@@ -1,0 +1,91 @@
+"""V2 terminal report renderer — public entry point.
+
+Composes overview, findings-by-line, remediation playbook, and scan-complete
+footer into a single terminal report. Called from display_rich_scan_results_v2
+when --report-format v2 or PHI_SCAN_REPORT_V2=1 is active.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from phi_scan.constants import SEVERITY_RANK, SeverityLevel
+from phi_scan.models import ScanResult
+from phi_scan.output.console.core import get_console
+from phi_scan.report.v2.aggregation import (
+    dedupe_remediations,
+    group_by_file,
+    group_by_line,
+)
+from phi_scan.report.v2.findings import render_findings_by_line
+from phi_scan.report.v2.footer import render_scan_complete
+from phi_scan.report.v2.overview import render_overview
+from phi_scan.report.v2.playbook import render_remediation_playbook
+
+_DEFAULT_EXPAND_CUTOFF: SeverityLevel = SeverityLevel.MEDIUM
+
+
+def _resolve_expand_cutoff(severity_threshold: SeverityLevel) -> SeverityLevel:
+    """Determine the expansion cutoff for line cards.
+
+    If the user set --severity-threshold to low, expand low-severity cards
+    inline instead of collapsing them. Otherwise default to medium.
+    """
+    if SEVERITY_RANK[severity_threshold] <= SEVERITY_RANK[SeverityLevel.LOW]:
+        return severity_threshold
+    return _DEFAULT_EXPAND_CUTOFF
+
+
+def display_rich_scan_results_v2(
+    scan_result: ScanResult,
+    scan_target: str = ".",
+    severity_threshold: SeverityLevel = SeverityLevel.LOW,
+    is_verbose: bool = False,
+    report_path: Path | None = None,
+) -> None:
+    """Render the full v2 terminal report.
+
+    This is the public entry point called by the CLI when v2 rendering is
+    active. It replaces display_rich_scan_results for v2 mode only.
+
+    Args:
+        scan_result: Completed scan result from the detection engine.
+        scan_target: Display name of the scan target (file or directory path).
+        severity_threshold: Effective severity threshold from config/CLI.
+        is_verbose: Whether --verbose was passed.
+        report_path: Path to generated report file, if any.
+    """
+    console = get_console()
+
+    line_aggregates = group_by_line(scan_result.findings)
+    all_actions = dedupe_remediations(scan_result.findings)
+    file_aggregates = group_by_file(line_aggregates)
+
+    render_overview(console, scan_result, scan_target, all_actions)
+
+    if not scan_result.is_clean:
+        expand_cutoff = _resolve_expand_cutoff(severity_threshold)
+        total_line_count = len(line_aggregates)
+
+        render_findings_by_line(
+            console,
+            file_aggregates,
+            total_finding_count=len(scan_result.findings),
+            total_line_count=total_line_count,
+            severity_threshold=expand_cutoff,
+            is_verbose=is_verbose,
+        )
+
+        render_remediation_playbook(
+            console,
+            all_actions,
+            total_finding_count=len(scan_result.findings),
+            report_path=report_path,
+        )
+
+    render_scan_complete(
+        console,
+        scan_result,
+        unique_action_count=len(all_actions),
+        report_path=report_path,
+    )

--- a/phi_scan/report/v2/console.py
+++ b/phi_scan/report/v2/console.py
@@ -28,8 +28,9 @@ _DEFAULT_EXPAND_CUTOFF: SeverityLevel = SeverityLevel.MEDIUM
 def _resolve_expand_cutoff(severity_threshold: SeverityLevel) -> SeverityLevel:
     """Determine the expansion cutoff for line cards.
 
-    If the user set --severity-threshold to low, expand low-severity cards
-    inline instead of collapsing them. Otherwise default to medium.
+    When the user passes a threshold at or below LOW (i.e. LOW or INFO),
+    all findings at that level and above are expanded inline.  Otherwise
+    the default cutoff of MEDIUM applies, collapsing LOW and INFO cards.
     """
     if SEVERITY_RANK[severity_threshold] <= SEVERITY_RANK[SeverityLevel.LOW]:
         return severity_threshold

--- a/phi_scan/report/v2/findings.py
+++ b/phi_scan/report/v2/findings.py
@@ -38,6 +38,7 @@ _LINE_BADGE_STYLE: dict[SeverityLevel, str] = {
 _TYPE_CHIP_STYLE: str = "cyan"
 _PREVIEW_MARKER: str = "▸"
 _EXPAND_CUTOFF_DEFAULT: SeverityLevel = SeverityLevel.MEDIUM
+_MAX_FIX_DISPLAY_LENGTH: int = 120
 
 
 def _should_expand_line(
@@ -78,13 +79,12 @@ def _render_line_card(console: Console, line_aggregate: LineAggregate) -> None:
         f"     [dim]{line_aggregate.finding_count} {finding_word}[/dim]  {pill}"
     )
 
-    preview = f"  {_PREVIEW_MARKER}  {escape_markup(line_aggregate.combined_code_context)}"
+    preview = f"  {_PREVIEW_MARKER}  {escape_markup(line_aggregate.display_context)}"
     type_chips = f"  types: {_build_type_chips(line_aggregate.category_counts)}"
 
     fix_text = line_aggregate.combined_fix
-    _max_fix_display_length = 120
-    if len(fix_text) > _max_fix_display_length:
-        fix_text = fix_text[:_max_fix_display_length] + "..."
+    if len(fix_text) > _MAX_FIX_DISPLAY_LENGTH:
+        fix_text = fix_text[:_MAX_FIX_DISPLAY_LENGTH] + "..."
     fix_line = f"  fix:   {escape_markup(fix_text)}"
 
     body = f"{header}\n\n{preview}\n{type_chips}\n{fix_line}"

--- a/phi_scan/report/v2/findings.py
+++ b/phi_scan/report/v2/findings.py
@@ -1,0 +1,156 @@
+"""V2 renderer: findings-by-line section with line cards grouped by file."""
+
+from __future__ import annotations
+
+from rich import box as rich_box
+from rich.console import Console
+from rich.markup import escape as escape_markup
+from rich.panel import Panel
+
+from phi_scan.constants import SEVERITY_RANK, SeverityLevel
+from phi_scan.report.v2.aggregation import build_line_title
+from phi_scan.report.v2.models import FileAggregate, LineAggregate
+
+_SECTION_HEADER_STYLE: str = "bold green"
+_SECTION_BAR_STYLE: str = "green"
+
+_SEVERITY_PILL_STYLE: dict[SeverityLevel, str] = {
+    SeverityLevel.HIGH: "reverse red",
+    SeverityLevel.MEDIUM: "reverse yellow",
+    SeverityLevel.LOW: "reverse green",
+    SeverityLevel.INFO: "reverse dim",
+}
+
+_SEVERITY_BORDER_STYLE: dict[SeverityLevel, str] = {
+    SeverityLevel.HIGH: "red",
+    SeverityLevel.MEDIUM: "yellow",
+    SeverityLevel.LOW: "green",
+    SeverityLevel.INFO: "dim",
+}
+
+_LINE_BADGE_STYLE: dict[SeverityLevel, str] = {
+    SeverityLevel.HIGH: "bold red",
+    SeverityLevel.MEDIUM: "bold yellow",
+    SeverityLevel.LOW: "bold green",
+    SeverityLevel.INFO: "dim",
+}
+
+_TYPE_CHIP_STYLE: str = "cyan"
+_PREVIEW_MARKER: str = "▸"
+_EXPAND_CUTOFF_DEFAULT: SeverityLevel = SeverityLevel.MEDIUM
+
+
+def _should_expand_line(
+    line_aggregate: LineAggregate,
+    expand_cutoff: SeverityLevel,
+    is_verbose: bool,
+) -> bool:
+    """Determine if a line card should be expanded or collapsed."""
+    if is_verbose:
+        return True
+    return SEVERITY_RANK[line_aggregate.highest_severity] >= SEVERITY_RANK[expand_cutoff]
+
+
+def _build_type_chips(category_counts: dict[str, int]) -> str:
+    """Build type chips like 'SSN · AGE_OVER_THRESHOLD ×2 · ZIP_CODE'."""
+    chips: list[str] = []
+    for entity_type, count in sorted(category_counts.items()):
+        if count > 1:
+            chips.append(f"[{_TYPE_CHIP_STYLE}]{entity_type} ×{count}[/{_TYPE_CHIP_STYLE}]")
+        else:
+            chips.append(f"[{_TYPE_CHIP_STYLE}]{entity_type}[/{_TYPE_CHIP_STYLE}]")
+    return "  ·  ".join(chips)
+
+
+def _render_line_card(console: Console, line_aggregate: LineAggregate) -> None:
+    """Render a single line card panel."""
+    severity = line_aggregate.highest_severity
+    badge_style = _LINE_BADGE_STYLE[severity]
+    border_style = _SEVERITY_BORDER_STYLE[severity]
+    pill_style = _SEVERITY_PILL_STYLE[severity]
+
+    title = build_line_title(line_aggregate)
+    finding_word = "finding" if line_aggregate.finding_count == 1 else "findings"
+    pill = f"[{pill_style}] {severity.value.upper()} [/{pill_style}]"
+    header = (
+        f"[{badge_style}] line {line_aggregate.line_number} [/{badge_style}]  "
+        f"[bold]{escape_markup(title)}[/bold]"
+        f"     [dim]{line_aggregate.finding_count} {finding_word}[/dim]  {pill}"
+    )
+
+    preview = f"  {_PREVIEW_MARKER}  {escape_markup(line_aggregate.combined_code_context)}"
+    type_chips = f"  types: {_build_type_chips(line_aggregate.category_counts)}"
+
+    fix_text = line_aggregate.combined_fix
+    _max_fix_display_length = 120
+    if len(fix_text) > _max_fix_display_length:
+        fix_text = fix_text[:_max_fix_display_length] + "..."
+    fix_line = f"  fix:   {escape_markup(fix_text)}"
+
+    body = f"{header}\n\n{preview}\n{type_chips}\n{fix_line}"
+
+    console.print(Panel(body, box=rich_box.ROUNDED, border_style=border_style, padding=(0, 1)))
+
+
+def render_findings_by_line(
+    console: Console,
+    file_aggregates: list[FileAggregate],
+    total_finding_count: int,
+    total_line_count: int,
+    severity_threshold: SeverityLevel,
+    is_verbose: bool,
+) -> None:
+    """Render the FINDINGS BY LINE section with file grouping."""
+    console.print()
+    console.print()
+    console.print(
+        f"[{_SECTION_BAR_STYLE}]▎[/{_SECTION_BAR_STYLE}] "
+        f"[{_SECTION_HEADER_STYLE}]FINDINGS BY LINE[/{_SECTION_HEADER_STYLE}]"
+    )
+    console.print(
+        f"[dim]{total_finding_count} findings collapsed into {total_line_count} unique lines[/dim]"
+    )
+    console.print()
+
+    collapsed_line_count = 0
+    collapsed_finding_count = 0
+    expanded_any = False
+
+    for file_agg in file_aggregates:
+        has_expanded_lines = False
+        for line_agg in file_agg.line_aggregates:
+            if _should_expand_line(line_agg, severity_threshold, is_verbose):
+                has_expanded_lines = True
+                break
+
+        if has_expanded_lines:
+            console.print(
+                f"[bold]{escape_markup(str(file_agg.file_path))}[/bold]  "
+                f"[dim]({file_agg.total_finding_count} findings)[/dim]"
+            )
+            console.print()
+
+        for line_agg in file_agg.line_aggregates:
+            if _should_expand_line(line_agg, severity_threshold, is_verbose):
+                _render_line_card(console, line_agg)
+                expanded_any = True
+            else:
+                collapsed_line_count += 1
+                collapsed_finding_count += line_agg.finding_count
+
+    if collapsed_line_count > 0 and not is_verbose:
+        console.print()
+        console.print(
+            Panel(
+                f"[bold]+ {collapsed_line_count} more lines[/bold]  ·  "
+                f"[dim]{collapsed_finding_count} low-severity findings collapsed.[/dim]\n"
+                "[dim]Re-run with [bold]--verbose[/bold] or "
+                "[bold]--severity-threshold low[/bold] to expand them.[/dim]",
+                box=rich_box.ROUNDED,
+                border_style="dim",
+                padding=(0, 1),
+            )
+        )
+
+    if not expanded_any and collapsed_line_count == 0:
+        console.print("[dim]No findings to display.[/dim]")

--- a/phi_scan/report/v2/footer.py
+++ b/phi_scan/report/v2/footer.py
@@ -1,0 +1,108 @@
+"""V2 renderer: scan-complete footer section."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rich import box as rich_box
+from rich.columns import Columns
+from rich.console import Console
+from rich.panel import Panel
+
+from phi_scan.constants import SeverityLevel
+from phi_scan.models import ScanResult
+
+_SECTION_HEADER_STYLE: str = "bold green"
+_SECTION_BAR_STYLE: str = "green"
+
+
+def _build_violation_left(scan_result: ScanResult, unique_action_count: int) -> str:
+    """Build the left column content for a violation scan-complete card."""
+    risk_label = scan_result.risk_level.value
+    total = len(scan_result.findings)
+    high = scan_result.severity_counts.get(SeverityLevel.HIGH, 0)
+    medium = scan_result.severity_counts.get(SeverityLevel.MEDIUM, 0)
+    low = scan_result.severity_counts.get(SeverityLevel.LOW, 0)
+    files_with = scan_result.files_with_findings
+    files_total = scan_result.files_scanned
+
+    return (
+        "[bold red]⚠ VIOLATION[/bold red]\n\n"
+        f"Risk level:  [bold red]{risk_label}[/bold red]\n\n"
+        f"Findings:    [bold]{total}[/bold]  ·  "
+        f"high {high}   medium {medium}   low {low}\n"
+        f"Files:       {files_with} of {files_total} contain PHI\n"
+        f"Actions:     {unique_action_count} unique remediations required\n"
+        f"Elapsed:     {scan_result.scan_duration:.2f} s"
+    )
+
+
+def _build_violation_right(report_path: Path | None) -> str:
+    """Build the right column content with next steps and exit code explanation."""
+    next_steps = "[bold]Next steps[/bold]\n\n"
+
+    if report_path is not None:
+        next_steps += f"  →  open   {report_path}\n"
+
+    next_steps += "  →  run    phi-scan fix --interactive\n  →  rerun  phi-scan scan . --verbose\n"
+
+    exit_panel = (
+        "\n[bold red]EXIT 1[/bold red]\n"
+        "[dim]Pipeline blocked until findings are\n"
+        "remediated or explicitly suppressed with\n"
+        "[bold yellow]# phi-scan:ignore[/bold yellow] comments.[/dim]"
+    )
+
+    return next_steps + exit_panel
+
+
+def _build_clean_left(scan_result: ScanResult) -> str:
+    """Build the left column content for a clean scan-complete card."""
+    return (
+        "[bold green]✓ CLEAN[/bold green]\n\n"
+        f"Files:       {scan_result.files_scanned} scanned\n"
+        f"Findings:    0\n"
+        f"Elapsed:     {scan_result.scan_duration:.2f} s"
+    )
+
+
+def _build_clean_right() -> str:
+    """Build the right column content for a clean scan."""
+    return "[bold]Next steps[/bold]\n\n  →  No action required.\n  →  Pipeline clear — exit code 0."
+
+
+def render_scan_complete(
+    console: Console,
+    scan_result: ScanResult,
+    unique_action_count: int,
+    report_path: Path | None,
+) -> None:
+    """Render the SCAN COMPLETE footer section."""
+    console.print()
+    console.print()
+    console.print(
+        f"[{_SECTION_BAR_STYLE}]▎[/{_SECTION_BAR_STYLE}] "
+        f"[{_SECTION_HEADER_STYLE}]SCAN COMPLETE[/{_SECTION_HEADER_STYLE}]"
+    )
+    console.print()
+
+    if scan_result.is_clean:
+        left_content = _build_clean_left(scan_result)
+        right_content = _build_clean_right()
+        border_style = "bold green"
+    else:
+        left_content = _build_violation_left(scan_result, unique_action_count)
+        right_content = _build_violation_right(report_path)
+        border_style = "bold red"
+
+    left_panel = Panel(left_content, box=rich_box.ROUNDED, expand=True, padding=(1, 2))
+    right_panel = Panel(right_content, box=rich_box.ROUNDED, expand=True, padding=(1, 2))
+
+    console.print(
+        Panel(
+            Columns([left_panel, right_panel], equal=True, expand=True),
+            box=rich_box.ROUNDED,
+            border_style=border_style,
+            padding=(0, 0),
+        )
+    )

--- a/phi_scan/report/v2/models.py
+++ b/phi_scan/report/v2/models.py
@@ -1,0 +1,58 @@
+"""Aggregation dataclasses for the v2 terminal report renderer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from phi_scan.constants import SEVERITY_RANK, PhiCategory, SeverityLevel
+from phi_scan.models import ScanFinding
+
+
+@dataclass(frozen=True)
+class LineAggregate:
+    """All findings on a single (file_path, line_number)."""
+
+    file_path: Path
+    line_number: int
+    findings: tuple[ScanFinding, ...]
+    highest_severity: SeverityLevel
+    category_counts: dict[str, int]
+    combined_code_context: str
+    combined_fix: str
+
+    @property
+    def finding_count(self) -> int:
+        return len(self.findings)
+
+    @property
+    def severity_rank(self) -> int:
+        return SEVERITY_RANK[self.highest_severity]
+
+
+@dataclass(frozen=True)
+class RemediationAction:
+    """Findings grouped by unique remediation_hint string."""
+
+    remediation_hint: str
+    title: str
+    hipaa_category: PhiCategory
+    finding_count: int
+    highest_severity: SeverityLevel
+    mean_confidence: float
+    affected_lines: tuple[tuple[Path, int], ...]
+    severity_weight_score: float
+
+    @property
+    def severity_rank(self) -> int:
+        return SEVERITY_RANK[self.highest_severity]
+
+
+@dataclass(frozen=True)
+class FileAggregate:
+    """All line aggregates for a single file, sorted by severity/count/line."""
+
+    file_path: Path
+    line_aggregates: tuple[LineAggregate, ...]
+    total_finding_count: int
+    highest_severity: SeverityLevel

--- a/phi_scan/report/v2/models.py
+++ b/phi_scan/report/v2/models.py
@@ -11,14 +11,20 @@ from phi_scan.models import ScanFinding
 
 @dataclass(frozen=True)
 class LineAggregate:
-    """All findings on a single (file_path, line_number)."""
+    """All findings on a single (file_path, line_number).
+
+    ``display_context`` holds the pre-redacted code context from the first
+    finding on this line.  ScanFinding enforces at construction time that
+    ``code_context`` always contains ``[REDACTED]`` in place of the matched
+    PHI value, so ``display_context`` is safe for terminal rendering.
+    """
 
     file_path: Path
     line_number: int
     findings: tuple[ScanFinding, ...]
     highest_severity: SeverityLevel
     category_counts: dict[str, int]
-    combined_code_context: str
+    display_context: str
     combined_fix: str
 
     @property

--- a/phi_scan/report/v2/overview.py
+++ b/phi_scan/report/v2/overview.py
@@ -1,0 +1,263 @@
+"""V2 renderer: executive summary section (title strip, status banner, stats, top actions, bars)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from rich import box as rich_box
+from rich.columns import Columns
+from rich.console import Console
+from rich.markup import escape as escape_markup
+from rich.panel import Panel
+
+from phi_scan import __version__
+from phi_scan.constants import SeverityLevel
+from phi_scan.models import ScanResult
+from phi_scan.report.v2.aggregation import (
+    compute_category_severity_distribution,
+    compute_hotspot_count,
+    group_by_line,
+    rank_top_actions,
+)
+from phi_scan.report.v2.models import LineAggregate, RemediationAction
+
+_TITLE_TEMPLATE: str = (
+    "[bold]phi-scan[/bold] v{version}   PHI / PII Scanner  ·  HIPAA Safe-Harbor aligned"
+)
+_TIMESTAMP_FORMAT: str = "%Y-%m-%d  %H:%M:%S"
+
+_STATUS_VIOLATION: str = "VIOLATION"
+_STATUS_CLEAN: str = "CLEAN"
+_VIOLATION_SUBTITLE_TEMPLATE: str = "Pipeline blocked — {risk} risk level, exit code 1"
+_CLEAN_SUBTITLE: str = "No PHI/PII detected. Pipeline clear."
+
+_STAT_FINDINGS: str = "FINDINGS"
+_STAT_HIGH: str = "HIGH"
+_STAT_MEDIUM: str = "MEDIUM"
+_STAT_LOW: str = "LOW"
+_STAT_HOTSPOTS: str = "HOTSPOTS"
+
+_BAR_FILLED: str = "█"
+_BAR_MAX_WIDTH: int = 40
+_BAR_DENOMINATOR_FLOOR: int = 1
+
+_SEVERITY_BAR_COLORS: dict[SeverityLevel, str] = {
+    SeverityLevel.HIGH: "red",
+    SeverityLevel.MEDIUM: "yellow",
+    SeverityLevel.LOW: "green",
+    SeverityLevel.INFO: "dim",
+}
+
+_SEVERITY_PILL_STYLE: dict[SeverityLevel, str] = {
+    SeverityLevel.HIGH: "reverse red",
+    SeverityLevel.MEDIUM: "reverse yellow",
+    SeverityLevel.LOW: "reverse green",
+    SeverityLevel.INFO: "reverse dim",
+}
+
+_SECTION_HEADER_STYLE: str = "bold green"
+_SECTION_BAR_STYLE: str = "green"
+
+
+def render_title_strip(console: Console, scan_target: str) -> None:
+    """Print the compact one-line title strip with version and timestamp."""
+    timestamp = datetime.now(tz=UTC).strftime(_TIMESTAMP_FORMAT)
+    title = _TITLE_TEMPLATE.format(version=__version__)
+    console.print(f"{title}   [dim]{timestamp}[/dim]")
+    console.print()
+
+
+def render_status_banner(
+    console: Console,
+    scan_result: ScanResult,
+    scan_target: str,
+) -> None:
+    """Print the full-width status banner (violation or clean)."""
+    if scan_result.is_clean:
+        right_meta = (
+            f"Target: [bold]{escape_markup(scan_target)}[/bold]\n"
+            f"Elapsed: [bold]{scan_result.scan_duration:.2f} s[/bold]"
+            f"  ·  {scan_result.files_scanned} file(s)"
+        )
+        clean_body = (
+            f"  [bold green]✓ {_STATUS_CLEAN}[/bold green]\n"
+            f"  [green]{_CLEAN_SUBTITLE}[/green]\n\n  {right_meta}"
+        )
+        console.print(
+            Panel(
+                clean_body,
+                box=rich_box.ROUNDED,
+                border_style="bold green",
+                expand=True,
+            )
+        )
+        return
+
+    risk_label = scan_result.risk_level.value
+    subtitle = _VIOLATION_SUBTITLE_TEMPLATE.format(risk=risk_label)
+    right_meta = (
+        f"Target: [bold]{escape_markup(scan_target)}[/bold]\n"
+        f"Elapsed: [bold]{scan_result.scan_duration:.2f} s[/bold]  ·  "
+        f"{scan_result.files_scanned} file(s)"
+    )
+
+    left_text = f"  [bold red]⚠ {_STATUS_VIOLATION}[/bold red]\n  [dim]{subtitle}[/dim]"
+    content = f"{left_text}\n\n  {right_meta}"
+
+    console.print(
+        Panel(
+            content,
+            box=rich_box.ROUNDED,
+            border_style="bold red",
+            expand=True,
+        )
+    )
+
+
+def _render_stat_tile(label: str, value: int, color: str, subtitle: str = "") -> Panel:
+    """Build a single stat tile panel."""
+    value_text = f"[{color}]{value}[/{color}]"
+    body = f"[dim]{label}[/dim]\n[bold]{value_text}[/bold]"
+    if subtitle:
+        body += f"\n[dim]{subtitle}[/dim]"
+    return Panel(body, box=rich_box.ROUNDED, expand=True, padding=(0, 1))
+
+
+def render_stat_tiles(
+    console: Console,
+    scan_result: ScanResult,
+    line_aggregates: list[LineAggregate],
+) -> None:
+    """Print the five stat tiles (findings, high, medium, low, hotspots)."""
+    total = len(scan_result.findings)
+    high = scan_result.severity_counts.get(SeverityLevel.HIGH, 0)
+    medium = scan_result.severity_counts.get(SeverityLevel.MEDIUM, 0)
+    low = scan_result.severity_counts.get(SeverityLevel.LOW, 0)
+    hotspots = compute_hotspot_count(line_aggregates)
+
+    file_count = scan_result.files_with_findings
+    file_label = "file" if file_count == 1 else "files"
+
+    tiles = [
+        _render_stat_tile(_STAT_FINDINGS, total, "white", f"across {file_count} {file_label}"),
+        _render_stat_tile(_STAT_HIGH, high, "red"),
+        _render_stat_tile(_STAT_MEDIUM, medium, "yellow"),
+        _render_stat_tile(_STAT_LOW, low, "green"),
+        _render_stat_tile(_STAT_HOTSPOTS, hotspots, "magenta", "— unique PHI hotspot lines —"),
+    ]
+    console.print(Columns(tiles, equal=True, expand=True))
+
+
+def render_top_actions(
+    console: Console,
+    top_actions: list[RemediationAction],
+) -> None:
+    """Print the TOP ACTIONS section — numbered remediation priorities."""
+    console.print()
+    console.print(
+        f"[{_SECTION_BAR_STYLE}]▎[/{_SECTION_BAR_STYLE}] "
+        f"[{_SECTION_HEADER_STYLE}]TOP ACTIONS[/{_SECTION_HEADER_STYLE}]"
+        "    [dim]ranked by residual risk if ignored[/dim]"
+    )
+    console.print()
+
+    for index, action in enumerate(top_actions, start=1):
+        pill_style = _SEVERITY_PILL_STYLE[action.highest_severity]
+        pill = f"[{pill_style}] {action.highest_severity.value.upper()} [/{pill_style}]"
+
+        lines_str = _format_affected_lines_compact(action.affected_lines)
+        title_with_count = action.title
+        if action.finding_count > 1:
+            title_with_count = f"{action.title}"
+
+        body = (
+            f" [{index}]  [bold]{escape_markup(title_with_count)}[/bold]"
+            f"     {pill}\n      [dim]{lines_str}[/dim]"
+        )
+        console.print(Panel(body, box=rich_box.ROUNDED, padding=(0, 1)))
+
+
+def _format_affected_lines_compact(
+    affected_lines: tuple[tuple[Path, int], ...],
+) -> str:
+    """Format affected lines as a compact string like 'lines 7, 24, 40, 54'."""
+    _max_displayed_lines = 8
+    line_numbers = [pair[1] for pair in affected_lines]
+    if len(line_numbers) <= _max_displayed_lines:
+        return "lines " + ", ".join(str(ln) for ln in line_numbers)
+    shown = ", ".join(str(ln) for ln in line_numbers[:_max_displayed_lines])
+    remaining = len(line_numbers) - _max_displayed_lines
+    return f"lines {shown} (+{remaining} more)"
+
+
+def render_category_breakdown(
+    console: Console,
+    scan_result: ScanResult,
+) -> None:
+    """Print the CATEGORY BREAKDOWN section with severity-segmented bars."""
+    console.print()
+    console.print(
+        f"[{_SECTION_BAR_STYLE}]▎[/{_SECTION_BAR_STYLE}] "
+        f"[{_SECTION_HEADER_STYLE}]CATEGORY BREAKDOWN[/{_SECTION_HEADER_STYLE}]"
+    )
+    console.print()
+
+    distribution = compute_category_severity_distribution(scan_result.findings)
+    category_totals: list[tuple[str, int, dict[SeverityLevel, int]]] = []
+    for category_name, sev_dist in distribution.items():
+        total = sum(sev_dist.values())
+        category_totals.append((category_name, total, sev_dist))
+
+    category_totals.sort(key=lambda ct: -ct[1])
+
+    max_count = max((ct[1] for ct in category_totals), default=_BAR_DENOMINATOR_FLOOR)
+    max_count = max(max_count, _BAR_DENOMINATOR_FLOOR)
+
+    _name_col_width = 16
+    _count_col_width = 5
+
+    for category_name, total, sev_dist in category_totals:
+        bar_width = round(total / max_count * _BAR_MAX_WIDTH)
+        bar_width = max(bar_width, 1)
+
+        bar_parts: list[str] = []
+        severity_order = (
+            SeverityLevel.HIGH,
+            SeverityLevel.MEDIUM,
+            SeverityLevel.LOW,
+            SeverityLevel.INFO,
+        )
+        for severity in severity_order:
+            sev_count = sev_dist.get(severity, 0)
+            if sev_count > 0:
+                segment_width = max(round(sev_count / total * bar_width), 1)
+                color = _SEVERITY_BAR_COLORS[severity]
+                bar_parts.append(f"[{color}]{_BAR_FILLED * segment_width}[/{color}]")
+
+        bar_str = "".join(bar_parts)
+        name_padded = category_name.ljust(_name_col_width)
+        count_padded = str(total).rjust(_count_col_width)
+
+        console.print(f"  {name_padded}{count_padded}  {bar_str}")
+
+
+def render_overview(
+    console: Console,
+    scan_result: ScanResult,
+    scan_target: str,
+    all_actions: list[RemediationAction],
+) -> None:
+    """Compose and render the full overview section."""
+    line_aggregates = group_by_line(scan_result.findings)
+
+    render_title_strip(console, scan_target)
+    render_status_banner(console, scan_result, scan_target)
+    console.print()
+
+    if not scan_result.is_clean:
+        render_stat_tiles(console, scan_result, line_aggregates)
+        top_actions = rank_top_actions(all_actions)
+        if top_actions:
+            render_top_actions(console, top_actions)
+        render_category_breakdown(console, scan_result)

--- a/phi_scan/report/v2/playbook.py
+++ b/phi_scan/report/v2/playbook.py
@@ -1,0 +1,172 @@
+"""V2 renderer: deduplicated remediation playbook section."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rich import box as rich_box
+from rich.console import Console
+from rich.markup import escape as escape_markup
+from rich.panel import Panel
+
+from phi_scan.constants import SeverityLevel
+from phi_scan.report.v2.models import RemediationAction
+
+_SECTION_HEADER_STYLE: str = "bold green"
+_SECTION_BAR_STYLE: str = "green"
+
+_SEVERITY_PILL_STYLE: dict[SeverityLevel, str] = {
+    SeverityLevel.HIGH: "reverse red",
+    SeverityLevel.MEDIUM: "reverse yellow",
+    SeverityLevel.LOW: "reverse green",
+    SeverityLevel.INFO: "reverse dim",
+}
+
+_SEVERITY_BORDER_STYLE: dict[SeverityLevel, str] = {
+    SeverityLevel.HIGH: "red",
+    SeverityLevel.MEDIUM: "yellow",
+    SeverityLevel.LOW: "green",
+    SeverityLevel.INFO: "dim",
+}
+
+_CONFIDENCE_DOT_FILLED: str = "●"
+_CONFIDENCE_DOT_EMPTY: str = "○"
+_CONFIDENCE_DOT_COUNT: int = 5
+
+_MAX_DISPLAYED_LINES: int = 12
+
+
+def _render_confidence_dots(mean_confidence: float) -> str:
+    """Render mean confidence as a 5-dot scale."""
+    filled_count = round(mean_confidence * _CONFIDENCE_DOT_COUNT)
+    filled_count = max(0, min(_CONFIDENCE_DOT_COUNT, filled_count))
+    empty_count = _CONFIDENCE_DOT_COUNT - filled_count
+    return _CONFIDENCE_DOT_FILLED * filled_count + _CONFIDENCE_DOT_EMPTY * empty_count
+
+
+def _format_lines_compact(affected_lines: tuple[tuple[Path, int], ...]) -> str:
+    """Format affected lines with range compression for consecutive lines."""
+    if not affected_lines:
+        return ""
+
+    line_numbers = sorted(pair[1] for pair in affected_lines)
+
+    if len(line_numbers) <= _MAX_DISPLAYED_LINES:
+        ranges = _compress_line_ranges(line_numbers)
+        parts: list[str] = []
+        for start, end in ranges:
+            if start == end:
+                parts.append(f"line {start}")
+            else:
+                parts.append(f"lines {start}–{end}")
+        return "  ·  ".join(parts)
+
+    shown = line_numbers[:_MAX_DISPLAYED_LINES]
+    ranges = _compress_line_ranges(shown)
+    parts = []
+    for start, end in ranges:
+        if start == end:
+            parts.append(str(start))
+        else:
+            parts.append(f"{start}–{end}")
+    remaining = len(line_numbers) - _MAX_DISPLAYED_LINES
+    return "lines " + ", ".join(parts) + f" (+{remaining} more)"
+
+
+def _compress_line_ranges(line_numbers: list[int]) -> list[tuple[int, int]]:
+    """Compress consecutive line numbers into (start, end) ranges."""
+    if not line_numbers:
+        return []
+
+    ranges: list[tuple[int, int]] = []
+    start = line_numbers[0]
+    end = start
+
+    for line_number in line_numbers[1:]:
+        if line_number == end + 1:
+            end = line_number
+        else:
+            ranges.append((start, end))
+            start = line_number
+            end = line_number
+
+    ranges.append((start, end))
+    return ranges
+
+
+def _render_action_card(
+    console: Console,
+    action: RemediationAction,
+    index: int,
+) -> None:
+    """Render a single remediation action card."""
+    border_style = _SEVERITY_BORDER_STYLE[action.highest_severity]
+    pill_style = _SEVERITY_PILL_STYLE[action.highest_severity]
+    pill = f"[{pill_style}] {action.highest_severity.value.upper()} [/{pill_style}]"
+    dots = _render_confidence_dots(action.mean_confidence)
+
+    lines_str = _format_lines_compact(action.affected_lines)
+
+    finding_word = "findings" if action.finding_count != 1 else "finding"
+    count_label = f"[bold]{action.finding_count}[/bold] {finding_word}"
+
+    body = (
+        f" ({index})  [bold]{escape_markup(action.title)}[/bold]"
+        f"     {count_label}  {pill}\n"
+        f"      [dim]{escape_markup(action.remediation_hint[:100])}[/dim]\n"
+        f"      [dim]{lines_str}[/dim]\n"
+        f"      {dots}"
+    )
+
+    console.print(Panel(body, box=rich_box.ROUNDED, border_style=border_style, padding=(0, 1)))
+
+
+def render_remediation_playbook(
+    console: Console,
+    actions: list[RemediationAction],
+    total_finding_count: int,
+    report_path: Path | None,
+) -> None:
+    """Render the REMEDIATION PLAYBOOK section."""
+    console.print()
+    console.print()
+    console.print(
+        f"[{_SECTION_BAR_STYLE}]▎[/{_SECTION_BAR_STYLE}] "
+        f"[{_SECTION_HEADER_STYLE}]REMEDIATION PLAYBOOK[/{_SECTION_HEADER_STYLE}]"
+    )
+    action_word = "action" if len(actions) == 1 else "actions"
+    console.print(
+        f"[dim]{len(actions)} unique {action_word} resolve all "
+        f"{total_finding_count} findings. Each action shown once.[/dim]"
+    )
+    console.print()
+
+    for index, action in enumerate(actions, start=1):
+        _render_action_card(console, action, index)
+
+    _render_full_report_footer(console, report_path)
+
+
+def _render_full_report_footer(console: Console, report_path: Path | None) -> None:
+    """Render the FULL REPORT footer with actual or suggested report paths."""
+    console.print()
+
+    if report_path is not None:
+        body = f"[bold]FULL REPORT[/bold]\n  {escape_markup(str(report_path))}"
+    else:
+        body = (
+            "[bold]FULL REPORT[/bold]\n"
+            "  [dim]Generate full reports with:[/dim]\n"
+            "  [dim]  phi-scan scan . --output json --report-path report.json[/dim]\n"
+            "  [dim]  phi-scan scan . --output html --report-path report.html[/dim]\n"
+            "  [dim]  phi-scan scan . --output sarif --report-path report.sarif[/dim]"
+        )
+
+    console.print(
+        Panel(
+            body,
+            box=rich_box.ROUNDED,
+            border_style="dim",
+            padding=(0, 1),
+        )
+    )

--- a/phi_scan/report/v2/playbook.py
+++ b/phi_scan/report/v2/playbook.py
@@ -34,6 +34,7 @@ _CONFIDENCE_DOT_EMPTY: str = "○"
 _CONFIDENCE_DOT_COUNT: int = 5
 
 _MAX_DISPLAYED_LINES: int = 12
+_MAX_HINT_DISPLAY_LENGTH: int = 100
 
 
 def _render_confidence_dots(mean_confidence: float) -> str:
@@ -113,7 +114,7 @@ def _render_action_card(
     body = (
         f" ({index})  [bold]{escape_markup(action.title)}[/bold]"
         f"     {count_label}  {pill}\n"
-        f"      [dim]{escape_markup(action.remediation_hint[:100])}[/dim]\n"
+        f"      [dim]{escape_markup(action.remediation_hint[:_MAX_HINT_DISPLAY_LENGTH])}[/dim]\n"
         f"      [dim]{lines_str}[/dim]\n"
         f"      {dots}"
     )

--- a/tests/test_report_v2_aggregation.py
+++ b/tests/test_report_v2_aggregation.py
@@ -1,0 +1,287 @@
+"""Tests for the v2 report aggregation layer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import MappingProxyType
+
+from phi_scan.constants import PhiCategory, RiskLevel, SeverityLevel
+from phi_scan.models import ScanFinding, ScanResult
+from phi_scan.report.v2.aggregation import (
+    build_line_title,
+    compute_category_severity_distribution,
+    compute_hotspot_count,
+    dedupe_remediations,
+    group_by_file,
+    group_by_line,
+    rank_top_actions,
+)
+
+_HASH_PLACEHOLDER: str = "a" * 64
+
+
+def _make_finding(
+    file_path: str = "test.py",
+    line_number: int = 1,
+    entity_type: str = "SSN",
+    hipaa_category: PhiCategory = PhiCategory.SSN,
+    confidence: float = 0.9,
+    severity: SeverityLevel = SeverityLevel.HIGH,
+    remediation_hint: str = "Remove SSN",
+    code_context: str = "SSN: [REDACTED]",
+) -> ScanFinding:
+    return ScanFinding(
+        file_path=Path(file_path),
+        line_number=line_number,
+        entity_type=entity_type,
+        hipaa_category=hipaa_category,
+        confidence=confidence,
+        detection_layer="regex",
+        value_hash=_HASH_PLACEHOLDER,
+        severity=severity,
+        code_context=code_context,
+        remediation_hint=remediation_hint,
+    )
+
+
+def _make_scan_result(findings: list[ScanFinding]) -> ScanResult:
+    severity_counts: dict[SeverityLevel, int] = {}
+    category_counts: dict[PhiCategory, int] = {}
+    for finding in findings:
+        severity_counts[finding.severity] = severity_counts.get(finding.severity, 0) + 1
+        category_counts[finding.hipaa_category] = category_counts.get(finding.hipaa_category, 0) + 1
+    is_clean = len(findings) == 0
+    return ScanResult(
+        findings=tuple(findings),
+        files_scanned=1,
+        files_with_findings=0 if is_clean else 1,
+        scan_duration=0.05,
+        is_clean=is_clean,
+        risk_level=RiskLevel.CLEAN if is_clean else RiskLevel.CRITICAL,
+        severity_counts=MappingProxyType(severity_counts),
+        category_counts=MappingProxyType(category_counts),
+    )
+
+
+class TestGroupByLine:
+    def test_groups_findings_on_same_line(self) -> None:
+        findings = (
+            _make_finding(line_number=1, entity_type="SSN"),
+            _make_finding(line_number=1, entity_type="DATE", hipaa_category=PhiCategory.DATE),
+            _make_finding(line_number=2, entity_type="EMAIL", hipaa_category=PhiCategory.EMAIL),
+        )
+        aggregates = group_by_line(findings)
+        assert len(aggregates) == 2
+        line_1 = [a for a in aggregates if a.line_number == 1][0]
+        assert line_1.finding_count == 2
+        assert "SSN" in line_1.category_counts
+        assert "DATE" in line_1.category_counts
+
+    def test_highest_severity_is_correct(self) -> None:
+        findings = (
+            _make_finding(line_number=1, severity=SeverityLevel.LOW),
+            _make_finding(line_number=1, severity=SeverityLevel.HIGH),
+        )
+        aggregates = group_by_line(findings)
+        assert aggregates[0].highest_severity == SeverityLevel.HIGH
+
+    def test_category_counts_track_duplicates(self) -> None:
+        findings = (
+            _make_finding(line_number=1, entity_type="ACCOUNT_NUMBER"),
+            _make_finding(line_number=1, entity_type="ACCOUNT_NUMBER"),
+            _make_finding(line_number=1, entity_type="SSN"),
+        )
+        aggregates = group_by_line(findings)
+        assert aggregates[0].category_counts["ACCOUNT_NUMBER"] == 2
+        assert aggregates[0].category_counts["SSN"] == 1
+
+    def test_combined_fix_deduplicates(self) -> None:
+        findings = (
+            _make_finding(line_number=1, remediation_hint="Fix A"),
+            _make_finding(line_number=1, remediation_hint="Fix A"),
+            _make_finding(line_number=1, remediation_hint="Fix B"),
+        )
+        aggregates = group_by_line(findings)
+        assert aggregates[0].combined_fix == "Fix A; Fix B"
+
+
+class TestGroupByFile:
+    def test_groups_by_file_path(self) -> None:
+        findings = (
+            _make_finding(file_path="a.py", line_number=1),
+            _make_finding(file_path="a.py", line_number=2),
+            _make_finding(file_path="b.py", line_number=1),
+        )
+        line_aggregates = group_by_line(findings)
+        file_aggregates = group_by_file(line_aggregates)
+        assert len(file_aggregates) == 2
+        assert file_aggregates[0].file_path == Path("a.py")
+        assert file_aggregates[1].file_path == Path("b.py")
+
+    def test_lines_sorted_by_severity_then_count_then_line(self) -> None:
+        findings = (
+            _make_finding(file_path="a.py", line_number=10, severity=SeverityLevel.LOW),
+            _make_finding(file_path="a.py", line_number=5, severity=SeverityLevel.HIGH),
+            _make_finding(file_path="a.py", line_number=1, severity=SeverityLevel.HIGH),
+            _make_finding(file_path="a.py", line_number=1, severity=SeverityLevel.HIGH),
+        )
+        line_aggregates = group_by_line(findings)
+        file_aggregates = group_by_file(line_aggregates)
+        lines = file_aggregates[0].line_aggregates
+        assert lines[0].line_number == 1
+        assert lines[1].line_number == 5
+        assert lines[2].line_number == 10
+
+
+class TestDedupeRemediations:
+    def test_groups_by_remediation_hint(self) -> None:
+        findings = (
+            _make_finding(line_number=1, remediation_hint="Remove SSN"),
+            _make_finding(line_number=2, remediation_hint="Remove SSN"),
+            _make_finding(line_number=3, remediation_hint="Fix dates"),
+        )
+        actions = dedupe_remediations(findings)
+        assert len(actions) == 2
+        ssn_action = [a for a in actions if a.remediation_hint == "Remove SSN"][0]
+        assert ssn_action.finding_count == 2
+
+    def test_no_duplicate_remediation_strings(self) -> None:
+        findings = (
+            _make_finding(remediation_hint="Hint A"),
+            _make_finding(remediation_hint="Hint A"),
+            _make_finding(remediation_hint="Hint B"),
+            _make_finding(remediation_hint="Hint B"),
+            _make_finding(remediation_hint="Hint C"),
+        )
+        actions = dedupe_remediations(findings)
+        hints = [a.remediation_hint for a in actions]
+        assert len(hints) == len(set(hints))
+
+    def test_sorted_by_severity_then_count(self) -> None:
+        findings = (
+            _make_finding(line_number=1, severity=SeverityLevel.LOW, remediation_hint="Low fix"),
+            _make_finding(line_number=2, severity=SeverityLevel.HIGH, remediation_hint="High fix"),
+        )
+        actions = dedupe_remediations(findings)
+        assert actions[0].remediation_hint == "High fix"
+        assert actions[1].remediation_hint == "Low fix"
+
+    def test_mean_confidence(self) -> None:
+        findings = (
+            _make_finding(confidence=0.8, remediation_hint="Fix"),
+            _make_finding(confidence=0.6, remediation_hint="Fix"),
+        )
+        actions = dedupe_remediations(findings)
+        assert abs(actions[0].mean_confidence - 0.7) < 0.001
+
+    def test_affected_lines_deduplicated(self) -> None:
+        findings = (
+            _make_finding(line_number=1, remediation_hint="Fix"),
+            _make_finding(line_number=1, remediation_hint="Fix"),
+            _make_finding(line_number=2, remediation_hint="Fix"),
+        )
+        actions = dedupe_remediations(findings)
+        assert len(actions[0].affected_lines) == 2
+
+
+class TestRankTopActions:
+    def test_returns_top_5(self) -> None:
+        findings = tuple(
+            _make_finding(remediation_hint=f"Fix {i}", line_number=i) for i in range(1, 8)
+        )
+        actions = dedupe_remediations(findings)
+        top = rank_top_actions(actions)
+        assert len(top) <= 5
+
+    def test_ranked_by_severity_weight_score(self) -> None:
+        findings = (
+            _make_finding(
+                line_number=1,
+                severity=SeverityLevel.HIGH,
+                remediation_hint="High",
+            ),
+            _make_finding(
+                line_number=2,
+                severity=SeverityLevel.LOW,
+                remediation_hint="Low 1",
+            ),
+            _make_finding(
+                line_number=3,
+                severity=SeverityLevel.LOW,
+                remediation_hint="Low 2",
+            ),
+        )
+        actions = dedupe_remediations(findings)
+        top = rank_top_actions(actions)
+        assert top[0].remediation_hint == "High"
+
+
+class TestHotspotCount:
+    def test_counts_lines_with_multiple_categories(self) -> None:
+        findings = (
+            _make_finding(line_number=1, entity_type="SSN"),
+            _make_finding(
+                line_number=1,
+                entity_type="DATE",
+                hipaa_category=PhiCategory.DATE,
+            ),
+            _make_finding(line_number=2, entity_type="SSN"),
+        )
+        aggregates = group_by_line(findings)
+        assert compute_hotspot_count(aggregates) == 1
+
+
+class TestCategorySeverityDistribution:
+    def test_builds_per_category_distribution(self) -> None:
+        findings = (
+            _make_finding(hipaa_category=PhiCategory.SSN, severity=SeverityLevel.HIGH),
+            _make_finding(hipaa_category=PhiCategory.SSN, severity=SeverityLevel.MEDIUM),
+            _make_finding(hipaa_category=PhiCategory.EMAIL, severity=SeverityLevel.LOW),
+        )
+        distribution = compute_category_severity_distribution(findings)
+        assert distribution["ssn"][SeverityLevel.HIGH] == 1
+        assert distribution["ssn"][SeverityLevel.MEDIUM] == 1
+        assert distribution["email"][SeverityLevel.LOW] == 1
+
+
+class TestBuildLineTitle:
+    def test_sweeney_risk_title(self) -> None:
+        findings = (
+            _make_finding(
+                line_number=1,
+                entity_type="DATE",
+                hipaa_category=PhiCategory.DATE,
+            ),
+            _make_finding(
+                line_number=1,
+                entity_type="GEOGRAPHIC",
+                hipaa_category=PhiCategory.GEOGRAPHIC,
+            ),
+            _make_finding(
+                line_number=1,
+                entity_type="AGE_OVER_THRESHOLD",
+                hipaa_category=PhiCategory.UNIQUE_ID,
+            ),
+        )
+        aggregates = group_by_line(findings)
+        title = build_line_title(aggregates[0])
+        assert "Sweeney" in title
+
+    def test_ssn_title(self) -> None:
+        findings = (_make_finding(line_number=1, entity_type="SSN"),)
+        aggregates = group_by_line(findings)
+        title = build_line_title(aggregates[0])
+        assert "Social Security" in title
+
+    def test_cluster_title_for_many_categories(self) -> None:
+        findings = tuple(
+            _make_finding(
+                line_number=1,
+                entity_type=f"TYPE_{i}",
+                hipaa_category=PhiCategory.UNIQUE_ID,
+            )
+            for i in range(6)
+        )
+        aggregates = group_by_line(findings)
+        title = build_line_title(aggregates[0])
+        assert "cluster" in title.lower()

--- a/tests/test_report_v2_renderer.py
+++ b/tests/test_report_v2_renderer.py
@@ -1,0 +1,208 @@
+"""Tests for the v2 terminal report renderer structure and output."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import MappingProxyType
+
+from rich.console import Console
+
+from phi_scan.constants import PhiCategory, RiskLevel, SeverityLevel
+from phi_scan.models import ScanFinding, ScanResult
+from phi_scan.report.v2.console import display_rich_scan_results_v2
+
+_HASH_PLACEHOLDER: str = "a" * 64
+
+_EXPECTED_SECTIONS_VIOLATION: list[str] = [
+    "phi-scan",
+    "VIOLATION",
+    "FINDINGS",
+    "TOP ACTIONS",
+    "CATEGORY BREAKDOWN",
+    "FINDINGS BY LINE",
+    "REMEDIATION PLAYBOOK",
+    "SCAN COMPLETE",
+]
+
+_EXPECTED_SECTIONS_CLEAN: list[str] = [
+    "phi-scan",
+    "CLEAN",
+    "SCAN COMPLETE",
+]
+
+
+def _make_finding(
+    file_path: str = "test.py",
+    line_number: int = 1,
+    entity_type: str = "SSN",
+    hipaa_category: PhiCategory = PhiCategory.SSN,
+    confidence: float = 0.9,
+    severity: SeverityLevel = SeverityLevel.HIGH,
+    remediation_hint: str = "Remove SSN immediately.",
+    code_context: str = "SSN: [REDACTED]",
+) -> ScanFinding:
+    return ScanFinding(
+        file_path=Path(file_path),
+        line_number=line_number,
+        entity_type=entity_type,
+        hipaa_category=hipaa_category,
+        confidence=confidence,
+        detection_layer="regex",
+        value_hash=_HASH_PLACEHOLDER,
+        severity=severity,
+        code_context=code_context,
+        remediation_hint=remediation_hint,
+    )
+
+
+def _make_violation_result() -> ScanResult:
+    findings = [
+        _make_finding(line_number=1, severity=SeverityLevel.HIGH),
+        _make_finding(
+            line_number=1,
+            entity_type="DATE",
+            hipaa_category=PhiCategory.DATE,
+            severity=SeverityLevel.HIGH,
+            remediation_hint="Replace dates with year only.",
+            code_context="DOB: [REDACTED]",
+        ),
+        _make_finding(
+            line_number=2,
+            entity_type="EMAIL",
+            hipaa_category=PhiCategory.EMAIL,
+            severity=SeverityLevel.MEDIUM,
+            remediation_hint="Fake email addresses.",
+            code_context="email: [REDACTED]",
+        ),
+        _make_finding(
+            line_number=3,
+            entity_type="ACCOUNT_NUMBER",
+            hipaa_category=PhiCategory.ACCOUNT,
+            severity=SeverityLevel.LOW,
+            remediation_hint="Replace account numbers.",
+            code_context="acct: [REDACTED]",
+        ),
+    ]
+    return ScanResult(
+        findings=tuple(findings),
+        files_scanned=1,
+        files_with_findings=1,
+        scan_duration=0.05,
+        is_clean=False,
+        risk_level=RiskLevel.CRITICAL,
+        severity_counts=MappingProxyType(
+            {
+                SeverityLevel.HIGH: 2,
+                SeverityLevel.MEDIUM: 1,
+                SeverityLevel.LOW: 1,
+            }
+        ),
+        category_counts=MappingProxyType(
+            {
+                PhiCategory.SSN: 1,
+                PhiCategory.DATE: 1,
+                PhiCategory.EMAIL: 1,
+                PhiCategory.ACCOUNT: 1,
+            }
+        ),
+    )
+
+
+def _make_clean_result() -> ScanResult:
+    return ScanResult(
+        findings=(),
+        files_scanned=5,
+        files_with_findings=0,
+        scan_duration=0.02,
+        is_clean=True,
+        risk_level=RiskLevel.CLEAN,
+        severity_counts=MappingProxyType({}),
+        category_counts=MappingProxyType({}),
+    )
+
+
+def _capture_v2_output(
+    scan_result: ScanResult,
+    is_verbose: bool = False,
+    severity_threshold: SeverityLevel = SeverityLevel.LOW,
+) -> str:
+    console = Console(record=True, width=120, force_terminal=True)
+    from phi_scan.report.v2 import console as v2_console_module
+
+    original_get_console = v2_console_module.get_console
+    v2_console_module.get_console = lambda: console  # type: ignore[assignment]
+    try:
+        display_rich_scan_results_v2(
+            scan_result,
+            scan_target="test.py",
+            severity_threshold=severity_threshold,
+            is_verbose=is_verbose,
+        )
+    finally:
+        v2_console_module.get_console = original_get_console  # type: ignore[assignment]
+    return console.export_text()
+
+
+class TestV2ViolationOutput:
+    def test_all_sections_present(self) -> None:
+        output = _capture_v2_output(_make_violation_result())
+        for section in _EXPECTED_SECTIONS_VIOLATION:
+            assert section in output, f"Missing section: {section}"
+
+    def test_section_ordering(self) -> None:
+        output = _capture_v2_output(_make_violation_result())
+        positions = [output.index(section) for section in _EXPECTED_SECTIONS_VIOLATION]
+        assert positions == sorted(positions), "Sections are out of order"
+
+    def test_remediation_strings_unique(self) -> None:
+        output = _capture_v2_output(_make_violation_result())
+        playbook_start = output.index("REMEDIATION PLAYBOOK")
+        scan_complete_start = output.index("SCAN COMPLETE")
+        playbook_section = output[playbook_start:scan_complete_start]
+        hint = "Remove SSN immediately."
+        assert playbook_section.count(hint) == 1
+
+    def test_no_duplicate_findings_table(self) -> None:
+        output = _capture_v2_output(_make_violation_result())
+        assert "FINDINGS TABLE" not in output.upper() or output.upper().count("FINDINGS TABLE") == 0
+
+    def test_output_under_200_lines(self) -> None:
+        output = _capture_v2_output(_make_violation_result())
+        line_count = len(output.strip().split("\n"))
+        assert line_count <= 200, f"Output is {line_count} lines, expected <= 200"
+
+
+class TestV2CleanOutput:
+    def test_clean_sections_present(self) -> None:
+        output = _capture_v2_output(_make_clean_result())
+        for section in _EXPECTED_SECTIONS_CLEAN:
+            assert section in output, f"Missing section: {section}"
+
+    def test_no_violation_sections_in_clean(self) -> None:
+        output = _capture_v2_output(_make_clean_result())
+        assert "FINDINGS BY LINE" not in output
+        assert "REMEDIATION PLAYBOOK" not in output
+        assert "TOP ACTIONS" not in output
+
+
+class TestV2CollapseExpand:
+    def test_low_severity_collapsed_by_default(self) -> None:
+        output = _capture_v2_output(
+            _make_violation_result(),
+            severity_threshold=SeverityLevel.MEDIUM,
+        )
+        assert "collapsed" in output.lower() or "more lines" in output.lower()
+
+    def test_verbose_expands_all(self) -> None:
+        output = _capture_v2_output(
+            _make_violation_result(),
+            is_verbose=True,
+        )
+        assert "line 3" in output
+
+    def test_low_threshold_shows_low_inline(self) -> None:
+        output = _capture_v2_output(
+            _make_violation_result(),
+            severity_threshold=SeverityLevel.LOW,
+        )
+        assert "line 3" in output


### PR DESCRIPTION
## Summary

- Adds redesigned terminal report renderer activated via `--report-format v2` CLI flag or `PHI_SCAN_REPORT_V2=1` env var
- New aggregation layer groups findings by line and file, deduplicates remediations, ranks top actions by severity-weighted score
- Four renderer sections: executive overview (status banner, stat tiles, top actions, category bars), findings-by-line cards with collapse/expand, remediation playbook with confidence dots, and scan-complete footer with next steps
- V1 remains the default — no breaking changes to existing output
- 28 new tests covering aggregation logic and rendered output structure

## Architecture

```
phi_scan/report/v2/
├── __init__.py          # package init
├── models.py            # LineAggregate, RemediationAction, FileAggregate
├── aggregation.py       # group_by_line, group_by_file, dedupe_remediations, rank_top_actions
├── overview.py          # title strip, status banner, stat tiles, top actions, category bars
├── findings.py          # findings-by-line cards with collapse/expand
├── playbook.py          # remediation playbook with confidence dots
├── footer.py            # scan-complete footer with next steps
└── console.py           # compose entry point: display_rich_scan_results_v2()
```

## Activation

```bash
# CLI flag
phi-scan scan . --report-format v2

# Environment variable
PHI_SCAN_REPORT_V2=1 phi-scan scan .
```

## Test plan

- [x] 17 aggregation tests (group_by_line, group_by_file, dedupe_remediations, rank_top_actions, hotspot count, category distribution, build_line_title)
- [x] 11 renderer tests (section presence, ordering, remediation uniqueness, output under 200 lines, collapse/expand behavior, clean output)
- [ ] Manual test: `phi-scan scan test_phi_data.txt --report-format v2`
- [ ] Manual test: `phi-scan scan . --report-format v2 --verbose`
- [ ] Manual test: `PHI_SCAN_REPORT_V2=1 phi-scan scan .`
- [ ] Verify v1 output unchanged when flag is absent