### PR TITLE
fix(report): align v2 renderer with design mockups

### DIFF
--- a/phi_scan/report/v2/console.py
+++ b/phi_scan/report/v2/console.py
@@ -75,6 +75,7 @@ def display_rich_scan_results_v2(
             total_line_count=total_line_count,
             severity_threshold=expand_cutoff,
             is_verbose=is_verbose,
+            scan_target=scan_target,
         )
 
         render_remediation_playbook(

--- a/phi_scan/report/v2/findings.py
+++ b/phi_scan/report/v2/findings.py
@@ -100,6 +100,7 @@ def render_findings_by_line(
     total_line_count: int,
     severity_threshold: SeverityLevel,
     is_verbose: bool,
+    scan_target: str = "",
 ) -> None:
     """Render the FINDINGS BY LINE section with file grouping."""
     console.print()
@@ -108,8 +109,11 @@ def render_findings_by_line(
         f"[{_SECTION_BAR_STYLE}]{SECTION_BAR}[/{_SECTION_BAR_STYLE}] "
         f"[{_SECTION_HEADER_STYLE}]FINDINGS BY LINE[/{_SECTION_HEADER_STYLE}]"
     )
+    target_prefix = f"{escape_markup(scan_target)}  {SEPARATOR}  " if scan_target else ""
     console.print(
-        f"[dim]{total_finding_count} findings collapsed into {total_line_count} unique lines[/dim]"
+        f"[dim]{target_prefix}"
+        f"{total_finding_count} findings collapsed into "
+        f"{total_line_count} unique lines[/dim]"
     )
     console.print()
 

--- a/phi_scan/report/v2/footer.py
+++ b/phi_scan/report/v2/footer.py
@@ -53,15 +53,14 @@ def _build_violation_right(report_path: Path | None) -> str:
         next_steps += f"  {ARROW}  open   {report_path}\n"
 
     next_steps += (
-        f"  {ARROW}  run    phi-scan fix --interactive\n"
-        f"  {ARROW}  rerun  phi-scan scan . --verbose\n"
+        f"  {ARROW}  run    phi-scan fix --interactive\n  {ARROW}  view   phi-scan show --line 6\n"
     )
 
     exit_panel = (
         "\n[bold red]EXIT 1[/bold red]\n"
         "[dim]Pipeline blocked until findings are\n"
-        "remediated or explicitly suppressed with\n"
-        "[bold yellow]# phi-scan:ignore[/bold yellow] comments.[/dim]"
+        "remediated or explicitly waived with\n"
+        "[bold yellow]--allow-findings <id,id,...>[/bold yellow][/dim]"
     )
 
     return next_steps + exit_panel

--- a/phi_scan/report/v2/overview.py
+++ b/phi_scan/report/v2/overview.py
@@ -24,6 +24,7 @@ from phi_scan.report.v2.glyphs import (
     BAR_FILLED,
     CLEAN_MARKER,
     EM_DASH,
+    MULTIPLIER,
     SECTION_BAR,
     SEPARATOR,
     VIOLATION_MARKER,
@@ -128,10 +129,14 @@ def render_status_banner(
     )
 
 
+_STAT_BAR_WIDTH: int = 6
+
+
 def _render_stat_tile(label: str, value: int, color: str, subtitle: str = "") -> Panel:
-    """Build a single stat tile panel."""
+    """Build a single stat tile panel with colored accent bar."""
     value_text = f"[{color}]{value}[/{color}]"
-    body = f"[dim]{label}[/dim]\n[bold]{value_text}[/bold]"
+    accent_bar = f"[{color}]{BAR_FILLED * _STAT_BAR_WIDTH}[/{color}]"
+    body = f"[dim]{label}[/dim]\n[bold]{value_text}[/bold]\n{accent_bar}"
     if subtitle:
         body += f"\n[dim]{subtitle}[/dim]"
     return Panel(body, box=rich_box.ROUNDED, expand=True, padding=(0, 1))
@@ -182,12 +187,12 @@ def render_top_actions(
         pill = f"[{pill_style}] {action.highest_severity.value.upper()} [/{pill_style}]"
 
         lines_str = _format_affected_lines_compact(action.affected_lines)
-        title_with_count = action.title
+        title_display = action.title
         if action.finding_count > 1:
-            title_with_count = f"{action.title}"
+            title_display = f"{action.title} ({MULTIPLIER}{action.finding_count})"
 
         body = (
-            f" [{index}]  [bold]{escape_markup(title_with_count)}[/bold]"
+            f" [{index}]  [bold]{escape_markup(title_display)}[/bold]"
             f"     {pill}\n      [dim]{lines_str}[/dim]"
         )
         console.print(Panel(body, box=rich_box.ROUNDED, padding=(0, 1)))

--- a/phi_scan/report/v2/playbook.py
+++ b/phi_scan/report/v2/playbook.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from rich import box as rich_box
+from rich.columns import Columns
 from rich.console import Console
 from rich.markup import escape as escape_markup
 from rich.panel import Panel
@@ -105,26 +106,43 @@ def _render_action_card(
     action: RemediationAction,
     index: int,
 ) -> None:
-    """Render a single remediation action card."""
+    """Render a remediation action card with count and severity on the right."""
     border_style = _SEVERITY_BORDER_STYLE[action.highest_severity]
     pill_style = _SEVERITY_PILL_STYLE[action.highest_severity]
     pill = f"[{pill_style}] {action.highest_severity.value.upper()} [/{pill_style}]"
     dots = _render_confidence_dots(action.mean_confidence)
-
     lines_str = _format_lines_compact(action.affected_lines)
-
     finding_word = "findings" if action.finding_count != 1 else "finding"
-    count_label = f"[bold]{action.finding_count}[/bold] {finding_word}"
+    hint_display = action.remediation_hint[:_MAX_HINT_DISPLAY_LENGTH]
 
-    body = (
-        f" ({index})  [bold]{escape_markup(action.title)}[/bold]"
-        f"     {count_label}  {pill}\n"
-        f"      [dim]{escape_markup(action.remediation_hint[:_MAX_HINT_DISPLAY_LENGTH])}[/dim]\n"
-        f"      [dim]{lines_str}[/dim]\n"
-        f"      {dots}"
+    left_body = (
+        f" ({index})  [bold]{escape_markup(action.title)}[/bold]\n"
+        f"      [dim]{escape_markup(hint_display)}[/dim]\n"
+        f"      [dim]{lines_str}[/dim]"
+    )
+    right_body = f"[bold]{action.finding_count}[/bold]\n[dim]{finding_word}[/dim]\n{dots}\n{pill}"
+
+    left_panel = Panel(
+        left_body,
+        box=rich_box.SIMPLE,
+        expand=True,
+        padding=(0, 0),
+    )
+    right_panel = Panel(
+        right_body,
+        box=rich_box.SIMPLE,
+        expand=False,
+        padding=(0, 1),
     )
 
-    console.print(Panel(body, box=rich_box.ROUNDED, border_style=border_style, padding=(0, 1)))
+    console.print(
+        Panel(
+            Columns([left_panel, right_panel], expand=True),
+            box=rich_box.ROUNDED,
+            border_style=border_style,
+            padding=(0, 0),
+        )
+    )
 
 
 def render_remediation_playbook(


### PR DESCRIPTION
## Summary

- Top actions include finding count in title (e.g., "Remove Social Security Numbers (×4)")
- Stat tiles have colored accent bars under each number matching mockup
- Findings-by-line header shows scan target filename before collapse stats
- Playbook cards use two-column layout: title/hint/lines on left, large count + confidence dots + severity pill on right
- Footer uses `--allow-findings <id,id,...>` waiver text (was `# phi-scan:ignore`)
- Footer shows `phi-scan show --line 6` command

## Test plan

- [x] 28 v2 tests pass
- [x] Lint and format clean
- [ ] Visual comparison with mockup PNGs on Windows Terminal