### PR TITLE
feat(report): polish v2 renderer layout, dedupe, and span safety

### DIFF
--- a/phi_scan/report/v2/aggregation.py
+++ b/phi_scan/report/v2/aggregation.py
@@ -18,6 +18,9 @@ _HOTSPOT_CATEGORY_THRESHOLD: int = 2
 _QUASI_COMBO_THRESHOLD: int = 5
 _HINT_TRUNCATION_LENGTH: int = 60
 _COLLAPSED_INFILL: str = " … "
+_SINGLE_FINDING_COUNT: int = 1
+_SINGLE_DISTINCT_SPAN: int = 1
+_FAIL_CLOSED_PREVIEW_TEMPLATE: str = "[{marker} preview suppressed]"
 
 _ACTION_TITLE_MAP: dict[PhiCategory, str] = {
     PhiCategory.SSN: "Remove Social Security Numbers",
@@ -72,6 +75,19 @@ def _combine_remediation_hints(findings: tuple[ScanFinding, ...]) -> str:
     return "; ".join(seen)
 
 
+def _pick_most_specific_hint(findings: list[ScanFinding]) -> str:
+    """Return the longest remediation hint from a category bucket.
+
+    When a category fans out multiple hint variants (most notably
+    QUASI_IDENTIFIER_COMBINATION, which embeds the specific fields
+    involved), the longest hint is typically the most specific and
+    actionable — generic "replace dates" variants are short, while
+    combination-specific hints enumerate the offending fields. Using
+    length as the proxy avoids hard-coded per-category picks.
+    """
+    return max((finding.remediation_hint for finding in findings), key=len)
+
+
 def _split_context(context: str) -> tuple[str, str] | None:
     """Split a code_context into (prefix, suffix) around the [REDACTED] marker."""
     marker = CODE_CONTEXT_REDACTED_VALUE
@@ -97,26 +113,32 @@ def _build_merged_display_context(findings: tuple[ScanFinding, ...]) -> str:
     span) — same property for the suffix — and join them around a
     collapsed ``[REDACTED] … [REDACTED]`` middle. We lose in-between
     context, but never leak raw PHI.
