### PR TITLE
fix(report): Windows Unicode crash on v2 renderer

### DIFF
--- a/phi_scan/report/v2/findings.py
+++ b/phi_scan/report/v2/findings.py
@@ -9,6 +9,7 @@ from rich.panel import Panel
 
 from phi_scan.constants import SEVERITY_RANK, SeverityLevel
 from phi_scan.report.v2.aggregation import build_line_title
+from phi_scan.report.v2.glyphs import MULTIPLIER, PREVIEW_MARKER, SECTION_BAR, SEPARATOR
 from phi_scan.report.v2.models import FileAggregate, LineAggregate
 
 _SECTION_HEADER_STYLE: str = "bold green"
@@ -36,7 +37,6 @@ _LINE_BADGE_STYLE: dict[SeverityLevel, str] = {
 }
 
 _TYPE_CHIP_STYLE: str = "cyan"
-_PREVIEW_MARKER: str = "▸"
 _EXPAND_CUTOFF_DEFAULT: SeverityLevel = SeverityLevel.MEDIUM
 _MAX_FIX_DISPLAY_LENGTH: int = 120
 
@@ -57,10 +57,11 @@ def _build_type_chips(category_counts: dict[str, int]) -> str:
     chips: list[str] = []
     for entity_type, count in sorted(category_counts.items()):
         if count > 1:
-            chips.append(f"[{_TYPE_CHIP_STYLE}]{entity_type} ×{count}[/{_TYPE_CHIP_STYLE}]")
+            chip = f"[{_TYPE_CHIP_STYLE}]{entity_type} {MULTIPLIER}{count}[/{_TYPE_CHIP_STYLE}]"
+            chips.append(chip)
         else:
             chips.append(f"[{_TYPE_CHIP_STYLE}]{entity_type}[/{_TYPE_CHIP_STYLE}]")
-    return "  ·  ".join(chips)
+    return f"  {SEPARATOR}  ".join(chips)
 
 
 def _render_line_card(console: Console, line_aggregate: LineAggregate) -> None:
@@ -79,7 +80,7 @@ def _render_line_card(console: Console, line_aggregate: LineAggregate) -> None:
         f"     [dim]{line_aggregate.finding_count} {finding_word}[/dim]  {pill}"
     )
 
-    preview = f"  {_PREVIEW_MARKER}  {escape_markup(line_aggregate.display_context)}"
+    preview = f"  {PREVIEW_MARKER}  {escape_markup(line_aggregate.display_context)}"
     type_chips = f"  types: {_build_type_chips(line_aggregate.category_counts)}"
 
     fix_text = line_aggregate.combined_fix
