### PR TITLE
feat(report): graduate v2 terminal renderer to default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No changes yet._
 
+## [0.7.0] - TBD
+
+### Changed
+
+- **v2 terminal renderer is now the default.** The redesigned grouped-output
+  renderer (introduced behind `--report-format v2` in 0.6.x) is now the default
+  `table` output. v2 aggregates findings by line, deduplicates remediation
+  hints into a single playbook, and degrades cleanly under `NO_COLOR`, `CI=true`,
+  and non-TTY (piped) environments — verified before release.
+- **Non-breaking for CI pipelines.** This change is user-visible but non-breaking
+  for anything parsing `--output json`, `--output sarif`, or exit codes. The
+  `table` renderer's visual layout is not a stable contract and has never been;
+  CI owners relying on structured output are safe.
+- **Documentation:** Added an explicit "terminal output is not a stable
+  interface" note to the README and `--report-format` help text, directing
+  programmatic consumers to JSON or SARIF.
+
+### Deprecated
+
+- **`--report-format v1` is deprecated** and will be **removed in phi-scan
+  0.8.0** (scheduled 2026-07). Passing `--report-format v1` continues to render
+  the legacy output for one release but now prints a `DeprecationWarning` line
+  to stderr pointing at `--output json` / `--output sarif` for stable
+  machine-readable output. The `PHI_SCAN_REPORT_V2` environment variable has
+  been removed — it was an opt-in for v2 during the flagged-preview period and
+  is redundant now that v2 is the default.
+
 ## [0.6.2] - TBD
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ phi-scan scan . --output sarif --report-path phi-scan-results.sarif
 
 PDF and HTML reports include a compliance control matrix when `--framework` is specified.
 
+> **Terminal output is not a stable interface.** The default `table` renderer is
+> designed for human consumption and may change between releases without a
+> deprecation cycle. For programmatic consumption — CI gates, dashboards,
+> anything that greps or parses scan output — use `--output json` or
+> `--output sarif`. Exit codes, JSON schemas, and SARIF payloads are the stable
+> machine-readable contracts.
+
 ---
 
 ## Compliance Framework Annotation

--- a/phi_scan/cli/scan.py
+++ b/phi_scan/cli/scan.py
@@ -133,6 +133,10 @@ _SCAN_REPORT_FORMAT_HELP: str = (
 )
 _REPORT_FORMAT_V2: str = "v2"
 _REPORT_FORMAT_V1: str = "v1"