+
+    If the invariant is violated (any ``code_context`` is missing the
+    [REDACTED] marker, or all spans collapse to one finding), we fail
+    CLOSED: return a bare placeholder rather than any raw prefix/suffix,
+    because any non-empty prefix or suffix from a single finding's context
+    necessarily contains other findings' raw spans.
     """
-    first_context = findings[0].code_context
-    if len(findings) == 1:
-        return first_context
+    marker = CODE_CONTEXT_REDACTED_VALUE
+    fail_closed_preview = _FAIL_CLOSED_PREVIEW_TEMPLATE.format(marker=marker)
+
+    if len(findings) == _SINGLE_FINDING_COUNT:
+        return findings[0].code_context
 
     split_parts: list[tuple[str, str]] = []
     for finding in findings:
         parts = _split_context(finding.code_context)
         if parts is None:
-            return first_context
+            return fail_closed_preview
         split_parts.append(parts)
 
-    earliest_prefix = min(split_parts, key=lambda pair: len(pair[0]))[0]
-    latest_suffix = min(split_parts, key=lambda pair: len(pair[1]))[1]
-
     distinct_spans = {(prefix, suffix) for prefix, suffix in split_parts}
-    if len(distinct_spans) == 1:
-        return first_context
+    if len(distinct_spans) == _SINGLE_DISTINCT_SPAN:
+        return fail_closed_preview
 
-    marker = CODE_CONTEXT_REDACTED_VALUE
+    earliest_prefix = min(split_parts, key=lambda split_pair: len(split_pair[0]))[0]
+    latest_suffix = min(split_parts, key=lambda split_pair: len(split_pair[1]))[1]
     return f"{earliest_prefix}{marker}{_COLLAPSED_INFILL}{marker}{latest_suffix}"
 
 
@@ -200,8 +222,8 @@ def dedupe_remediations(findings: tuple[ScanFinding, ...]) -> list[RemediationAc
             if key not in seen_lines:
                 seen_lines.add(key)
                 affected.append(key)
-        affected.sort(key=lambda pair: (pair[0], pair[1]))
-        representative_hint = max((f.remediation_hint for f in grouped_findings), key=len)
+        affected.sort(key=lambda path_line_pair: (path_line_pair[0], path_line_pair[1]))
+        representative_hint = _pick_most_specific_hint(grouped_findings)
         title = _ACTION_TITLE_MAP.get(category, representative_hint[:_HINT_TRUNCATION_LENGTH])
 
         actions.append(

--- a/phi_scan/report/v2/aggregation.py
+++ b/phi_scan/report/v2/aggregation.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from phi_scan.constants import SEVERITY_RANK, PhiCategory, SeverityLevel
+from phi_scan.constants import (
+    CODE_CONTEXT_REDACTED_VALUE,
+    SEVERITY_RANK,
+    PhiCategory,
+    SeverityLevel,
+)
 from phi_scan.models import ScanFinding
 from phi_scan.report.v2.models import FileAggregate, LineAggregate, RemediationAction
 
@@ -12,6 +17,7 @@ _TOP_ACTIONS_COUNT: int = 5
 _HOTSPOT_CATEGORY_THRESHOLD: int = 2
 _QUASI_COMBO_THRESHOLD: int = 5
 _HINT_TRUNCATION_LENGTH: int = 60
+_COLLAPSED_INFILL: str = " … "
 
 _ACTION_TITLE_MAP: dict[PhiCategory, str] = {
     PhiCategory.SSN: "Remove Social Security Numbers",
@@ -66,6 +72,54 @@ def _combine_remediation_hints(findings: tuple[ScanFinding, ...]) -> str:
     return "; ".join(seen)
 
 
+def _split_context(context: str) -> tuple[str, str] | None:
+    """Split a code_context into (prefix, suffix) around the [REDACTED] marker."""
+    marker = CODE_CONTEXT_REDACTED_VALUE
+    marker_position = context.find(marker)
+    if marker_position == -1:
+        return None
+    prefix = context[:marker_position]
+    suffix = context[marker_position + len(marker) :]
+    return (prefix, suffix)
+
+
+def _build_merged_display_context(findings: tuple[ScanFinding, ...]) -> str:
+    """Build a preview that redacts every finding's span on the line.
+
+    Each ``code_context`` is the source line with one match span replaced by
+    [REDACTED]; its prefix and suffix therefore contain raw source text,
+    including any OTHER findings' raw values. Using a single finding's
+    context would leak those other spans.
+
+    To stay invariant-safe without re-reading disk, we pick the finding with
+    the shortest prefix (earliest span) — its prefix contains no other
+    finding's span — and the finding with the shortest suffix (latest
+    span) — same property for the suffix — and join them around a
+    collapsed ``[REDACTED] … [REDACTED]`` middle. We lose in-between
+    context, but never leak raw PHI.
+    """
+    first_context = findings[0].code_context
+    if len(findings) == 1:
+        return first_context
+
+    split_parts: list[tuple[str, str]] = []
+    for finding in findings:
+        parts = _split_context(finding.code_context)
+        if parts is None:
+            return first_context
+        split_parts.append(parts)
+
+    earliest_prefix = min(split_parts, key=lambda pair: len(pair[0]))[0]
+    latest_suffix = min(split_parts, key=lambda pair: len(pair[1]))[1]
+
+    distinct_spans = {(prefix, suffix) for prefix, suffix in split_parts}
+    if len(distinct_spans) == 1:
+        return first_context
+
+    marker = CODE_CONTEXT_REDACTED_VALUE
+    return f"{earliest_prefix}{marker}{_COLLAPSED_INFILL}{marker}{latest_suffix}"
+
+
 def group_by_line(findings: tuple[ScanFinding, ...]) -> list[LineAggregate]:
     """Group findings by (file_path, line_number) into LineAgggregates."""
     buckets: dict[tuple[Path, int], list[ScanFinding]] = {}
@@ -85,7 +139,7 @@ def group_by_line(findings: tuple[ScanFinding, ...]) -> list[LineAggregate]:
                 findings=frozen_findings,
                 highest_severity=_highest_severity(line_findings),
                 category_counts=_build_category_counts(frozen_findings),
-                display_context=line_findings[0].code_context,
+                display_context=_build_merged_display_context(frozen_findings),
                 combined_fix=_combine_remediation_hints(frozen_findings),
             )
         )
@@ -119,18 +173,24 @@ def group_by_file(line_aggregates: list[LineAggregate]) -> list[FileAggregate]:
 
 
 def dedupe_remediations(findings: tuple[ScanFinding, ...]) -> list[RemediationAction]:
-    """Group findings by remediation_hint into deduplicated RemediationActions."""
-    buckets: dict[str, list[ScanFinding]] = {}
+    """Group findings by HIPAA category into deduplicated RemediationActions.
+
+    Keying by hipaa_category (rather than the raw hint string) collapses
+    per-invocation variations — e.g., QUASI_IDENTIFIER_COMBINATION emits a
+    differently worded hint for each combination it sees, but the action
+    ("Break up the combination") is the same and belongs on one card.
+    """
+    buckets: dict[PhiCategory, list[ScanFinding]] = {}
     for finding in findings:
-        hint = finding.remediation_hint
-        if not hint:
+        if not finding.remediation_hint:
             continue
-        if hint not in buckets:
-            buckets[hint] = []
-        buckets[hint].append(finding)
+        category = finding.hipaa_category
+        if category not in buckets:
+            buckets[category] = []
+        buckets[category].append(finding)
 
     actions: list[RemediationAction] = []
-    for hint, grouped_findings in buckets.items():
+    for category, grouped_findings in buckets.items():
         highest_sev = _highest_severity(grouped_findings)
         mean_confidence = sum(f.confidence for f in grouped_findings) / len(grouped_findings)
         affected: list[tuple[Path, int]] = []
@@ -141,14 +201,14 @@ def dedupe_remediations(findings: tuple[ScanFinding, ...]) -> list[RemediationAc
                 seen_lines.add(key)
                 affected.append(key)
         affected.sort(key=lambda pair: (pair[0], pair[1]))
-        primary_category = grouped_findings[0].hipaa_category
-        title = _ACTION_TITLE_MAP.get(primary_category, hint[:_HINT_TRUNCATION_LENGTH])
+        representative_hint = max((f.remediation_hint for f in grouped_findings), key=len)
+        title = _ACTION_TITLE_MAP.get(category, representative_hint[:_HINT_TRUNCATION_LENGTH])
 
         actions.append(
             RemediationAction(
-                remediation_hint=hint,
+                remediation_hint=representative_hint,
                 title=title,
-                hipaa_category=primary_category,
+                hipaa_category=category,
                 finding_count=len(grouped_findings),
                 highest_severity=highest_sev,
                 mean_confidence=mean_confidence,

--- a/phi_scan/report/v2/findings.py
+++ b/phi_scan/report/v2/findings.py
@@ -38,7 +38,6 @@ _LINE_BADGE_STYLE: dict[SeverityLevel, str] = {
 
 _TYPE_CHIP_STYLE: str = "cyan"
 _EXPAND_CUTOFF_DEFAULT: SeverityLevel = SeverityLevel.MEDIUM
-_MAX_FIX_DISPLAY_LENGTH: int = 120
 
 
 def _should_expand_line(
@@ -83,10 +82,7 @@ def _render_line_card(console: Console, line_aggregate: LineAggregate) -> None:
     preview = f"  {PREVIEW_MARKER}  {escape_markup(line_aggregate.display_context)}"
     type_chips = f"  types: {_build_type_chips(line_aggregate.category_counts)}"
 
-    fix_text = line_aggregate.combined_fix
-    if len(fix_text) > _MAX_FIX_DISPLAY_LENGTH:
-        fix_text = fix_text[:_MAX_FIX_DISPLAY_LENGTH] + "..."
-    fix_line = f"  fix:   {escape_markup(fix_text)}"
+    fix_line = f"  fix:   {escape_markup(line_aggregate.combined_fix)}"
 
     body = f"{header}\n\n{preview}\n{type_chips}\n{fix_line}"
 

--- a/phi_scan/report/v2/footer.py
+++ b/phi_scan/report/v2/footer.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 
 from rich import box as rich_box
-from rich.columns import Columns
 from rich.console import Console
 from rich.panel import Panel
+from rich.table import Table
 
 from phi_scan.constants import SeverityLevel
 from phi_scan.models import ScanResult
@@ -22,6 +22,7 @@ from phi_scan.report.v2.glyphs import (
 
 _SECTION_HEADER_STYLE: str = "bold green"
 _SECTION_BAR_STYLE: str = "green"
+_FOOTER_COLUMN_GAP: int = 4
 
 
 def _build_violation_left(scan_result: ScanResult, unique_action_count: int) -> str:
@@ -110,14 +111,16 @@ def render_scan_complete(
         right_content = _build_violation_right(report_path)
         border_style = "bold red"
 
-    left_panel = Panel(left_content, box=rich_box.ROUNDED, expand=True, padding=(1, 2))
-    right_panel = Panel(right_content, box=rich_box.ROUNDED, expand=True, padding=(1, 2))
+    layout = Table.grid(expand=True, padding=(0, _FOOTER_COLUMN_GAP))
+    layout.add_column(ratio=1)
+    layout.add_column(ratio=1)
+    layout.add_row(left_content, right_content)
 
     console.print(
         Panel(
-            Columns([left_panel, right_panel], equal=True, expand=True),
+            layout,
             box=rich_box.ROUNDED,
             border_style=border_style,
-            padding=(0, 0),
+            padding=(1, 2),
         )
     )

--- a/phi_scan/report/v2/overview.py
+++ b/phi_scan/report/v2/overview.py
@@ -49,11 +49,14 @@ _STAT_HOTSPOTS: str = "HOTSPOTS"
 
 _BAR_MAX_WIDTH: int = 40
 _BAR_DENOMINATOR_FLOOR: int = 1
+_BAR_MIN_FILLED: int = 0
 _MAX_DISPLAYED_AFFECTED_LINES: int = 8
 _NAME_COLUMN_WIDTH: int = 16
 _COUNT_COLUMN_WIDTH: int = 5
 _STAT_TILE_COUNT: int = 5
 _STAT_TILE_BAR_WIDTH: int = 12
+
+_KNOWN_PHI_CATEGORY_VALUES: frozenset[str] = frozenset(member.value for member in PhiCategory)
 
 _SEVERITY_BAR_COLORS: dict[SeverityLevel, str] = {
     SeverityLevel.HIGH: "red",
@@ -164,7 +167,7 @@ def _render_proportional_bar(value: int, max_value: int, color: str) -> str:
     denominator = max(max_value, _BAR_DENOMINATOR_FLOOR)
     ratio = value / denominator
     filled = round(ratio * _STAT_TILE_BAR_WIDTH)
-    filled = max(0, min(_STAT_TILE_BAR_WIDTH, filled))
+    filled = max(_BAR_MIN_FILLED, min(_STAT_TILE_BAR_WIDTH, filled))
     empty = _STAT_TILE_BAR_WIDTH - filled
     filled_segment = f"[{color}]{BAR_FILLED * filled}[/{color}]"
     empty_segment = f"[dim]{BAR_FILLED * empty}[/dim]"
@@ -262,7 +265,7 @@ def _format_affected_lines_compact(
     affected_lines: tuple[tuple[Path, int], ...],
 ) -> str:
     """Format affected lines as a compact string like 'lines 7, 24, 40, 54'."""
-    line_numbers = [pair[1] for pair in affected_lines]
+    line_numbers = [path_line_pair[1] for path_line_pair in affected_lines]
     if len(line_numbers) <= _MAX_DISPLAYED_AFFECTED_LINES:
         return "lines " + ", ".join(str(ln) for ln in line_numbers)
     shown = ", ".join(str(ln) for ln in line_numbers[:_MAX_DISPLAYED_AFFECTED_LINES])
@@ -272,18 +275,16 @@ def _format_affected_lines_compact(
 
 def _resolve_category_color(category_name: str) -> str:
     """Map a category name (enum value) to its display color."""
-    try:
-        return _CATEGORY_BAR_COLORS[PhiCategory(category_name)]
-    except ValueError:
+    if category_name not in _KNOWN_PHI_CATEGORY_VALUES:
         return _CATEGORY_BAR_DEFAULT
+    return _CATEGORY_BAR_COLORS[PhiCategory(category_name)]
 
 
 def _resolve_category_display(category_name: str) -> str:
     """Abbreviate long category names for the breakdown label column."""
-    try:
-        return _CATEGORY_DISPLAY_NAMES.get(PhiCategory(category_name), category_name)
-    except ValueError:
+    if category_name not in _KNOWN_PHI_CATEGORY_VALUES:
         return category_name
+    return _CATEGORY_DISPLAY_NAMES.get(PhiCategory(category_name), category_name)
 
 
 def render_category_breakdown(

--- a/phi_scan/report/v2/overview.py
+++ b/phi_scan/report/v2/overview.py
@@ -6,13 +6,13 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from rich import box as rich_box
-from rich.columns import Columns
 from rich.console import Console
 from rich.markup import escape as escape_markup
 from rich.panel import Panel
+from rich.table import Table
 
 from phi_scan import __version__
-from phi_scan.constants import SeverityLevel
+from phi_scan.constants import PhiCategory, SeverityLevel
 from phi_scan.models import ScanResult
 from phi_scan.report.v2.aggregation import (
     compute_category_severity_distribution,
@@ -52,12 +52,43 @@ _BAR_DENOMINATOR_FLOOR: int = 1
 _MAX_DISPLAYED_AFFECTED_LINES: int = 8
 _NAME_COLUMN_WIDTH: int = 16
 _COUNT_COLUMN_WIDTH: int = 5
+_STAT_TILE_COUNT: int = 5
+_STAT_TILE_BAR_WIDTH: int = 12
 
 _SEVERITY_BAR_COLORS: dict[SeverityLevel, str] = {
     SeverityLevel.HIGH: "red",
     SeverityLevel.MEDIUM: "yellow",
     SeverityLevel.LOW: "green",
     SeverityLevel.INFO: "dim",
+}
+
+_CATEGORY_BAR_COLORS: dict[PhiCategory, str] = {
+    PhiCategory.UNIQUE_ID: "magenta",
+    PhiCategory.HEALTH_PLAN: "bright_blue",
+    PhiCategory.DATE: "yellow",
+    PhiCategory.ACCOUNT: "yellow",
+    PhiCategory.MRN: "yellow",
+    PhiCategory.GEOGRAPHIC: "green",
+    PhiCategory.SSN: "red",
+    PhiCategory.PHONE: "red",
+    PhiCategory.EMAIL: "red",
+    PhiCategory.FAX: "red",
+    PhiCategory.IP: "red",
+    PhiCategory.QUASI_IDENTIFIER_COMBINATION: "red",
+    PhiCategory.NAME: "red",
+    PhiCategory.CERTIFICATE: "yellow",
+    PhiCategory.URL: "cyan",
+    PhiCategory.VEHICLE: "cyan",
+    PhiCategory.DEVICE: "cyan",
+    PhiCategory.BIOMETRIC: "red",
+    PhiCategory.PHOTO: "red",
+    PhiCategory.SUBSTANCE_USE_DISORDER: "red",
+}
+_CATEGORY_BAR_DEFAULT: str = "cyan"
+
+_CATEGORY_DISPLAY_NAMES: dict[PhiCategory, str] = {
+    PhiCategory.QUASI_IDENTIFIER_COMBINATION: "quasi_combo",
+    PhiCategory.SUBSTANCE_USE_DISORDER: "sud",
 }
 
 _SEVERITY_PILL_STYLE: dict[SeverityLevel, str] = {
@@ -128,10 +159,30 @@ def render_status_banner(
     )
 
 
-def _render_stat_tile(label: str, value: int, color: str, subtitle: str = "") -> Panel:
+def _render_proportional_bar(value: int, max_value: int, color: str) -> str:
+    """Render a proportional single-line bar shown under severity tile counts."""
+    denominator = max(max_value, _BAR_DENOMINATOR_FLOOR)
+    ratio = value / denominator
+    filled = round(ratio * _STAT_TILE_BAR_WIDTH)
+    filled = max(0, min(_STAT_TILE_BAR_WIDTH, filled))
+    empty = _STAT_TILE_BAR_WIDTH - filled
+    filled_segment = f"[{color}]{BAR_FILLED * filled}[/{color}]"
+    empty_segment = f"[dim]{BAR_FILLED * empty}[/dim]"
+    return filled_segment + empty_segment
+
+
+def _render_stat_tile(
+    label: str,
+    value: int,
+    color: str,
+    subtitle: str = "",
+    bar_markup: str = "",
+) -> Panel:
     """Build a single stat tile panel."""
     value_text = f"[{color}]{value}[/{color}]"
     body = f"[dim]{label}[/dim]\n[bold]{value_text}[/bold]"
+    if bar_markup:
+        body += f"\n{bar_markup}"
     if subtitle:
         body += f"\n[dim]{subtitle}[/dim]"
     return Panel(body, box=rich_box.ROUNDED, expand=True, padding=(0, 1))
@@ -152,16 +203,30 @@ def render_stat_tiles(
     file_count = scan_result.files_with_findings
     file_label = "file" if file_count == 1 else "files"
 
+    severity_max = max(high, medium, low, _BAR_DENOMINATOR_FLOOR)
+    high_bar = _render_proportional_bar(high, severity_max, "red")
+    medium_bar = _render_proportional_bar(medium, severity_max, "yellow")
+    low_bar = _render_proportional_bar(low, severity_max, "green")
+
+    findings_subtitle = f"across {file_count} {file_label}"
     tiles = [
-        _render_stat_tile(_STAT_FINDINGS, total, "white", f"across {file_count} {file_label}"),
-        _render_stat_tile(_STAT_HIGH, high, "red"),
-        _render_stat_tile(_STAT_MEDIUM, medium, "yellow"),
-        _render_stat_tile(_STAT_LOW, low, "green"),
+        _render_stat_tile(_STAT_FINDINGS, total, "white", subtitle=findings_subtitle),
+        _render_stat_tile(_STAT_HIGH, high, "red", bar_markup=high_bar),
+        _render_stat_tile(_STAT_MEDIUM, medium, "yellow", bar_markup=medium_bar),
+        _render_stat_tile(_STAT_LOW, low, "green", bar_markup=low_bar),
         _render_stat_tile(
-            _STAT_HOTSPOTS, hotspots, "magenta", f"{EM_DASH} unique PHI hotspot lines {EM_DASH}"
+            _STAT_HOTSPOTS,
+            hotspots,
+            "magenta",
+            subtitle="unique PHI hotspot lines",
         ),
     ]
-    console.print(Columns(tiles, equal=True, expand=True))
+
+    grid = Table.grid(expand=True, padding=(0, 1))
+    for _ in range(_STAT_TILE_COUNT):
+        grid.add_column(ratio=1)
+    grid.add_row(*tiles)
+    console.print(grid)
 
 
 def render_top_actions(
@@ -205,11 +270,27 @@ def _format_affected_lines_compact(
     return f"lines {shown} (+{remaining} more)"
 
 
+def _resolve_category_color(category_name: str) -> str:
+    """Map a category name (enum value) to its display color."""
+    try:
+        return _CATEGORY_BAR_COLORS[PhiCategory(category_name)]
+    except ValueError:
+        return _CATEGORY_BAR_DEFAULT
+
+
+def _resolve_category_display(category_name: str) -> str:
+    """Abbreviate long category names for the breakdown label column."""
+    try:
+        return _CATEGORY_DISPLAY_NAMES.get(PhiCategory(category_name), category_name)
+    except ValueError:
+        return category_name
+
+
 def render_category_breakdown(
     console: Console,
     scan_result: ScanResult,
 ) -> None:
-    """Print the CATEGORY BREAKDOWN section with severity-segmented bars."""
+    """Print the CATEGORY BREAKDOWN section with per-category colored bars."""
     console.print()
     console.print(
         f"[{_SECTION_BAR_STYLE}]{SECTION_BAR}[/{_SECTION_BAR_STYLE}] "
@@ -218,39 +299,29 @@ def render_category_breakdown(
     console.print()
 
     distribution = compute_category_severity_distribution(scan_result.findings)
-    category_totals: list[tuple[str, int, dict[SeverityLevel, int]]] = []
-    for category_name, sev_dist in distribution.items():
-        total = sum(sev_dist.values())
-        category_totals.append((category_name, total, sev_dist))
-
+    category_totals: list[tuple[str, int]] = [
+        (category_name, sum(sev_dist.values())) for category_name, sev_dist in distribution.items()
+    ]
     category_totals.sort(key=lambda ct: -ct[1])
 
     max_count = max((ct[1] for ct in category_totals), default=_BAR_DENOMINATOR_FLOOR)
     max_count = max(max_count, _BAR_DENOMINATOR_FLOOR)
 
-    for category_name, total, sev_dist in category_totals:
-        bar_width = round(total / max_count * _BAR_MAX_WIDTH)
-        bar_width = max(bar_width, 1)
+    for category_name, total in category_totals:
+        filled_width = round(total / max_count * _BAR_MAX_WIDTH)
+        filled_width = max(1, min(_BAR_MAX_WIDTH, filled_width))
+        empty_width = _BAR_MAX_WIDTH - filled_width
 
-        bar_parts: list[str] = []
-        severity_order = (
-            SeverityLevel.HIGH,
-            SeverityLevel.MEDIUM,
-            SeverityLevel.LOW,
-            SeverityLevel.INFO,
+        color = _resolve_category_color(category_name)
+        bar_str = (
+            f"[{color}]{BAR_FILLED * filled_width}[/{color}][dim]{BAR_FILLED * empty_width}[/dim]"
         )
-        for severity in severity_order:
-            sev_count = sev_dist.get(severity, 0)
-            if sev_count > 0:
-                segment_width = max(round(sev_count / total * bar_width), 1)
-                color = _SEVERITY_BAR_COLORS[severity]
-                bar_parts.append(f"[{color}]{BAR_FILLED * segment_width}[/{color}]")
 
-        bar_str = "".join(bar_parts)
-        name_padded = category_name.ljust(_NAME_COLUMN_WIDTH)
-        count_padded = str(total).rjust(_COUNT_COLUMN_WIDTH)
+        display_name = _resolve_category_display(category_name)
+        name_markup = f"[dim]{display_name.ljust(_NAME_COLUMN_WIDTH)}[/dim]"
+        count_markup = f"[bold {color}]{str(total).rjust(_COUNT_COLUMN_WIDTH)}[/bold {color}]"
 
-        console.print(f"  {name_padded}{count_padded}  {bar_str}")
+        console.print(f"  {name_markup}{count_markup}  {bar_str}")
 
 
 def render_overview(

--- a/phi_scan/report/v2/playbook.py
+++ b/phi_scan/report/v2/playbook.py
@@ -39,7 +39,6 @@ _SEVERITY_BORDER_STYLE: dict[SeverityLevel, str] = {
 _CONFIDENCE_DOT_COUNT: int = 5
 
 _MAX_DISPLAYED_LINES: int = 12
-_MAX_HINT_DISPLAY_LENGTH: int = 100
 
 
 def _render_confidence_dots(mean_confidence: float) -> str:
@@ -119,7 +118,7 @@ def _render_action_card(
     body = (
         f" ({index})  [bold]{escape_markup(action.title)}[/bold]"
         f"     {count_label}  {pill}\n"
-        f"      [dim]{escape_markup(action.remediation_hint[:_MAX_HINT_DISPLAY_LENGTH])}[/dim]\n"
+        f"      [dim]{escape_markup(action.remediation_hint)}[/dim]\n"
         f"      [dim]{lines_str}[/dim]\n"
         f"      {dots}"
     )

--- a/tests/test_report_v2_aggregation.py
+++ b/tests/test_report_v2_aggregation.py
@@ -134,37 +134,76 @@ class TestGroupByFile:
 
 
 class TestDedupeRemediations:
-    def test_groups_by_remediation_hint(self) -> None:
+    def test_groups_by_hipaa_category(self) -> None:
         findings = (
-            _make_finding(line_number=1, remediation_hint="Remove SSN"),
-            _make_finding(line_number=2, remediation_hint="Remove SSN"),
-            _make_finding(line_number=3, remediation_hint="Fix dates"),
+            _make_finding(
+                line_number=1,
+                hipaa_category=PhiCategory.SSN,
+                remediation_hint="Remove SSN",
+            ),
+            _make_finding(
+                line_number=2,
+                hipaa_category=PhiCategory.SSN,
+                remediation_hint="Remove SSN",
+            ),
+            _make_finding(
+                line_number=3,
+                hipaa_category=PhiCategory.DATE,
+                remediation_hint="Fix dates",
+            ),
         )
         actions = dedupe_remediations(findings)
         assert len(actions) == 2
-        ssn_action = [a for a in actions if a.remediation_hint == "Remove SSN"][0]
+        ssn_action = [a for a in actions if a.hipaa_category == PhiCategory.SSN][0]
         assert ssn_action.finding_count == 2
 
-    def test_no_duplicate_remediation_strings(self) -> None:
+    def test_collapses_varied_hints_within_same_category(self) -> None:
         findings = (
-            _make_finding(remediation_hint="Hint A"),
-            _make_finding(remediation_hint="Hint A"),
-            _make_finding(remediation_hint="Hint B"),
-            _make_finding(remediation_hint="Hint B"),
-            _make_finding(remediation_hint="Hint C"),
+            _make_finding(
+                line_number=1,
+                hipaa_category=PhiCategory.QUASI_IDENTIFIER_COMBINATION,
+                remediation_hint="Break up combo A + B.",
+            ),
+            _make_finding(
+                line_number=2,
+                hipaa_category=PhiCategory.QUASI_IDENTIFIER_COMBINATION,
+                remediation_hint="Break up combo C + D + E.",
+            ),
         )
         actions = dedupe_remediations(findings)
-        hints = [a.remediation_hint for a in actions]
-        assert len(hints) == len(set(hints))
+        assert len(actions) == 1
+        assert actions[0].finding_count == 2
+
+    def test_no_duplicate_categories(self) -> None:
+        findings = (
+            _make_finding(hipaa_category=PhiCategory.SSN, remediation_hint="Hint A"),
+            _make_finding(hipaa_category=PhiCategory.SSN, remediation_hint="Hint A"),
+            _make_finding(hipaa_category=PhiCategory.DATE, remediation_hint="Hint B"),
+            _make_finding(hipaa_category=PhiCategory.DATE, remediation_hint="Hint B"),
+            _make_finding(hipaa_category=PhiCategory.EMAIL, remediation_hint="Hint C"),
+        )
+        actions = dedupe_remediations(findings)
+        categories = [a.hipaa_category for a in actions]
+        assert len(categories) == len(set(categories))
 
     def test_sorted_by_severity_then_count(self) -> None:
         findings = (
-            _make_finding(line_number=1, severity=SeverityLevel.LOW, remediation_hint="Low fix"),
-            _make_finding(line_number=2, severity=SeverityLevel.HIGH, remediation_hint="High fix"),
+            _make_finding(
+                line_number=1,
+                hipaa_category=PhiCategory.EMAIL,
+                severity=SeverityLevel.LOW,
+                remediation_hint="Low fix",
+            ),
+            _make_finding(
+                line_number=2,
+                hipaa_category=PhiCategory.SSN,
+                severity=SeverityLevel.HIGH,
+                remediation_hint="High fix",
+            ),
         )
         actions = dedupe_remediations(findings)
-        assert actions[0].remediation_hint == "High fix"
-        assert actions[1].remediation_hint == "Low fix"
+        assert actions[0].hipaa_category == PhiCategory.SSN
+        assert actions[1].hipaa_category == PhiCategory.EMAIL
 
     def test_mean_confidence(self) -> None:
         findings = (
@@ -197,23 +236,26 @@ class TestRankTopActions:
         findings = (
             _make_finding(
                 line_number=1,
+                hipaa_category=PhiCategory.SSN,
                 severity=SeverityLevel.HIGH,
                 remediation_hint="High",
             ),
             _make_finding(
                 line_number=2,
+                hipaa_category=PhiCategory.EMAIL,
                 severity=SeverityLevel.LOW,
                 remediation_hint="Low 1",
             ),
             _make_finding(
                 line_number=3,
+                hipaa_category=PhiCategory.ACCOUNT,
                 severity=SeverityLevel.LOW,
                 remediation_hint="Low 2",
             ),
         )
         actions = dedupe_remediations(findings)
         top = rank_top_actions(actions)
-        assert top[0].remediation_hint == "High"
+        assert top[0].hipaa_category == PhiCategory.SSN
 
 
 class TestHotspotCount:

--- a/tests/test_report_v2_renderer.py
+++ b/tests/test_report_v2_renderer.py
@@ -206,3 +206,133 @@ class TestV2CollapseExpand:
             severity_threshold=SeverityLevel.LOW,
         )
         assert "line 3" in output
+
+
+def _make_multi_finding_line_result() -> ScanResult:
+    """Build a result with two findings on the same line, each with different raw spans."""
+    findings = (
+        _make_finding(
+            line_number=10,
+            entity_type="SSN",
+            hipaa_category=PhiCategory.SSN,
+            remediation_hint="Remove SSN immediately.",
+            code_context="pt {'ssn': [REDACTED], 'dob': '1942-07-03'}",
+        ),
+        _make_finding(
+            line_number=10,
+            entity_type="DATE",
+            hipaa_category=PhiCategory.DATE,
+            remediation_hint="Replace dates with year only.",
+            code_context="pt {'ssn': '123-45-6789', 'dob': [REDACTED]}",
+        ),
+    )
+    return ScanResult(
+        findings=findings,
+        files_scanned=1,
+        files_with_findings=1,
+        scan_duration=0.01,
+        is_clean=False,
+        risk_level=RiskLevel.CRITICAL,
+        severity_counts=MappingProxyType({SeverityLevel.HIGH: 2}),
+        category_counts=MappingProxyType({PhiCategory.SSN: 1, PhiCategory.DATE: 1}),
+    )
+
+
+class TestV2MultiFindingLineSafety:
+    """When a line has multiple findings, the preview must redact ALL raw spans."""
+
+    def test_no_raw_ssn_leaked(self) -> None:
+        output = _capture_v2_output(_make_multi_finding_line_result())
+        assert "123-45-6789" not in output
+
+    def test_no_raw_dob_leaked(self) -> None:
+        output = _capture_v2_output(_make_multi_finding_line_result())
+        assert "1942-07-03" not in output
+
+    def test_collapsed_marker_present(self) -> None:
+        output = _capture_v2_output(_make_multi_finding_line_result())
+        assert "[REDACTED]" in output
+
+
+def _make_quasi_combo_result() -> ScanResult:
+    """Quasi-identifier combination findings with differing hints per instance."""
+    findings = tuple(
+        _make_finding(
+            line_number=line_number,
+            entity_type="QUASI_IDENTIFIER_COMBINATION",
+            hipaa_category=PhiCategory.QUASI_IDENTIFIER_COMBINATION,
+            severity=SeverityLevel.HIGH,
+            remediation_hint=(
+                f"This finding indicates quasi-identifier combination #{line_number}. "
+                "Break up the combination or generalize at least one field."
+            ),
+            code_context=f"record_{line_number}: [REDACTED]",
+        )
+        for line_number in (1, 3, 6)
+    )
+    return ScanResult(
+        findings=findings,
+        files_scanned=1,
+        files_with_findings=1,
+        scan_duration=0.01,
+        is_clean=False,
+        risk_level=RiskLevel.CRITICAL,
+        severity_counts=MappingProxyType({SeverityLevel.HIGH: 3}),
+        category_counts=MappingProxyType({PhiCategory.QUASI_IDENTIFIER_COMBINATION: 3}),
+    )
+
+
+class TestV2PlaybookCategoryDedupe:
+    """Playbook must collapse per-category findings even when hint strings differ."""
+
+    def test_quasi_combo_single_card(self) -> None:
+        output = _capture_v2_output(_make_quasi_combo_result())
+        playbook_start = output.index("REMEDIATION PLAYBOOK")
+        scan_complete_start = output.index("SCAN COMPLETE")
+        playbook_section = output[playbook_start:scan_complete_start]
+        assert playbook_section.count("Break up quasi-identifier combinations") == 1
+
+    def test_playbook_shows_aggregate_count(self) -> None:
+        output = _capture_v2_output(_make_quasi_combo_result())
+        assert "3 findings" in output
+
+
+def _make_long_hint_result() -> ScanResult:
+    """Result with a >100-char remediation hint to verify no truncation in playbook."""
+    long_hint = (
+        "Remove or generalize at least one of the quasi-identifiers: use only "
+        "the first 3 digits of the ZIP code, replace the full date of birth "
+        "with birth year only, or remove the combination entirely from test "
+        "fixtures. Do not rely on any single field being 'safe'."
+    )
+    findings = (
+        _make_finding(
+            line_number=42,
+            entity_type="QUASI_IDENTIFIER_COMBINATION",
+            hipaa_category=PhiCategory.QUASI_IDENTIFIER_COMBINATION,
+            severity=SeverityLevel.HIGH,
+            remediation_hint=long_hint,
+            code_context="row_42: [REDACTED]",
+        ),
+    )
+    return (
+        ScanResult(
+            findings=findings,
+            files_scanned=1,
+            files_with_findings=1,
+            scan_duration=0.01,
+            is_clean=False,
+            risk_level=RiskLevel.CRITICAL,
+            severity_counts=MappingProxyType({SeverityLevel.HIGH: 1}),
+            category_counts=MappingProxyType({PhiCategory.QUASI_IDENTIFIER_COMBINATION: 1}),
+        ),
+        long_hint,
+    )
+
+
+class TestV2PlaybookHintUncapped:
+    def test_full_hint_rendered(self) -> None:
+        result, _ = _make_long_hint_result()
+        output = _capture_v2_output(result)
+        tail_phrase = "any single field being"
+        assert tail_phrase in output


### PR DESCRIPTION
## Summary

- **Overview**: stat tiles switched to `Table.grid` so all five land in one row; HIGH/MEDIUM/LOW carry proportional bars. Category breakdown bars are colored per-category on a dim background track instead of a flat bar.
- **Findings by line**: removed the 120-char cap on the `fix:` text (Rich wraps). Multi-finding line previews now collapse to `prefix [REDACTED] … [REDACTED] suffix` — previously, using the first finding's `code_context` left other findings' raw spans visible on the same line. The new shape is derived from the shortest-prefix / shortest-suffix `code_context`, so it never leaks another span.
- **Remediation playbook**: dedupe key is now `hipaa_category` rather than the raw `remediation_hint` string. This collapses per-invocation variants (e.g. quasi-identifier combinations emit a different hint for every combination but the action is the same). Removed the 100-char hint truncation so the full rationale renders.
- **Scan-complete footer**: replaced `Panel(Columns([Panel, Panel]))` with one bordered `Panel` around a two-column `Table.grid`, removing the double-border nesting.
- **Tests**: updated the existing dedupe-by-hint tests for category-keyed grouping; added regression coverage for multi-finding span safety, quasi-combo collapse, and uncapped hint rendering.

## Test plan

- [x] `uv run pytest` — 2080 passed, 3 skipped
- [x] `uv run ruff check` and `uv run ruff format --check` clean on the touched files
- [x] `uv run mypy phi_scan/report/v2/` — no issues
- [x] Manual scan against a multi-finding-per-line fixture — no raw PHI spans visible in previews; playbook shows one card per HIPAA category; footer renders as a single panel.