@@ -104,7 +105,7 @@ def render_findings_by_line(
     console.print()
     console.print()
     console.print(
-        f"[{_SECTION_BAR_STYLE}]▎[/{_SECTION_BAR_STYLE}] "
+        f"[{_SECTION_BAR_STYLE}]{SECTION_BAR}[/{_SECTION_BAR_STYLE}] "
         f"[{_SECTION_HEADER_STYLE}]FINDINGS BY LINE[/{_SECTION_HEADER_STYLE}]"
     )
     console.print(
@@ -142,7 +143,7 @@ def render_findings_by_line(
         console.print()
         console.print(
             Panel(
-                f"[bold]+ {collapsed_line_count} more lines[/bold]  ·  "
+                f"[bold]+ {collapsed_line_count} more lines[/bold]  {SEPARATOR}  "
                 f"[dim]{collapsed_finding_count} low-severity findings collapsed.[/dim]\n"
                 "[dim]Re-run with [bold]--verbose[/bold] or "
                 "[bold]--severity-threshold low[/bold] to expand them.[/dim]",

--- a/phi_scan/report/v2/footer.py
+++ b/phi_scan/report/v2/footer.py
@@ -11,6 +11,14 @@ from rich.panel import Panel
 
 from phi_scan.constants import SeverityLevel
 from phi_scan.models import ScanResult
+from phi_scan.report.v2.glyphs import (
+    ARROW,
+    CLEAN_MARKER,
+    EM_DASH,
+    SECTION_BAR,
+    SEPARATOR,
+    VIOLATION_MARKER,
+)
 
 _SECTION_HEADER_STYLE: str = "bold green"
 _SECTION_BAR_STYLE: str = "green"
@@ -27,9 +35,9 @@ def _build_violation_left(scan_result: ScanResult, unique_action_count: int) -> 
     files_total = scan_result.files_scanned
 
     return (
-        "[bold red]⚠ VIOLATION[/bold red]\n\n"
+        f"[bold red]{VIOLATION_MARKER} VIOLATION[/bold red]\n\n"
         f"Risk level:  [bold red]{risk_label}[/bold red]\n\n"
-        f"Findings:    [bold]{total}[/bold]  ·  "
+        f"Findings:    [bold]{total}[/bold]  {SEPARATOR}  "
         f"high {high}   medium {medium}   low {low}\n"
         f"Files:       {files_with} of {files_total} contain PHI\n"
         f"Actions:     {unique_action_count} unique remediations required\n"
@@ -42,9 +50,12 @@ def _build_violation_right(report_path: Path | None) -> str:
     next_steps = "[bold]Next steps[/bold]\n\n"
 
     if report_path is not None:
-        next_steps += f"  →  open   {report_path}\n"
+        next_steps += f"  {ARROW}  open   {report_path}\n"
 
-    next_steps += "  →  run    phi-scan fix --interactive\n  →  rerun  phi-scan scan . --verbose\n"
+    next_steps += (
+        f"  {ARROW}  run    phi-scan fix --interactive\n"
+        f"  {ARROW}  rerun  phi-scan scan . --verbose\n"
+    )
 
     exit_panel = (
         "\n[bold red]EXIT 1[/bold red]\n"
@@ -59,7 +70,7 @@ def _build_violation_right(report_path: Path | None) -> str:
 def _build_clean_left(scan_result: ScanResult) -> str:
     """Build the left column content for a clean scan-complete card."""
     return (
-        "[bold green]✓ CLEAN[/bold green]\n\n"
+        f"[bold green]{CLEAN_MARKER} CLEAN[/bold green]\n\n"
         f"Files:       {scan_result.files_scanned} scanned\n"
         f"Findings:    0\n"
         f"Elapsed:     {scan_result.scan_duration:.2f} s"
@@ -68,7 +79,11 @@ def _build_clean_left(scan_result: ScanResult) -> str:
 
 def _build_clean_right() -> str:
     """Build the right column content for a clean scan."""
-    return "[bold]Next steps[/bold]\n\n  →  No action required.\n  →  Pipeline clear — exit code 0."
+    return (
+        f"[bold]Next steps[/bold]\n\n"
+        f"  {ARROW}  No action required.\n"
+        f"  {ARROW}  Pipeline clear {EM_DASH} exit code 0."
+    )
 
 
 def render_scan_complete(
@@ -81,7 +96,7 @@ def render_scan_complete(
     console.print()
     console.print()
     console.print(
-        f"[{_SECTION_BAR_STYLE}]▎[/{_SECTION_BAR_STYLE}] "
+        f"[{_SECTION_BAR_STYLE}]{SECTION_BAR}[/{_SECTION_BAR_STYLE}] "
         f"[{_SECTION_HEADER_STYLE}]SCAN COMPLETE[/{_SECTION_HEADER_STYLE}]"
     )
     console.print()

--- a/phi_scan/report/v2/glyphs.py
+++ b/phi_scan/report/v2/glyphs.py
@@ -1,0 +1,25 @@
+"""Platform-aware glyph constants for the v2 terminal renderer.
+
+Windows legacy consoles use codepage 1252 which cannot encode most Unicode
+box-drawing and symbol characters.  This module detects the platform at
+import time and exposes ASCII-safe fallbacks on Windows.
+"""
+
+from __future__ import annotations
+
+import sys
+
+_IS_WINDOWS: bool = sys.platform == "win32"
+
+VIOLATION_MARKER: str = "[!]" if _IS_WINDOWS else "\u26a0"
+CLEAN_MARKER: str = "[ok]" if _IS_WINDOWS else "\u2713"
+SECTION_BAR: str = "|" if _IS_WINDOWS else "\u258e"
+PREVIEW_MARKER: str = ">" if _IS_WINDOWS else "\u25b8"
+BAR_FILLED: str = "#" if _IS_WINDOWS else "\u2588"
+CONFIDENCE_DOT_FILLED: str = "*" if _IS_WINDOWS else "\u25cf"
+CONFIDENCE_DOT_EMPTY: str = "." if _IS_WINDOWS else "\u25cb"
+SEPARATOR: str = "-" if _IS_WINDOWS else "\u00b7"
+MULTIPLIER: str = "x" if _IS_WINDOWS else "\u00d7"
+ARROW: str = "->" if _IS_WINDOWS else "\u2192"
+EM_DASH: str = "--" if _IS_WINDOWS else "\u2014"
+EN_DASH: str = "-" if _IS_WINDOWS else "\u2013"

--- a/phi_scan/report/v2/overview.py
+++ b/phi_scan/report/v2/overview.py
@@ -20,16 +20,25 @@ from phi_scan.report.v2.aggregation import (
     group_by_line,
     rank_top_actions,
 )
+from phi_scan.report.v2.glyphs import (
+    BAR_FILLED,
+    CLEAN_MARKER,
+    EM_DASH,
+    SECTION_BAR,
+    SEPARATOR,
+    VIOLATION_MARKER,
+)
 from phi_scan.report.v2.models import LineAggregate, RemediationAction
 
 _TITLE_TEMPLATE: str = (
-    "[bold]phi-scan[/bold] v{version}   PHI / PII Scanner  ·  HIPAA Safe-Harbor aligned"
+    "[bold]phi-scan[/bold] v{version}   PHI / PII Scanner"
+    f"  {SEPARATOR}  HIPAA Safe-Harbor aligned"
 )
 _TIMESTAMP_FORMAT: str = "%Y-%m-%d  %H:%M:%S"
 
 _STATUS_VIOLATION: str = "VIOLATION"
 _STATUS_CLEAN: str = "CLEAN"
-_VIOLATION_SUBTITLE_TEMPLATE: str = "Pipeline blocked — {risk} risk level, exit code 1"
+_VIOLATION_SUBTITLE_TEMPLATE: str = f"Pipeline blocked {EM_DASH} {{risk}} risk level, exit code 1"
 _CLEAN_SUBTITLE: str = "No PHI/PII detected. Pipeline clear."
 
 _STAT_FINDINGS: str = "FINDINGS"
@@ -38,9 +47,11 @@ _STAT_MEDIUM: str = "MEDIUM"
 _STAT_LOW: str = "LOW"
 _STAT_HOTSPOTS: str = "HOTSPOTS"
 
-_BAR_FILLED: str = "█"
 _BAR_MAX_WIDTH: int = 40
 _BAR_DENOMINATOR_FLOOR: int = 1
+_MAX_DISPLAYED_AFFECTED_LINES: int = 8
+_NAME_COLUMN_WIDTH: int = 16
+_COUNT_COLUMN_WIDTH: int = 5
 
 _SEVERITY_BAR_COLORS: dict[SeverityLevel, str] = {
     SeverityLevel.HIGH: "red",
@@ -78,10 +89,10 @@ def render_status_banner(
         right_meta = (
             f"Target: [bold]{escape_markup(scan_target)}[/bold]\n"
             f"Elapsed: [bold]{scan_result.scan_duration:.2f} s[/bold]"
-            f"  ·  {scan_result.files_scanned} file(s)"
+            f"  {SEPARATOR}  {scan_result.files_scanned} file(s)"
         )
         clean_body = (
-            f"  [bold green]✓ {_STATUS_CLEAN}[/bold green]\n"
+            f"  [bold green]{CLEAN_MARKER} {_STATUS_CLEAN}[/bold green]\n"
             f"  [green]{_CLEAN_SUBTITLE}[/green]\n\n  {right_meta}"
         )
         console.print(
@@ -98,11 +109,13 @@ def render_status_banner(
     subtitle = _VIOLATION_SUBTITLE_TEMPLATE.format(risk=risk_label)
     right_meta = (
         f"Target: [bold]{escape_markup(scan_target)}[/bold]\n"
-        f"Elapsed: [bold]{scan_result.scan_duration:.2f} s[/bold]  ·  "
+        f"Elapsed: [bold]{scan_result.scan_duration:.2f} s[/bold]  {SEPARATOR}  "
         f"{scan_result.files_scanned} file(s)"
     )
 
-    left_text = f"  [bold red]⚠ {_STATUS_VIOLATION}[/bold red]\n  [dim]{subtitle}[/dim]"
+    left_text = (
+        f"  [bold red]{VIOLATION_MARKER} {_STATUS_VIOLATION}[/bold red]\n  [dim]{subtitle}[/dim]"
+    )
     content = f"{left_text}\n\n  {right_meta}"
 
     console.print(
@@ -144,7 +157,9 @@ def render_stat_tiles(
         _render_stat_tile(_STAT_HIGH, high, "red"),
         _render_stat_tile(_STAT_MEDIUM, medium, "yellow"),
         _render_stat_tile(_STAT_LOW, low, "green"),
-        _render_stat_tile(_STAT_HOTSPOTS, hotspots, "magenta", "— unique PHI hotspot lines —"),
+        _render_stat_tile(
+            _STAT_HOTSPOTS, hotspots, "magenta", f"{EM_DASH} unique PHI hotspot lines {EM_DASH}"
+        ),
     ]
     console.print(Columns(tiles, equal=True, expand=True))
 
@@ -156,7 +171,7 @@ def render_top_actions(
     """Print the TOP ACTIONS section — numbered remediation priorities."""
     console.print()
     console.print(
-        f"[{_SECTION_BAR_STYLE}]▎[/{_SECTION_BAR_STYLE}] "
+        f"[{_SECTION_BAR_STYLE}]{SECTION_BAR}[/{_SECTION_BAR_STYLE}] "
         f"[{_SECTION_HEADER_STYLE}]TOP ACTIONS[/{_SECTION_HEADER_STYLE}]"
         "    [dim]ranked by residual risk if ignored[/dim]"
     )
@@ -182,12 +197,11 @@ def _format_affected_lines_compact(
     affected_lines: tuple[tuple[Path, int], ...],
 ) -> str:
     """Format affected lines as a compact string like 'lines 7, 24, 40, 54'."""
-    _max_displayed_lines = 8
     line_numbers = [pair[1] for pair in affected_lines]
-    if len(line_numbers) <= _max_displayed_lines:
+    if len(line_numbers) <= _MAX_DISPLAYED_AFFECTED_LINES:
         return "lines " + ", ".join(str(ln) for ln in line_numbers)
-    shown = ", ".join(str(ln) for ln in line_numbers[:_max_displayed_lines])
-    remaining = len(line_numbers) - _max_displayed_lines
+    shown = ", ".join(str(ln) for ln in line_numbers[:_MAX_DISPLAYED_AFFECTED_LINES])
+    remaining = len(line_numbers) - _MAX_DISPLAYED_AFFECTED_LINES
     return f"lines {shown} (+{remaining} more)"
 
 
@@ -198,7 +212,7 @@ def render_category_breakdown(
     """Print the CATEGORY BREAKDOWN section with severity-segmented bars."""
     console.print()
     console.print(
-        f"[{_SECTION_BAR_STYLE}]▎[/{_SECTION_BAR_STYLE}] "
+        f"[{_SECTION_BAR_STYLE}]{SECTION_BAR}[/{_SECTION_BAR_STYLE}] "
         f"[{_SECTION_HEADER_STYLE}]CATEGORY BREAKDOWN[/{_SECTION_HEADER_STYLE}]"
     )
     console.print()
@@ -213,9 +227,6 @@ def render_category_breakdown(
 
     max_count = max((ct[1] for ct in category_totals), default=_BAR_DENOMINATOR_FLOOR)
     max_count = max(max_count, _BAR_DENOMINATOR_FLOOR)
-
-    _name_col_width = 16
-    _count_col_width = 5
 
     for category_name, total, sev_dist in category_totals:
         bar_width = round(total / max_count * _BAR_MAX_WIDTH)
@@ -233,11 +244,11 @@ def render_category_breakdown(
             if sev_count > 0:
                 segment_width = max(round(sev_count / total * bar_width), 1)
                 color = _SEVERITY_BAR_COLORS[severity]
-                bar_parts.append(f"[{color}]{_BAR_FILLED * segment_width}[/{color}]")
+                bar_parts.append(f"[{color}]{BAR_FILLED * segment_width}[/{color}]")
 
         bar_str = "".join(bar_parts)
-        name_padded = category_name.ljust(_name_col_width)
-        count_padded = str(total).rjust(_count_col_width)
+        name_padded = category_name.ljust(_NAME_COLUMN_WIDTH)
+        count_padded = str(total).rjust(_COUNT_COLUMN_WIDTH)
 
         console.print(f"  {name_padded}{count_padded}  {bar_str}")
 

--- a/phi_scan/report/v2/playbook.py
+++ b/phi_scan/report/v2/playbook.py
@@ -10,6 +10,13 @@ from rich.markup import escape as escape_markup
 from rich.panel import Panel
 
 from phi_scan.constants import SeverityLevel
+from phi_scan.report.v2.glyphs import (
+    CONFIDENCE_DOT_EMPTY,
+    CONFIDENCE_DOT_FILLED,
+    EN_DASH,
+    SECTION_BAR,
+    SEPARATOR,
+)
 from phi_scan.report.v2.models import RemediationAction
 
 _SECTION_HEADER_STYLE: str = "bold green"
@@ -29,8 +36,6 @@ _SEVERITY_BORDER_STYLE: dict[SeverityLevel, str] = {
     SeverityLevel.INFO: "dim",
 }
 
-_CONFIDENCE_DOT_FILLED: str = "●"
-_CONFIDENCE_DOT_EMPTY: str = "○"
 _CONFIDENCE_DOT_COUNT: int = 5
 
 _MAX_DISPLAYED_LINES: int = 12
@@ -42,7 +47,7 @@ def _render_confidence_dots(mean_confidence: float) -> str:
     filled_count = round(mean_confidence * _CONFIDENCE_DOT_COUNT)
     filled_count = max(0, min(_CONFIDENCE_DOT_COUNT, filled_count))
     empty_count = _CONFIDENCE_DOT_COUNT - filled_count
-    return _CONFIDENCE_DOT_FILLED * filled_count + _CONFIDENCE_DOT_EMPTY * empty_count
+    return CONFIDENCE_DOT_FILLED * filled_count + CONFIDENCE_DOT_EMPTY * empty_count
 
 
 def _format_lines_compact(affected_lines: tuple[tuple[Path, int], ...]) -> str:
@@ -59,8 +64,8 @@ def _format_lines_compact(affected_lines: tuple[tuple[Path, int], ...]) -> str:
             if start == end:
                 parts.append(f"line {start}")
             else:
-                parts.append(f"lines {start}–{end}")
-        return "  ·  ".join(parts)
+                parts.append(f"lines {start}{EN_DASH}{end}")
+        return f"  {SEPARATOR}  ".join(parts)
 
     shown = line_numbers[:_MAX_DISPLAYED_LINES]
     ranges = _compress_line_ranges(shown)
@@ -69,7 +74,7 @@ def _format_lines_compact(affected_lines: tuple[tuple[Path, int], ...]) -> str:
         if start == end:
             parts.append(str(start))
         else:
-            parts.append(f"{start}–{end}")
+            parts.append(f"{start}{EN_DASH}{end}")
     remaining = len(line_numbers) - _MAX_DISPLAYED_LINES
     return "lines " + ", ".join(parts) + f" (+{remaining} more)"
 
@@ -132,7 +137,7 @@ def render_remediation_playbook(
     console.print()
     console.print()
     console.print(
-        f"[{_SECTION_BAR_STYLE}]▎[/{_SECTION_BAR_STYLE}] "
+        f"[{_SECTION_BAR_STYLE}]{SECTION_BAR}[/{_SECTION_BAR_STYLE}] "
         f"[{_SECTION_HEADER_STYLE}]REMEDIATION PLAYBOOK[/{_SECTION_HEADER_STYLE}]"
     )
     action_word = "action" if len(actions) == 1 else "actions"


### PR DESCRIPTION
## Summary

- Fixes `UnicodeEncodeError: 'charmap' codec can't encode character '\u26a0'` crash when running `--report-format v2` on Windows legacy consoles (codepage 1252)
- Adds `phi_scan/report/v2/glyphs.py` — detects `sys.platform == "win32"` at import time and provides ASCII-safe fallback glyphs
- All 12 Unicode glyphs centralized and replaced across overview, findings, playbook, and footer modules
- Also promotes remaining magic local variables to module-level constants (review followup from #171)

| Unicode | ASCII fallback | Used for |
|---------|---------------|----------|
| `⚠` | `[!]` | Violation marker |
| `✓` | `[ok]` | Clean marker |
| `▎` | `\|` | Section bar |
| `▸` | `>` | Preview marker |
| `█` | `#` | Bar fill |
| `●` | `*` | Confidence dot filled |
| `○` | `.` | Confidence dot empty |
| `·` | `-` | Separator |
| `×` | `x` | Multiplier |
| `→` | `->` | Arrow |
| `—` | `--` | Em dash |
| `–` | `-` | En dash |

## Test plan

- [x] 28 v2 renderer tests pass
- [x] `ruff check` and `ruff format --check` clean
- [ ] Manual test on Windows without `PYTHONUTF8=1`
- [ ] Manual test on Linux/macOS (Unicode glyphs still render)