+_VALID_REPORT_FORMATS: frozenset[str] = frozenset({_REPORT_FORMAT_V1, _REPORT_FORMAT_V2})
+_REPORT_FORMAT_INVALID_ERROR: str = (
+    "Invalid --report-format value: {value!r}. Expected one of: {valid}."
+)
 _REPORT_FORMAT_V1_DEPRECATION_NOTICE: str = (
     "DeprecationWarning: --report-format v1 is deprecated and will be removed in "
     "phi-scan 0.8.0. The v2 renderer is now the default. Terminal output is not a "
@@ -218,6 +222,23 @@ def _resolve_framework_flag(framework_flag_value: str | None) -> frozenset[Compl
     except InvalidFrameworkError as framework_error:
         typer.echo(_FRAMEWORK_PARSE_ERROR.format(error=framework_error), err=True)
         raise typer.Exit(code=EXIT_CODE_ERROR) from framework_error
+
+
+def _resolve_report_format(report_format_value: str) -> bool:
+    """Validate ``--report-format`` and return whether v2 rendering is selected.
+
+    Unknown values are rejected with a clear stderr message and a non-zero exit
+    code rather than silently resolving to a default; this keeps typos like
+    ``--report-format v3`` from masquerading as a valid v2 request.
+    """
+    if report_format_value not in _VALID_REPORT_FORMATS:
+        valid = ", ".join(sorted(_VALID_REPORT_FORMATS))
+        typer.echo(
+            _REPORT_FORMAT_INVALID_ERROR.format(value=report_format_value, valid=valid),
+            err=True,
+        )
+        raise typer.Exit(code=EXIT_CODE_ERROR)
+    return report_format_value == _REPORT_FORMAT_V2
 
 
 def _collect_scan_targets_for_phase(
@@ -325,8 +346,8 @@ def scan(
     output_format_enum = resolve_output_format(output_format)
     enabled_frameworks = _resolve_framework_flag(framework)
     is_rich_mode = not is_quiet and output_format_enum is OutputFormat.TABLE
-    is_v2 = report_format != _REPORT_FORMAT_V1
-    if report_format == _REPORT_FORMAT_V1 and is_rich_mode:
+    is_v2 = _resolve_report_format(report_format)
+    if report_format == _REPORT_FORMAT_V1 and not is_quiet:
         typer.echo(_REPORT_FORMAT_V1_DEPRECATION_NOTICE, err=True)
     with display_status_spinner(_SPINNER_CONFIG_LOAD_MESSAGE, is_active=is_rich_mode):
         scan_config = load_scan_config(config_path, severity_threshold)

--- a/phi_scan/cli/scan.py
+++ b/phi_scan/cli/scan.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import Annotated
 
@@ -128,13 +127,18 @@ _SCAN_WORKERS_HELP: str = (
     "Output ordering is deterministic regardless of thread completion order."
 )
 _SCAN_REPORT_FORMAT_HELP: str = (
-    "Terminal report format: v1 (current default) or v2 (redesigned grouped output). "
-    "Also settable via PHI_SCAN_REPORT_V2=1 environment variable."
+    "Terminal report format: v2 (default, redesigned grouped output) or v1 "
+    "(deprecated, removed in 0.8.0). Terminal output is not a stable interface — "
+    "use --output json or --output sarif for programmatic consumption."
 )
 _REPORT_FORMAT_V2: str = "v2"
 _REPORT_FORMAT_V1: str = "v1"
-_REPORT_FORMAT_ENV_VAR: str = "PHI_SCAN_REPORT_V2"
-_REPORT_FORMAT_ENV_TRUTHY: str = "1"
+_REPORT_FORMAT_V1_DEPRECATION_NOTICE: str = (
+    "DeprecationWarning: --report-format v1 is deprecated and will be removed in "
+    "phi-scan 0.8.0. The v2 renderer is now the default. Terminal output is not a "
+    "stable interface — use --output json or --output sarif for programmatic "
+    "consumption.\n"
+)
 
 _AUDIT_WRITE_FAILURE_WARNING: str = "Audit log write failed — scan result not persisted: {error}"
 _AUDIT_KEY_MISSING_DEBUG: str = (
@@ -307,7 +311,7 @@ def scan(
     ] = _DEFAULT_WORKER_COUNT,
     report_format: Annotated[
         str, typer.Option("--report-format", help=_SCAN_REPORT_FORMAT_HELP)
-    ] = _REPORT_FORMAT_V1,
+    ] = _REPORT_FORMAT_V2,
 ) -> None:
     """Scan a directory or file for PHI/PII.
 
@@ -321,10 +325,9 @@ def scan(
     output_format_enum = resolve_output_format(output_format)
     enabled_frameworks = _resolve_framework_flag(framework)
     is_rich_mode = not is_quiet and output_format_enum is OutputFormat.TABLE
-    is_v2 = (
-        report_format == _REPORT_FORMAT_V2
-        or os.environ.get(_REPORT_FORMAT_ENV_VAR) == _REPORT_FORMAT_ENV_TRUTHY
-    )
+    is_v2 = report_format != _REPORT_FORMAT_V1
+    if report_format == _REPORT_FORMAT_V1 and is_rich_mode:
+        typer.echo(_REPORT_FORMAT_V1_DEPRECATION_NOTICE, err=True)
     with display_status_spinner(_SPINNER_CONFIG_LOAD_MESSAGE, is_active=is_rich_mode):
         scan_config = load_scan_config(config_path, severity_threshold)
     if is_rich_mode and not is_v2:

--- a/phi_scan/report/v2/console.py
+++ b/phi_scan/report/v2/console.py
@@ -1,8 +1,8 @@
 """V2 terminal report renderer — public entry point.
 
 Composes overview, findings-by-line, remediation playbook, and scan-complete
-footer into a single terminal report. Called from display_rich_scan_results_v2
-when --report-format v2 or PHI_SCAN_REPORT_V2=1 is active.
+footer into a single terminal report. This is the default renderer; the legacy
+v1 renderer is retained behind --report-format v1 and will be removed in 0.8.0.
 """
 
 from __future__ import annotations

--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -29,6 +29,7 @@ from phi_scan.cli import app
 from phi_scan.constants import (
     DEFAULT_BASELINE_FILENAME,
     EXIT_CODE_CLEAN,
+    EXIT_CODE_ERROR,
     EXIT_CODE_VIOLATION,
     OutputFormat,
 )
@@ -343,9 +344,13 @@ class TestReportFormatDefaultAndV1Deprecation:
     """v2 is the default terminal renderer; v1 is a deprecated escape hatch.
 
     These tests pin the graduation contract established in 0.7.0:
-      - Default `scan` invocation uses v2 (no flag required)
-      - Passing `--report-format v1` continues to work but emits a
-        DeprecationWarning to stderr naming the 0.8.0 removal target
+      - Default ``scan`` invocation uses v2 (no flag required)
+      - Passing ``--report-format v1`` emits a DeprecationWarning to stderr
+        naming the 0.8.0 removal target — regardless of ``--output`` mode, so
+        CI pipelines using ``--report-format v1 --output json`` still see it
+      - ``--quiet`` suppresses the deprecation line alongside all other output
+      - Unknown ``--report-format`` values are rejected with a clear stderr
+        message and a non-zero exit code (no silent fall-through to v2)
       - JSON/SARIF/exit-code contracts are unaffected by renderer choice
     """
 
@@ -357,18 +362,25 @@ class TestReportFormatDefaultAndV1Deprecation:
         result = runner.invoke(app, ["scan", str(tmp_path)])
 
         assert result.exit_code == EXIT_CODE_VIOLATION
-        assert _V2_FOOTER_MARKER in result.output
+        assert _V2_FOOTER_MARKER in result.stdout
 
     def test_default_scan_does_not_emit_deprecation_warning(self, tmp_path: Path) -> None:
-        """No deprecation notice is printed when v2 (the default) is used."""
+        """No deprecation notice is printed when v2 (the default) is used.
+
+        Writes a PHI fixture so the full rendering path executes — a test
+        against an empty directory would pass vacuously even if the gate logic
+        were broken.
+        """
+        _write_phi_file(tmp_path)
         runner = CliRunner()
 
         result = runner.invoke(app, ["scan", str(tmp_path)])
 
-        assert _DEPRECATION_WARNING_FRAGMENT not in result.output
+        assert _DEPRECATION_WARNING_FRAGMENT not in result.stdout
+        assert _DEPRECATION_WARNING_FRAGMENT not in result.stderr
 
-    def test_explicit_v1_flag_emits_deprecation_warning(self, tmp_path: Path) -> None:
-        """`--report-format v1` prints a DeprecationWarning naming 0.8.0."""
+    def test_explicit_v1_flag_emits_deprecation_warning_on_stderr(self, tmp_path: Path) -> None:
+        """``--report-format v1`` prints a DeprecationWarning to stderr naming 0.8.0."""
         _write_phi_file(tmp_path)
         runner = CliRunner()
 
@@ -377,11 +389,36 @@ class TestReportFormatDefaultAndV1Deprecation:
             ["scan", str(tmp_path), "--report-format", "v1"],
         )
 
-        assert _DEPRECATION_WARNING_FRAGMENT in result.output
-        assert _DEPRECATION_REMOVAL_TARGET in result.output
+        assert _DEPRECATION_WARNING_FRAGMENT in result.stderr
+        assert _DEPRECATION_REMOVAL_TARGET in result.stderr
+        # stdout carries the rendered report, never the deprecation line
+        assert _DEPRECATION_WARNING_FRAGMENT not in result.stdout
+
+    def test_v1_deprecation_warning_fires_in_json_mode(self, tmp_path: Path) -> None:
+        """CI pipelines using ``--report-format v1 --output json`` still see the
+        notice — the deprecation must not be gated on rich-terminal mode."""
+        _write_phi_file(tmp_path)
+        runner = CliRunner()
+
+        result = runner.invoke(
+            app,
+            [
+                "scan",
+                str(tmp_path),
+                "--report-format",
+                "v1",
+                "--output",
+                OutputFormat.JSON.value,
+            ],
+        )
+
+        assert _DEPRECATION_WARNING_FRAGMENT in result.stderr
+        # stdout stays pure JSON — the deprecation goes to stderr, not stdout
+        parsed = json.loads(result.stdout)
+        assert _JSON_FINDINGS_KEY in parsed
 
     def test_quiet_suppresses_v1_deprecation_warning(self, tmp_path: Path) -> None:
-        """`--quiet` suppresses the v1 deprecation line alongside all other output."""
+        """``--quiet`` suppresses the v1 deprecation line alongside all other output."""
         _write_phi_file(tmp_path)
         runner = CliRunner()
 
@@ -390,7 +427,23 @@ class TestReportFormatDefaultAndV1Deprecation:
             ["scan", str(tmp_path), "--report-format", "v1", "--quiet"],
         )
 
-        assert _DEPRECATION_WARNING_FRAGMENT not in result.output
+        assert _DEPRECATION_WARNING_FRAGMENT not in result.stdout
+        assert _DEPRECATION_WARNING_FRAGMENT not in result.stderr
+
+    def test_unknown_report_format_exits_with_error(self, tmp_path: Path) -> None:
+        """Unknown --report-format values are rejected with a clear stderr
+        message and a non-zero exit code — no silent fall-through to v2."""
+        runner = CliRunner()
+
+        result = runner.invoke(
+            app,
+            ["scan", str(tmp_path), "--report-format", "v3"],
+        )
+
+        assert result.exit_code == EXIT_CODE_ERROR
+        assert "v3" in result.stderr
+        assert "v1" in result.stderr
+        assert "v2" in result.stderr
 
     def test_renderer_choice_does_not_affect_json_output(self, tmp_path: Path) -> None:
         """JSON output is identical whether v1 or v2 is selected — structured
@@ -415,6 +468,6 @@ class TestReportFormatDefaultAndV1Deprecation:
         )
 
         assert v2_result.exit_code == v1_result.exit_code == EXIT_CODE_VIOLATION
-        v2_parsed = json.loads(v2_result.output)
-        v1_parsed = json.loads(v1_result.output)
+        v2_parsed = json.loads(v2_result.stdout)
+        v1_parsed = json.loads(v1_result.stdout)
         assert len(v2_parsed[_JSON_FINDINGS_KEY]) == len(v1_parsed[_JSON_FINDINGS_KEY])

--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -50,6 +50,12 @@ _JUNIT_TESTSUITE_TAG: str = "testsuite"
 _CSV_HEADER_FRAGMENT: str = "file_path"
 _JSON_FINDINGS_KEY: str = "findings"
 
+# The v2 footer section is labelled "SCAN COMPLETE"; this string appears
+# exclusively in the v2 renderer and is a reliable marker for v2 output.
+_V2_FOOTER_MARKER: str = "SCAN COMPLETE"
+_DEPRECATION_WARNING_FRAGMENT: str = "DeprecationWarning"
+_DEPRECATION_REMOVAL_TARGET: str = "0.8.0"
+
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -326,3 +332,89 @@ class TestSeverityThresholdWithOutput:
         assert result.exit_code == EXIT_CODE_CLEAN
         parsed = json.loads(result.output)
         assert _JSON_FINDINGS_KEY in parsed
+
+
+# ---------------------------------------------------------------------------
+# --report-format default and v1 deprecation
+# ---------------------------------------------------------------------------
+
+
+class TestReportFormatDefaultAndV1Deprecation:
+    """v2 is the default terminal renderer; v1 is a deprecated escape hatch.
+
+    These tests pin the graduation contract established in 0.7.0:
+      - Default `scan` invocation uses v2 (no flag required)
+      - Passing `--report-format v1` continues to work but emits a
+        DeprecationWarning to stderr naming the 0.8.0 removal target
+      - JSON/SARIF/exit-code contracts are unaffected by renderer choice
+    """
+
+    def test_default_scan_renders_v2_output(self, tmp_path: Path) -> None:
+        """Scanning without --report-format produces v2 output."""
+        _write_phi_file(tmp_path)
+        runner = CliRunner()
+
+        result = runner.invoke(app, ["scan", str(tmp_path)])
+
+        assert result.exit_code == EXIT_CODE_VIOLATION
+        assert _V2_FOOTER_MARKER in result.output
+
+    def test_default_scan_does_not_emit_deprecation_warning(self, tmp_path: Path) -> None:
+        """No deprecation notice is printed when v2 (the default) is used."""
+        runner = CliRunner()
+
+        result = runner.invoke(app, ["scan", str(tmp_path)])
+
+        assert _DEPRECATION_WARNING_FRAGMENT not in result.output
+
+    def test_explicit_v1_flag_emits_deprecation_warning(self, tmp_path: Path) -> None:
+        """`--report-format v1` prints a DeprecationWarning naming 0.8.0."""
+        _write_phi_file(tmp_path)
+        runner = CliRunner()
+
+        result = runner.invoke(
+            app,
+            ["scan", str(tmp_path), "--report-format", "v1"],
+        )
+
+        assert _DEPRECATION_WARNING_FRAGMENT in result.output
+        assert _DEPRECATION_REMOVAL_TARGET in result.output
+
+    def test_quiet_suppresses_v1_deprecation_warning(self, tmp_path: Path) -> None:
+        """`--quiet` suppresses the v1 deprecation line alongside all other output."""
+        _write_phi_file(tmp_path)
+        runner = CliRunner()
+
+        result = runner.invoke(
+            app,
+            ["scan", str(tmp_path), "--report-format", "v1", "--quiet"],
+        )
+
+        assert _DEPRECATION_WARNING_FRAGMENT not in result.output
+
+    def test_renderer_choice_does_not_affect_json_output(self, tmp_path: Path) -> None:
+        """JSON output is identical whether v1 or v2 is selected — structured
+        contracts are independent of the terminal renderer."""
+        _write_phi_file(tmp_path)
+        runner = CliRunner()
+
+        v2_result = runner.invoke(
+            app,
+            ["scan", str(tmp_path), "--output", OutputFormat.JSON.value],
+        )
+        v1_result = runner.invoke(
+            app,
+            [
+                "scan",
+                str(tmp_path),
+                "--output",
+                OutputFormat.JSON.value,
+                "--report-format",
+                "v1",
+            ],
+        )
+
+        assert v2_result.exit_code == v1_result.exit_code == EXIT_CODE_VIOLATION
+        v2_parsed = json.loads(v2_result.output)
+        v1_parsed = json.loads(v1_result.output)
+        assert len(v2_parsed[_JSON_FINDINGS_KEY]) == len(v1_parsed[_JSON_FINDINGS_KEY])


### PR DESCRIPTION
## Summary

Graduates the v2 terminal renderer (landed behind `--report-format v2` in 0.6.x)
to the default `table` output. v1 is retained as a deprecated escape hatch for
one release and will be removed in 0.8.0.

- `phi-scan scan` now defaults to `--report-format v2`
- Passing `--report-format v1` emits a `DeprecationWarning` to stderr in rich
  terminal mode, pointing users at `--output json` / `--output sarif` for
  stable machine-readable output
- Dropped the `PHI_SCAN_REPORT_V2` opt-in env var — redundant now that v2 is
  the default
- README + `--report-format` help gain an explicit "terminal output is not a
  stable interface; use `--output json` for programmatic consumption" note
- CHANGELOG `[0.7.0]` section calls out that the change is **non-breaking**
  for anything parsing JSON, SARIF, or exit codes, and names the v1 removal
  target (0.8.0)

## Test plan

- [x] `uv run ruff check` passes (all checks)
- [x] `uv run ruff format --check` passes (all files formatted)
- [x] `uv run mypy phi_scan` passes (no issues in 98 source files)
- [x] Full test suite: 2098 passed, 3 skipped
- [x] New `TestReportFormatDefaultAndV1Deprecation` pins:
  - Default scan renders v2 output (SCAN COMPLETE marker present)
  - Default scan emits no deprecation notice
  - `--report-format v1` emits `DeprecationWarning` naming 0.8.0
  - `--quiet` suppresses the deprecation line
  - Renderer choice does not affect JSON output (finding counts match)
- [x] Manually verified v2 degrades cleanly under `NO_COLOR=1`, `CI=true`,
  and piped non-TTY output