### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No changes yet._
 
-## [0.7.0] - TBD
+## [0.7.0] - 2026-04-19
 
 ### Changed
 
@@ -36,7 +36,7 @@ _No changes yet._
   been removed — it was an opt-in for v2 during the flagged-preview period and
   is redundant now that v2 is the default.
 
-## [0.6.2] - TBD
+## [0.6.2] - 2026-04-15
 
 ### Changed
 
@@ -50,7 +50,7 @@ _No changes yet._
   API changes — PyPI long description and short summary will be refreshed on
   the next tagged release.
 
-## [0.6.1] - TBD
+## [0.6.1] - 2026-04-15
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "phi-scan"
-version = "0.6.2"
+version = "0.7.0"
 description = "PHI/PII scanner for HIPAA-aligned and FHIR-based environments. Local-first execution for CI/CD pipelines."
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -4,7 +4,7 @@ import phi_scan
 
 
 def test_version_is_defined() -> None:
-    assert phi_scan.__version__ == "0.6.2"
+    assert phi_scan.__version__ == "0.7.0"
 
 
 def test_app_name_is_defined() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1493,7 +1493,7 @@ wheels = [
 
 [[package]]
 name = "phi-scan"
-version = "0.6.2"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Prepares the 0.7.0 release. Bumps `pyproject.toml` and `uv.lock` to `0.7.0`,
stamps the CHANGELOG with today's date, updates the `__version__` smoke
assertion, and backfills CHANGELOG dates for `[0.6.1]` and `[0.6.2]` from
their tag commit dates (2026-04-15).

Headline change: **v2 terminal renderer is now the default; `--report-format v1`
remains available until 0.8.0 with a deprecation warning. Programmatic
consumers should switch to `--output json` or `--output sarif` — terminal
output is not a stable interface.**

Once this merges I'll tag `v0.7.0` from main; the release workflow will build
the wheel + sdist, sign with Sigstore, publish to PyPI, and create the GitHub
Release from the CHANGELOG excerpt.

## Test plan

- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run mypy phi_scan` passes
- [x] Full test suite: 2100 passed, 3 skipped
- [x] `uv build` produces clean sdist + wheel
- [x] `twine check dist/*` passes on both artifacts
- [x] CHANGELOG awk extractor in `.github/workflows/release.yml` matches
      `## [0.7.0]` regardless of trailing date